### PR TITLE
WIP: Parameter index lists

### DIFF
--- a/docs/android_sqlite/migrations.md
+++ b/docs/android_sqlite/migrations.md
@@ -9,7 +9,7 @@ val driver: SqlDriver = AndroidSqliteDriver(
     name = "test.db",
     callback = AndroidSqliteDriver.Callback(
         schema = Database.Schema,
-        AfterVersion(3) { database.execute(null, "INSERT INTO test (value) VALUES('hello')", 0) },
+        AfterVersion(3) { database.execute(null, "INSERT INTO test (value) VALUES('hello')", emptyList()) },
     )
 )
 ```

--- a/docs/common/migrations.md
+++ b/docs/common/migrations.md
@@ -42,7 +42,7 @@ Database.Schema.migrateWithCallbacks(
     driver = database,
     oldVersion = 0,
     newVersion = Database.Schema.version,
-    AfterVersion(3) { database.execute(null, "INSERT INTO test (value) VALUES('hello')", 0) },
+    AfterVersion(3) { database.execute(null, "INSERT INTO test (value) VALUES('hello')", emptyList()) },
 )
 ```
 
@@ -53,7 +53,7 @@ Database.Schema.migrateWithCallbacks(
     driver = database,
     oldVersion = 0,
     newVersion = Database.Schema.version,
-    AfterVersionWithDriver(3) { it.execute(null, "INSERT INTO test (value) VALUES('hello')", 0) },
+    AfterVersionWithDriver(3) { it.execute(null, "INSERT INTO test (value) VALUES('hello')", emptyList()) },
 )
 ```
 

--- a/drivers/android-driver/src/main/java/app/cash/sqldelight/driver/android/AndroidSqliteDriver.kt
+++ b/drivers/android-driver/src/main/java/app/cash/sqldelight/driver/android/AndroidSqliteDriver.kt
@@ -165,7 +165,7 @@ class AndroidSqliteDriver private constructor(
   override fun execute(
     identifier: Int?,
     sql: String,
-    parameters: Int,
+    parameterIndices: List<Int>,
     binders: (SqlPreparedStatement.() -> Unit)?,
   ): QueryResult<Long> = execute(identifier, { AndroidPreparedStatement(database.compileStatement(sql)) }, binders, { execute() })
 
@@ -173,9 +173,9 @@ class AndroidSqliteDriver private constructor(
     identifier: Int?,
     sql: String,
     mapper: (SqlCursor) -> R,
-    parameters: Int,
+    parameterIndices: List<Int>,
     binders: (SqlPreparedStatement.() -> Unit)?,
-  ) = execute(identifier, { AndroidQuery(sql, database, parameters) }, binders) { executeQuery(mapper) }
+  ) = execute(identifier, { AndroidQuery(sql, database, parameterIndices.size) }, binders) { executeQuery(mapper) }
 
   override fun close() {
     statements.evictAll()

--- a/drivers/android-driver/src/test/java/com/squareup/sqldelight/android/AndroidDriverTest.kt
+++ b/drivers/android-driver/src/test/java/com/squareup/sqldelight/android/AndroidDriverTest.kt
@@ -25,13 +25,13 @@ class AndroidDriverTest : DriverTest() {
   fun `cached statement can be reused`() {
     val driver = AndroidSqliteDriver(schema, getApplicationContext(), cacheSize = 1)
     lateinit var bindable: SqlPreparedStatement
-    driver.executeQuery(1, "SELECT * FROM test", {}, 0, { bindable = this })
+    driver.executeQuery(1, "SELECT * FROM test", {}, emptyList(), { bindable = this })
 
     driver.executeQuery(
       1,
       "SELECT * FROM test",
       {},
-      0,
+      emptyList(),
       {
         assertSame(bindable, this)
       },
@@ -42,15 +42,15 @@ class AndroidDriverTest : DriverTest() {
   fun `cached statement is evicted and closed`() {
     val driver = AndroidSqliteDriver(schema, getApplicationContext(), cacheSize = 1)
     lateinit var bindable: SqlPreparedStatement
-    driver.executeQuery(1, "SELECT * FROM test", {}, 0, { bindable = this })
+    driver.executeQuery(1, "SELECT * FROM test", {}, emptyList(), { bindable = this })
 
-    driver.executeQuery(2, "SELECT * FROM test", {}, 0)
+    driver.executeQuery(2, "SELECT * FROM test", {}, emptyList())
 
     driver.executeQuery(
       1,
       "SELECT * FROM test",
       {},
-      0,
+      emptyList(),
       {
         assertNotSame(bindable, this)
       },
@@ -61,7 +61,7 @@ class AndroidDriverTest : DriverTest() {
   fun `uncached statement is closed`() {
     val driver = AndroidSqliteDriver(schema, getApplicationContext(), cacheSize = 1)
     lateinit var bindable: AndroidStatement
-    driver.execute(null, "SELECT * FROM test", 0) {
+    driver.execute(null, "SELECT * FROM test", emptyList()) {
       bindable = this as AndroidStatement
     }
 

--- a/drivers/driver-test/src/commonMain/kotlin/com/squareup/sqldelight/driver/test/DriverTest.kt
+++ b/drivers/driver-test/src/commonMain/kotlin/com/squareup/sqldelight/driver/test/DriverTest.kt
@@ -32,7 +32,7 @@ abstract class DriverTest {
               |  value TEXT
               |);
         """.trimMargin(),
-        0,
+        emptyList(),
       )
       driver.execute(
         1,
@@ -45,7 +45,7 @@ abstract class DriverTest {
               |  real_value REAL
               |);
         """.trimMargin(),
-        0,
+        emptyList(),
       )
       return QueryResult.Unit
     }
@@ -67,7 +67,7 @@ abstract class DriverTest {
         it.next()
         it.getLong(0)
       }
-      driver.executeQuery(null, "SELECT changes()", mapper, 0).value
+      driver.executeQuery(null, "SELECT changes()", mapper, emptyList()).value
     }
   }
 
@@ -84,10 +84,10 @@ abstract class DriverTest {
   @Test
   fun insertCanRunMultipleTimes() {
     val insert = { binders: SqlPreparedStatement.() -> Unit ->
-      driver.execute(2, "INSERT INTO test VALUES (?, ?);", 2, binders)
+      driver.execute(2, "INSERT INTO test VALUES (?, ?);", listOf(25, 28), binders)
     }
     fun query(mapper: (SqlCursor) -> Unit) {
-      driver.executeQuery(3, "SELECT * FROM test", mapper, 0)
+      driver.executeQuery(3, "SELECT * FROM test", mapper, emptyList())
     }
 
     query {
@@ -127,7 +127,7 @@ abstract class DriverTest {
       assertEquals("Jake", it.getString(1))
     }
 
-    driver.execute(5, "DELETE FROM test", 0)
+    driver.execute(5, "DELETE FROM test", emptyList())
     assertEquals(2, changes())
 
     query {
@@ -138,7 +138,7 @@ abstract class DriverTest {
   @Test
   fun queryCanRunMultipleTimes() {
     val insert = { binders: SqlPreparedStatement.() -> Unit ->
-      driver.execute(2, "INSERT INTO test VALUES (?, ?);", 2, binders)
+      driver.execute(2, "INSERT INTO test VALUES (?, ?);", listOf(25, 28), binders)
     }
 
     insert {
@@ -153,7 +153,7 @@ abstract class DriverTest {
     assertEquals(1, changes())
 
     fun query(binders: SqlPreparedStatement.() -> Unit, mapper: (SqlCursor) -> Unit) {
-      driver.executeQuery(6, "SELECT * FROM test WHERE value = ?", mapper, 1, binders)
+      driver.executeQuery(6, "SELECT * FROM test WHERE value = ?", mapper, listOf(33), binders)
     }
 
     query(
@@ -182,7 +182,7 @@ abstract class DriverTest {
 
   @Test fun sqlResultSetGettersReturnNullIfTheColumnValuesAreNULL() {
     val insert = { binders: SqlPreparedStatement.() -> Unit ->
-      driver.execute(7, "INSERT INTO nullability_test VALUES (?, ?, ?, ?, ?);", 5, binders)
+      driver.execute(7, "INSERT INTO nullability_test VALUES (?, ?, ?, ?, ?);", listOf(37, 40, 43, 46, 49), binders)
     }
     insert {
       bindLong(0, 1)
@@ -201,6 +201,6 @@ abstract class DriverTest {
       assertNull(it.getBytes(3))
       assertNull(it.getDouble(4))
     }
-    driver.executeQuery(8, "SELECT * FROM nullability_test", mapper, 0)
+    driver.executeQuery(8, "SELECT * FROM nullability_test", mapper, emptyList())
   }
 }

--- a/drivers/driver-test/src/commonMain/kotlin/com/squareup/sqldelight/driver/test/QueryTest.kt
+++ b/drivers/driver-test/src/commonMain/kotlin/com/squareup/sqldelight/driver/test/QueryTest.kt
@@ -39,7 +39,7 @@ abstract class QueryTest {
                 value TEXT NOT NULL
                );
             """.trimIndent(),
-            0,
+            emptyList(),
           )
           return QueryResult.Unit
         }
@@ -164,7 +164,7 @@ abstract class QueryTest {
   }
 
   private fun insertTestData(testData: TestData) {
-    driver.execute(1, "INSERT INTO test VALUES (?, ?)", 2) {
+    driver.execute(1, "INSERT INTO test VALUES (?, ?)", listOf(25, 28)) {
       bindLong(0, testData.id)
       bindString(1, testData.value)
     }
@@ -173,7 +173,7 @@ abstract class QueryTest {
   private fun testDataQuery(): Query<TestData> {
     return object : Query<TestData>(mapper) {
       override fun <R> execute(mapper: (SqlCursor) -> R): QueryResult<R> {
-        return driver.executeQuery(0, "SELECT * FROM test", mapper, 0, null)
+        return driver.executeQuery(0, "SELECT * FROM test", mapper, emptyList(), null)
       }
 
       override fun addListener(listener: Listener) {

--- a/drivers/jdbc-driver/src/main/kotlin/app/cash/sqldelight/driver/jdbc/JdbcDriver.kt
+++ b/drivers/jdbc-driver/src/main/kotlin/app/cash/sqldelight/driver/jdbc/JdbcDriver.kt
@@ -118,7 +118,7 @@ abstract class JdbcDriver : SqlDriver, ConnectionManager {
   override fun execute(
     identifier: Int?,
     sql: String,
-    parameters: Int,
+    parameterIndices: List<Int>,
     binders: (SqlPreparedStatement.() -> Unit)?,
   ): QueryResult<Long> {
     val (connection, onClose) = connectionAndClose()
@@ -139,7 +139,7 @@ abstract class JdbcDriver : SqlDriver, ConnectionManager {
     identifier: Int?,
     sql: String,
     mapper: (SqlCursor) -> R,
-    parameters: Int,
+    parameterIndices: List<Int>,
     binders: (SqlPreparedStatement.() -> Unit)?,
   ): QueryResult<R> {
     val (connection, onClose) = connectionAndClose()

--- a/drivers/native-driver/src/nativeMain/kotlin/app/cash/sqldelight/driver/native/NativeSqlDatabase.kt
+++ b/drivers/native-driver/src/nativeMain/kotlin/app/cash/sqldelight/driver/native/NativeSqlDatabase.kt
@@ -51,7 +51,7 @@ sealed class ConnectionWrapper : SqlDriver {
   final override fun execute(
     identifier: Int?,
     sql: String,
-    parameters: Int,
+    parameterIndices: List<Int>,
     binders: (SqlPreparedStatement.() -> Unit)?,
   ): QueryResult<Long> = QueryResult.Value(
     accessStatement(false, identifier, sql, binders) { statement ->
@@ -63,7 +63,7 @@ sealed class ConnectionWrapper : SqlDriver {
     identifier: Int?,
     sql: String,
     mapper: (SqlCursor) -> R,
-    parameters: Int,
+    parameterIndices: List<Int>,
     binders: (SqlPreparedStatement.() -> Unit)?,
   ): QueryResult<R> = QueryResult.Value(
     accessStatement(true, identifier, sql, binders) { statement ->

--- a/drivers/native-driver/src/nativeTest/kotlin/com/squareup/sqldelight/drivers/native/LazyDriverBaseTest.kt
+++ b/drivers/native-driver/src/nativeTest/kotlin/com/squareup/sqldelight/drivers/native/LazyDriverBaseTest.kt
@@ -52,7 +52,7 @@ abstract class LazyDriverBaseTest {
                   |  value TEXT
                   |);
           """.trimMargin(),
-          0,
+          emptyList(),
         )
         driver.execute(
           30,
@@ -65,7 +65,7 @@ abstract class LazyDriverBaseTest {
                   |  real_value REAL
                   |);
           """.trimMargin(),
-          0,
+          emptyList(),
         )
         return QueryResult.Unit
       }

--- a/drivers/native-driver/src/nativeTest/kotlin/com/squareup/sqldelight/drivers/native/NativeSqliteDriverTest.kt.ignore
+++ b/drivers/native-driver/src/nativeTest/kotlin/com/squareup/sqldelight/drivers/native/NativeSqliteDriverTest.kt.ignore
@@ -69,7 +69,7 @@ abstract class NativeSqliteDriverTest : LazyDriverBaseTest() {
     val INSERTS = 10_000
     for (i in 0 until INSERTS) {
       ops.exe {
-        driver.execute(1, "insert into test(id, value)values(?, ?)", 2) {
+        driver.execute(1, "insert into test(id, value)values(?, ?)", listOf(34, 37)) {
           bindLong(1, i.toLong())
           bindString(2, "Hey $i")
         }
@@ -80,7 +80,7 @@ abstract class NativeSqliteDriverTest : LazyDriverBaseTest() {
 
     assertEquals(INSERTS.toLong(), countTestRows(driver))
     val strSet = mutableSetOf<String>()
-    val query = driver.executeQuery(2, "select id, value from test", 0)
+    val query = driver.executeQuery(2, "select id, value from test", emptyList())
     var sum = 0L
     while (query.next()) {
       strSet.add(query.getString(1)!!)
@@ -95,7 +95,7 @@ abstract class NativeSqliteDriverTest : LazyDriverBaseTest() {
   fun `failing transaction clears lock`() {
     assertFails {
       transacter.transaction {
-        driver.execute(1, "insert into test(id, value)values(?, ?)", 2) {
+        driver.execute(1, "insert into test(id, value)values(?, ?)", listOf(34, 37)) {
           bindLong(1, 1)
           bindString(2, "asdf")
         }
@@ -106,7 +106,7 @@ abstract class NativeSqliteDriverTest : LazyDriverBaseTest() {
 
     transacter.transaction {
       try {
-        driver.execute(1, "insert into test(id, value)values(?, ?)", 2) {
+        driver.execute(1, "insert into test(id, value)values(?, ?)", listOf(34, 37)) {
           bindLong(1, 1)
           bindString(2, "asdf")
         }
@@ -124,7 +124,7 @@ abstract class NativeSqliteDriverTest : LazyDriverBaseTest() {
   fun `bad bind doens't taint future binding`() {
     transacter.transaction {
       assertFails {
-        driver.execute(1, "insert into test(id, value)values(?, ?)", 2) {
+        driver.execute(1, "insert into test(id, value)values(?, ?)", listOf(34, 37)) {
           bindLong(1, 1)
           bindString(3, "asdf")
         }
@@ -132,7 +132,7 @@ abstract class NativeSqliteDriverTest : LazyDriverBaseTest() {
     }
 
     transacter.transaction {
-      driver.execute(1, "insert into test(id, value)values(?, ?)", 2) {
+      driver.execute(1, "insert into test(id, value)values(?, ?)", listOf(34, 37)) {
         bindLong(1, 1)
         bindString(2, "asdf")
       }
@@ -144,7 +144,7 @@ abstract class NativeSqliteDriverTest : LazyDriverBaseTest() {
   @Test
   fun `failed bind dumps sqlite statement`() {
     assertFails {
-      driver.execute(1, "insert into test(id, value) values(?, ?)", 2) {
+      driver.execute(1, "insert into test(id, value) values(?, ?)", listOf(35, 38)) {
         assertEquals(0, driver.queryPool.entry.statementCache.size)
         bindLong(1, 1L)
         throw assertFails { bindLong(3, 1L) }
@@ -165,7 +165,7 @@ abstract class NativeSqliteDriverTest : LazyDriverBaseTest() {
           transacter.transaction {
 
             for (i in 0 until 10) {
-              driver.execute(1, "insert into test(id, value)values(?, ?)", 2) {
+              driver.execute(1, "insert into test(id, value)values(?, ?)", listOf(34, 37)) {
                 bindLong(1, i.toLong())
                 bindString(2, "Hey $i")
               }
@@ -176,16 +176,16 @@ abstract class NativeSqliteDriverTest : LazyDriverBaseTest() {
         }
 
         exeQuiet {
-          driver.execute(1, "insert into test(id, value)values(?, ?)", 2) {
+          driver.execute(1, "insert into test(id, value)values(?, ?)", listOf(34, 37)) {
             bindLong(1, i.toLong())
             bindString(3, "Hey $i")
           }
         }
 
-        driver.executeQuery(2, "select id, value from test", 0).next()
+        driver.executeQuery(2, "select id, value from test", emptyList()).next()
 
         exeQuiet {
-          driver.executeQuery(3, "select id, value from toast", 0).next()
+          driver.executeQuery(3, "select id, value from toast", emptyList()).next()
         }
       }
     }
@@ -241,7 +241,7 @@ abstract class NativeSqliteDriverTest : LazyDriverBaseTest() {
         transacter.transaction {
           try {
             for (j in 0 until LOOPS) {
-              conn.execute(1, "insert into test(id, value)values(?, ?)", 2) {
+              conn.execute(1, "insert into test(id, value)values(?, ?)", listOf(34, 37)) {
                 val idInt = i * LOOPS + j + start
                 bindLong(1, idInt.toLong())
                 bindString(2, "row $idInt")
@@ -260,7 +260,7 @@ abstract class NativeSqliteDriverTest : LazyDriverBaseTest() {
 
   @Test
   fun `query statements cached but only 1`() {
-    val stmt = { driver.executeQuery(1, "select * from test", 0) }
+    val stmt = { driver.executeQuery(1, "select * from test", emptyList()) }
 
     assertEquals(0, driver.queryPool.entry.statementCache.size)
     assertEquals(0, driver.queryPool.entry.cursorCollection.size)
@@ -307,7 +307,7 @@ abstract class NativeSqliteDriverTest : LazyDriverBaseTest() {
   @Test
   fun `query exception clears statement`() {
     assertFails {
-      driver.executeQuery(1, "select * from test", 0) {
+      driver.executeQuery(1, "select * from test", emptyList()) {
         throw assertFails { bindLong(1, 2L) }
       }
     }
@@ -350,7 +350,7 @@ abstract class NativeSqliteDriverTest : LazyDriverBaseTest() {
   @Test
   fun `caching by index works as expected`() {
     val transacter = transacter
-    driver.execute(1, "insert into test(id, value)values(?, ?)", 2) {
+    driver.execute(1, "insert into test(id, value)values(?, ?)", listOf(34, 37)) {
       bindLong(1, 22L)
       bindString(2, "Hey 22")
     }
@@ -359,7 +359,7 @@ abstract class NativeSqliteDriverTest : LazyDriverBaseTest() {
     assertEquals(0, driver.transactionPool.entry.statementCache.size)
 
     transacter.transaction {
-      driver.execute(1, "insert into test(id, value)values(?, ?)", 2) {
+      driver.execute(1, "insert into test(id, value)values(?, ?)", listOf(34, 37)) {
         bindLong(1, 33L)
         bindString(2, "Hey 33")
       }
@@ -372,7 +372,7 @@ abstract class NativeSqliteDriverTest : LazyDriverBaseTest() {
         driver.transactionPool.entry.statementCache.entries.iterator().next().value
 
     transacter.transaction {
-      driver.execute(1, "insert into test(id, value)values(?, ?)", 2) {
+      driver.execute(1, "insert into test(id, value)values(?, ?)", listOf(34, 37)) {
         bindLong(1, 34L)
         bindString(2, "Hey 34")
       }
@@ -389,7 +389,7 @@ abstract class NativeSqliteDriverTest : LazyDriverBaseTest() {
   @Test
   fun `null identifier doesn't cache`() {
     val transacter = transacter
-    driver.execute(null, "insert into test(id, value)values(?, ?)", 2) {
+    driver.execute(null, "insert into test(id, value)values(?, ?)", emptyList()) {
       bindLong(1, 22L)
       bindString(2, "Hey 22")
     }
@@ -399,7 +399,7 @@ abstract class NativeSqliteDriverTest : LazyDriverBaseTest() {
     assertEquals(0, driver.transactionPool.entry.statementCache.size)
 
     transacter.transaction {
-      driver.execute(null, "insert into test(id, value)values(?, ?)", 2) {
+      driver.execute(null, "insert into test(id, value)values(?, ?)", emptyList()) {
         bindLong(1, 23L)
         bindString(2, "Hey 23")
       }

--- a/drivers/native-driver/src/nativeTest/kotlin/com/squareup/sqldelight/drivers/native/connectionpool/BaseConcurrencyTest.kt
+++ b/drivers/native-driver/src/nativeTest/kotlin/com/squareup/sqldelight/drivers/native/connectionpool/BaseConcurrencyTest.kt
@@ -20,7 +20,7 @@ abstract class BaseConcurrencyTest {
       0,
       "SELECT count(*) FROM test",
       { it.next(); it.getLong(0)!! },
-      0,
+      emptyList(),
     ).value
   }
 
@@ -122,7 +122,7 @@ abstract class BaseConcurrencyTest {
                 value TEXT NOT NULL
                );
             """.trimIndent(),
-            0,
+            emptyList(),
           )
           return QueryResult.Unit
         }
@@ -163,7 +163,7 @@ abstract class BaseConcurrencyTest {
   }
 
   internal fun insertTestData(testData: TestData, driver: SqlDriver = this.driver) {
-    driver.execute(1, "INSERT INTO test VALUES (?, ?)", 2) {
+    driver.execute(1, "INSERT INTO test VALUES (?, ?)", listOf(25, 28)) {
       bindLong(0, testData.id)
       bindString(1, testData.value)
     }

--- a/drivers/native-driver/src/nativeTest/kotlin/com/squareup/sqldelight/drivers/native/connectionpool/WalConcurrencyTest.kt
+++ b/drivers/native-driver/src/nativeTest/kotlin/com/squareup/sqldelight/drivers/native/connectionpool/WalConcurrencyTest.kt
@@ -104,7 +104,7 @@ class WalConcurrencyTest : BaseConcurrencyTest() {
   private fun testDataQuery(): Query<TestData> {
     return object : Query<TestData>(mapper) {
       override fun <R> execute(mapper: (SqlCursor) -> R): QueryResult<R> {
-        return driver.executeQuery(0, "SELECT * FROM test", mapper, 0, null)
+        return driver.executeQuery(0, "SELECT * FROM test", mapper, emptyList(), null)
       }
 
       override fun addListener(listener: Listener) {

--- a/drivers/r2dbc-driver/src/main/kotlin/app/cash/sqldelight/driver/r2dbc/R2dbcDriver.kt
+++ b/drivers/r2dbc-driver/src/main/kotlin/app/cash/sqldelight/driver/r2dbc/R2dbcDriver.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.reactive.awaitFirstOrNull
 import kotlinx.coroutines.reactive.awaitSingle
 
-class R2dbcDriver(private val connection: Connection) : SqlDriver {
+class R2dbcDriver(private val connection: Connection, private val replaceParameter: Boolean) : SqlDriver {
   private fun calcParameterReplacementAdditionalLength(parameters: Int): Int {
     var numbers = 9 // numbers with current length
     var strLen = 1 // length of each number in characters
@@ -28,9 +28,9 @@ class R2dbcDriver(private val connection: Connection) : SqlDriver {
     return lengthSum + remaining * strLen
   }
 
-  private fun replaceParameters(sql: String, parameterIndices: List<Int>): String {
+  private fun replaceParameters(sql: String, parameterIndices: List<Int>): String = if (replaceParameter) {
     val additionalSpace = calcParameterReplacementAdditionalLength(parameterIndices.size)
-    return buildString(sql.length + additionalSpace) {
+    buildString(sql.length + additionalSpace) {
       var lastIndex = 0
       parameterIndices.forEachIndexed { parameterIndex, stringIndex ->
         append(sql.substring(lastIndex, stringIndex))
@@ -42,6 +42,8 @@ class R2dbcDriver(private val connection: Connection) : SqlDriver {
         append(sql.substring(lastIndex))
       }
     }
+  } else {
+    sql
   }
 
   override fun <R> executeQuery(

--- a/drivers/sqljs-driver/src/main/kotlin/app/cash/sqldelight/driver/sqljs/JsSqlDriver.kt
+++ b/drivers/sqljs-driver/src/main/kotlin/app/cash/sqldelight/driver/sqljs/JsSqlDriver.kt
@@ -51,11 +51,11 @@ class JsSqlDriver(private val db: Database) : SqlDriver {
     identifier: Int?,
     sql: String,
     mapper: (SqlCursor) -> R,
-    parameters: Int,
+    parameterIndices: List<Int>,
     binders: (SqlPreparedStatement.() -> Unit)?,
   ): QueryResult<R> {
     val cursor = createOrGetStatement(identifier, sql).run {
-      bind(parameters, binders)
+      bind(parameterIndices.size, binders)
       JsSqlCursor(this)
     }
 
@@ -66,9 +66,14 @@ class JsSqlDriver(private val db: Database) : SqlDriver {
     }
   }
 
-  override fun execute(identifier: Int?, sql: String, parameters: Int, binders: (SqlPreparedStatement.() -> Unit)?): QueryResult<Long> =
+  override fun execute(
+    identifier: Int?,
+    sql: String,
+    parameterIndices: List<Int>,
+    binders: (SqlPreparedStatement.() -> Unit)?,
+  ): QueryResult<Long> =
     createOrGetStatement(identifier, sql).run {
-      bind(parameters, binders)
+      bind(parameterIndices.size, binders)
       step()
       freemem()
       return QueryResult.Value(0)

--- a/drivers/sqljs-driver/src/main/kotlin/app/cash/sqldelight/driver/sqljs/worker/JsWorkerSqlDriver.kt
+++ b/drivers/sqljs-driver/src/main/kotlin/app/cash/sqldelight/driver/sqljs/worker/JsWorkerSqlDriver.kt
@@ -36,7 +36,7 @@ class JsWorkerSqlDriver(private val worker: Worker) : SqlDriver {
   private var messageCounter = 0
   private var transaction: Transacter.Transaction? = null
 
-  override fun <R> executeQuery(identifier: Int?, sql: String, mapper: (SqlCursor) -> R, parameters: Int, binders: (SqlPreparedStatement.() -> Unit)?): QueryResult<R> {
+  override fun <R> executeQuery(identifier: Int?, sql: String, mapper: (SqlCursor) -> R, parameterIndices: List<Int>, binders: (SqlPreparedStatement.() -> Unit)?): QueryResult<R> {
     val bound = JsWorkerSqlPreparedStatement()
     binders?.invoke(bound)
 
@@ -61,7 +61,7 @@ class JsWorkerSqlDriver(private val worker: Worker) : SqlDriver {
     }
   }
 
-  override fun execute(identifier: Int?, sql: String, parameters: Int, binders: (SqlPreparedStatement.() -> Unit)?): QueryResult<Long> {
+  override fun execute(identifier: Int?, sql: String, parameterIndices: List<Int>, binders: (SqlPreparedStatement.() -> Unit)?): QueryResult<Long> {
     val bound = JsWorkerSqlPreparedStatement()
     binders?.invoke(bound)
 

--- a/drivers/sqljs-driver/src/test/kotlin/com/squareup/sqldelight/drivers/sqljs/JsDriverTest.kt
+++ b/drivers/sqljs-driver/src/test/kotlin/com/squareup/sqldelight/drivers/sqljs/JsDriverTest.kt
@@ -30,7 +30,7 @@ class JsDriverTest {
               |  value TEXT
               |);
         """.trimMargin(),
-        0,
+        emptyList(),
       )
       driver.execute(
         1,
@@ -43,7 +43,7 @@ class JsDriverTest {
               |  real_value REAL
               |);
         """.trimMargin(),
-        0,
+        emptyList(),
       )
       return QueryResult.Unit
     }
@@ -74,13 +74,13 @@ class JsDriverTest {
   @Test fun insert_can_run_multiple_times() = driverPromise.then { driver ->
 
     val insert = { binders: SqlPreparedStatement.() -> Unit ->
-      driver.execute(2, "INSERT INTO test VALUES (?, ?);", 2, binders)
+      driver.execute(2, "INSERT INTO test VALUES (?, ?);", listOf(25, 28), binders)
     }
     fun query(mapper: (SqlCursor) -> Unit) {
-      driver.executeQuery(3, "SELECT * FROM test", mapper, 0)
+      driver.executeQuery(3, "SELECT * FROM test", mapper, emptyList())
     }
     fun changes(mapper: (SqlCursor) -> Long?): Long? {
-      return driver.executeQuery(4, "SELECT changes()", mapper, 0).value
+      return driver.executeQuery(4, "SELECT changes()", mapper, emptyList()).value
     }
 
     query {
@@ -120,7 +120,7 @@ class JsDriverTest {
       assertEquals("Jake", it.getString(1))
     }
 
-    driver.execute(5, "DELETE FROM test", 0)
+    driver.execute(5, "DELETE FROM test", emptyList())
     assertEquals(2, changes { it.next(); it.getLong(0) })
 
     query {
@@ -131,10 +131,10 @@ class JsDriverTest {
   @Test fun query_can_run_multiple_times() = driverPromise.then { driver ->
 
     val insert = { binders: SqlPreparedStatement.() -> Unit ->
-      driver.execute(2, "INSERT INTO test VALUES (?, ?);", 2, binders)
+      driver.execute(2, "INSERT INTO test VALUES (?, ?);", listOf(25, 28), binders)
     }
     fun changes(mapper: (SqlCursor) -> Long?): Long? {
-      return driver.executeQuery(4, "SELECT changes()", mapper, 0).value
+      return driver.executeQuery(4, "SELECT changes()", mapper, emptyList()).value
     }
 
     insert {
@@ -149,7 +149,7 @@ class JsDriverTest {
     assertEquals(1, changes { it.next(); it.getLong(0) })
 
     fun query(binders: SqlPreparedStatement.() -> Unit, mapper: (SqlCursor) -> Unit) {
-      driver.executeQuery(6, "SELECT * FROM test WHERE value = ?", mapper, 1, binders)
+      driver.executeQuery(6, "SELECT * FROM test WHERE value = ?", mapper, listOf(33), binders)
     }
     query(
       binders = {
@@ -178,10 +178,10 @@ class JsDriverTest {
   @Test fun sqlResultSet_getters_return_null_if_the_column_values_are_NULL() = driverPromise.then { driver ->
 
     val insert = { binders: SqlPreparedStatement.() -> Unit ->
-      driver.execute(7, "INSERT INTO nullability_test VALUES (?, ?, ?, ?, ?);", 5, binders)
+      driver.execute(7, "INSERT INTO nullability_test VALUES (?, ?, ?, ?, ?);", listOf(37, 40, 43, 46, 49), binders)
     }
     fun changes(mapper: (SqlCursor) -> Long?): Long? {
-      return driver.executeQuery(4, "SELECT changes()", mapper, 0).value
+      return driver.executeQuery(4, "SELECT changes()", mapper, emptyList()).value
     }
 
     insert {
@@ -201,13 +201,13 @@ class JsDriverTest {
       assertNull(it.getBytes(3))
       assertNull(it.getDouble(4))
     }
-    driver.executeQuery(8, "SELECT * FROM nullability_test", mapper, 0)
+    driver.executeQuery(8, "SELECT * FROM nullability_test", mapper, emptyList())
   }
 
   @Test fun types_are_correctly_converted_from_JS_to_Kotlin_and_back() = driverPromise.then { driver ->
 
     val insert = { binders: SqlPreparedStatement.() -> Unit ->
-      driver.execute(7, "INSERT INTO nullability_test VALUES (?, ?, ?, ?, ?);", 5, binders)
+      driver.execute(7, "INSERT INTO nullability_test VALUES (?, ?, ?, ?, ?);", listOf(37, 40, 43, 46, 49), binders)
     }
 
     insert {
@@ -226,6 +226,6 @@ class JsDriverTest {
       it.getBytes(3)?.forEachIndexed { index, byte -> assertEquals(index.toByte(), byte) }
       assertEquals(Float.MAX_VALUE.toDouble(), it.getDouble(4))
     }
-    driver.executeQuery(8, "SELECT * FROM nullability_test", mapper, 0)
+    driver.executeQuery(8, "SELECT * FROM nullability_test", mapper, emptyList())
   }
 }

--- a/drivers/sqljs-driver/src/test/kotlin/com/squareup/sqldelight/drivers/sqljs/JsQueryTest.kt
+++ b/drivers/sqljs-driver/src/test/kotlin/com/squareup/sqldelight/drivers/sqljs/JsQueryTest.kt
@@ -37,7 +37,7 @@ class JsQueryTest {
                 value TEXT NOT NULL
                );
         """.trimIndent(),
-        0,
+        emptyList(),
       )
       return QueryResult.Unit
     }
@@ -171,7 +171,7 @@ class JsQueryTest {
   }
 
   private fun SqlDriver.insertTestData(testData: TestData) {
-    execute(1, "INSERT INTO test VALUES (?, ?)", 2) {
+    execute(1, "INSERT INTO test VALUES (?, ?)", listOf(25, 28)) {
       bindLong(0, testData.id)
       bindString(1, testData.value)
     }
@@ -180,7 +180,7 @@ class JsQueryTest {
   private fun SqlDriver.testDataQuery(): Query<TestData> {
     return object : Query<TestData>(mapper) {
       override fun <R> execute(mapper: (SqlCursor) -> R): QueryResult<R> {
-        return executeQuery(0, "SELECT * FROM test", mapper, 0, null)
+        return executeQuery(0, "SELECT * FROM test", mapper, emptyList(), null)
       }
 
       override fun addListener(listener: Listener) {

--- a/drivers/sqljs-driver/src/test/kotlin/com/squareup/sqldelight/drivers/sqljs/JsWorkerDriverTest.kt
+++ b/drivers/sqljs-driver/src/test/kotlin/com/squareup/sqldelight/drivers/sqljs/JsWorkerDriverTest.kt
@@ -33,7 +33,7 @@ class JsWorkerDriverTest {
               |  value TEXT
               |);
         """.trimMargin(),
-        0,
+        emptyList(),
       ).await()
       driver.execute(
         1,
@@ -46,7 +46,7 @@ class JsWorkerDriverTest {
               |  real_value REAL
               |);
         """.trimMargin(),
-        0,
+        emptyList(),
       ).await()
     }
 
@@ -63,15 +63,15 @@ class JsWorkerDriverTest {
   fun insert_can_run_multiple_times() = runTest { driver ->
 
     val insert: InsertFunction = { binders: SqlPreparedStatement.() -> Unit ->
-      driver.await(2, "INSERT INTO test VALUES (?, ?);", 2, binders)
+      driver.await(2, "INSERT INTO test VALUES (?, ?);", listOf(25, 28), binders)
     }
 
     suspend fun query(mapper: (SqlCursor) -> Unit) {
-      driver.awaitQuery(3, "SELECT * FROM test", mapper, 0)
+      driver.awaitQuery(3, "SELECT * FROM test", mapper, emptyList())
     }
 
     suspend fun changes(mapper: (SqlCursor) -> Long?): Long? {
-      return driver.awaitQuery(4, "SELECT changes()", mapper, 0)
+      return driver.awaitQuery(4, "SELECT changes()", mapper, emptyList())
     }
 
     query {
@@ -111,7 +111,7 @@ class JsWorkerDriverTest {
       assertEquals("Jake", it.getString(1))
     }
 
-    driver.await(5, "DELETE FROM test", 0)
+    driver.await(5, "DELETE FROM test", emptyList())
     assertEquals(2, changes { it.next(); it.getLong(0) })
 
     query {
@@ -123,11 +123,11 @@ class JsWorkerDriverTest {
   fun query_can_run_multiple_times() = runTest { driver ->
 
     val insert: InsertFunction = { binders: SqlPreparedStatement.() -> Unit ->
-      driver.await(2, "INSERT INTO test VALUES (?, ?);", 2, binders)
+      driver.await(2, "INSERT INTO test VALUES (?, ?);", listOf(25, 28), binders)
     }
 
     suspend fun changes(mapper: (SqlCursor) -> Long?): Long? {
-      return driver.awaitQuery(4, "SELECT changes()", mapper, 0)
+      return driver.awaitQuery(4, "SELECT changes()", mapper, emptyList())
     }
 
     insert {
@@ -142,7 +142,7 @@ class JsWorkerDriverTest {
     assertEquals(1, changes { it.next(); it.getLong(0) })
 
     suspend fun query(binders: SqlPreparedStatement.() -> Unit, mapper: (SqlCursor) -> Unit) {
-      driver.awaitQuery(6, "SELECT * FROM test WHERE value = ?", mapper, 1, binders)
+      driver.awaitQuery(6, "SELECT * FROM test WHERE value = ?", mapper, listOf(33), binders)
     }
     query(
       binders = {
@@ -171,11 +171,11 @@ class JsWorkerDriverTest {
   @Test
   fun sqlResultSet_getters_return_null_if_the_column_values_are_NULL() = runTest { driver ->
     val insert: InsertFunction = { binders: SqlPreparedStatement.() -> Unit ->
-      driver.await(7, "INSERT INTO nullability_test VALUES (?, ?, ?, ?, ?);", 5, binders)
+      driver.await(7, "INSERT INTO nullability_test VALUES (?, ?, ?, ?, ?);", listOf(37, 40, 43, 46, 49), binders)
     }
 
     suspend fun changes(mapper: (SqlCursor) -> Long?): Long? {
-      return driver.awaitQuery(4, "SELECT changes()", mapper, 0)
+      return driver.awaitQuery(4, "SELECT changes()", mapper, emptyList())
     }
 
     val inserted = insert {
@@ -194,14 +194,14 @@ class JsWorkerDriverTest {
       assertNull(it.getBytes(3))
       assertNull(it.getDouble(4))
     }
-    driver.awaitQuery(8, "SELECT * FROM nullability_test", mapper, 0)
+    driver.awaitQuery(8, "SELECT * FROM nullability_test", mapper, emptyList())
     changes { it.next(); it.getLong(0) }
   }
 
   @Test
   fun types_are_correctly_converted_from_JS_to_Kotlin_and_back() = runTest { driver ->
     val insert: InsertFunction = { binders: SqlPreparedStatement.() -> Unit ->
-      driver.await(7, "INSERT INTO nullability_test VALUES (?, ?, ?, ?, ?);", 5, binders)
+      driver.await(7, "INSERT INTO nullability_test VALUES (?, ?, ?, ?, ?);", listOf(37, 40, 43, 46, 49), binders)
     }
 
     insert {
@@ -220,7 +220,7 @@ class JsWorkerDriverTest {
       it.getBytes(3)?.forEachIndexed { index, byte -> assertEquals(index.toByte(), byte) }
       assertEquals(Float.MAX_VALUE.toDouble(), it.getDouble(4))
     }
-    driver.awaitQuery(8, "SELECT * FROM nullability_test", mapper, 0)
+    driver.awaitQuery(8, "SELECT * FROM nullability_test", mapper, emptyList())
   }
 
   @Test

--- a/extensions/android-paging3/android-test/src/test/java/app/cash/sqldelight/paging3/OffsetQueryPagingSourceTest.kt
+++ b/extensions/android-paging3/android-test/src/test/java/app/cash/sqldelight/paging3/OffsetQueryPagingSourceTest.kt
@@ -47,7 +47,7 @@ class OffsetQueryPagingSourceTest {
   @Before
   fun init() {
     driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
-    driver.execute(null, "CREATE TABLE TestItem(id INTEGER NOT NULL PRIMARY KEY);", 0)
+    driver.execute(null, "CREATE TABLE TestItem(id INTEGER NOT NULL PRIMARY KEY);", emptyList())
     transacter = object : TransacterImpl(driver) {}
   }
 
@@ -649,7 +649,7 @@ class OffsetQueryPagingSourceTest {
       TestItem(cursor.getLong(0)!!)
     },
   ) {
-    override fun <R> execute(mapper: (SqlCursor) -> R) = driver.executeQuery(1, "SELECT id FROM TestItem LIMIT ? OFFSET ?", mapper, 2) {
+    override fun <R> execute(mapper: (SqlCursor) -> R) = driver.executeQuery(1, "SELECT id FROM TestItem LIMIT ? OFFSET ?", mapper, listOf(30, 39)) {
       bindLong(0, limit)
       bindLong(1, offset)
     }
@@ -680,7 +680,7 @@ class OffsetQueryPagingSourceTest {
 
   private fun insertItems(items: List<TestItem>) {
     items.forEach {
-      driver.execute(0, "INSERT INTO TestItem (id) VALUES (?)", 1) {
+      driver.execute(0, "INSERT INTO TestItem (id) VALUES (?)", listOf(34)) {
         bindLong(0, it.id)
       }
     }
@@ -688,14 +688,14 @@ class OffsetQueryPagingSourceTest {
 
   private fun deleteItem(item: TestItem): Long =
     driver
-      .execute(0, "DELETE FROM TestItem WHERE id = ?;", 1) {
+      .execute(0, "DELETE FROM TestItem WHERE id = ?;", listOf(32)) {
         bindLong(0, item.id)
       }
       .value
 
   private fun deleteItems(range: IntRange): Long =
     driver
-      .execute(0, "DELETE FROM TestItem WHERE id >= ? AND id <= ?", 2) {
+      .execute(0, "DELETE FROM TestItem WHERE id >= ? AND id <= ?", listOf(33, 45)) {
         bindLong(0, range.first.toLong())
         bindLong(1, range.last.toLong())
       }

--- a/extensions/android-paging3/src/test/java/app/cash/sqldelight/paging3/KeyedQueryPagingSourceTest.kt
+++ b/extensions/android-paging3/src/test/java/app/cash/sqldelight/paging3/KeyedQueryPagingSourceTest.kt
@@ -26,7 +26,7 @@ class KeyedQueryPagingSourceTest {
 
   @Before fun before() {
     driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
-    driver.execute(null, "CREATE TABLE testTable(value INTEGER PRIMARY KEY)", 0)
+    driver.execute(null, "CREATE TABLE testTable(value INTEGER PRIMARY KEY)", emptyList())
     (0L until 10L).forEach { this.insert(it) }
     transacter = object : TransacterImpl(driver) {}
   }
@@ -177,7 +177,7 @@ class KeyedQueryPagingSourceTest {
     """.trimMargin()
 
     return object : Query<Long>({ cursor -> cursor.getLong(0)!! }) {
-      override fun <R> execute(mapper: (SqlCursor) -> R) = driver.executeQuery(identifier = 3, sql = sql, mapper = mapper, parameters = 2) {
+      override fun <R> execute(mapper: (SqlCursor) -> R) = driver.executeQuery(identifier = 3, sql = sql, mapper = mapper, parameterIndices = listOf(107, 108)) {
         bindLong(0, limit)
         bindLong(1, anchor)
       }
@@ -197,7 +197,7 @@ class KeyedQueryPagingSourceTest {
     return object : Query<Long>(
       { cursor -> cursor.getLong(0)!! },
     ) {
-      override fun <R> execute(mapper: (SqlCursor) -> R) = driver.executeQuery(identifier = 2, sql = sql, mapper = mapper, parameters = 2) {
+      override fun <R> execute(mapper: (SqlCursor) -> R) = driver.executeQuery(identifier = 2, sql = sql, mapper = mapper, parameterIndices = listOf(43, 59)) {
         bindLong(0, beginInclusive)
         bindLong(1, endExclusive)
       }
@@ -208,7 +208,7 @@ class KeyedQueryPagingSourceTest {
   }
 
   private fun insert(value: Long, db: SqlDriver = driver) {
-    db.execute(0, "INSERT INTO testTable (value) VALUES (?)", 1) {
+    db.execute(0, "INSERT INTO testTable (value) VALUES (?)", listOf(38)) {
       bindLong(0, value)
     }
   }

--- a/extensions/async-extensions/src/commonMain/kotlin/app/cash/sqldelight/async/coroutines/DriverExtensions.kt
+++ b/extensions/async-extensions/src/commonMain/kotlin/app/cash/sqldelight/async/coroutines/DriverExtensions.kt
@@ -9,16 +9,16 @@ suspend fun <R> SqlDriver.awaitQuery(
   identifier: Int?,
   sql: String,
   mapper: (SqlCursor) -> R,
-  parameters: Int,
+  parameterIndices: List<Int>,
   binders: (SqlPreparedStatement.() -> Unit)? = null,
-): R = executeQuery<R>(identifier, sql, mapper, parameters, binders).await()
+): R = executeQuery<R>(identifier, sql, mapper, parameterIndices, binders).await()
 
 suspend fun SqlDriver.await(
   identifier: Int?,
   sql: String,
-  parameters: Int,
+  parameterIndices: List<Int>,
   binders: (SqlPreparedStatement.() -> Unit)? = null,
-): Long = execute(identifier, sql, parameters, binders).await()
+): Long = execute(identifier, sql, parameterIndices, binders).await()
 
 suspend fun SqlSchema.awaitCreate(driver: SqlDriver) = create(driver).await()
 

--- a/extensions/coroutines-extensions/src/commonTest/kotlin/app/cash/sqldelight/coroutines/TestDb.kt
+++ b/extensions/coroutines-extensions/src/commonTest/kotlin/app/cash/sqldelight/coroutines/TestDb.kt
@@ -21,21 +21,21 @@ class TestDb(
   var eveId: Long by Atomic<Long>(0)
 
   init {
-    db.execute(null, "PRAGMA foreign_keys=ON", 0)
+    db.execute(null, "PRAGMA foreign_keys=ON", emptyList())
 
-    db.execute(null, CREATE_EMPLOYEE, 0)
+    db.execute(null, CREATE_EMPLOYEE, emptyList())
     aliceId = employee(Employee("alice", "Alice Allison"))
     bobId = employee(Employee("bob", "Bob Bobberson"))
     eveId = employee(Employee("eve", "Eve Evenson"))
 
-    db.execute(null, CREATE_MANAGER, 0)
+    db.execute(null, CREATE_MANAGER, emptyList())
     manager(eveId, aliceId)
   }
 
   fun <T : Any> createQuery(key: String, query: String, mapper: (SqlCursor) -> T): Query<T> {
     return object : Query<T>(mapper) {
       override fun <R> execute(mapper: (SqlCursor) -> R): QueryResult<R> {
-        return db.executeQuery(null, query, mapper, 0, null)
+        return db.executeQuery(null, query, mapper, emptyList(), null)
       }
 
       override fun addListener(listener: Listener) {
@@ -64,7 +64,7 @@ class TestDb(
       |VALUES (?, ?)
       |
       """.trimMargin(),
-      2,
+      listOf(54, 57),
     ) {
       bindString(0, employee.username)
       bindString(1, employee.name)
@@ -76,7 +76,7 @@ class TestDb(
         it.next()
         it.getLong(0)!!
       }
-      db.executeQuery(2, "SELECT last_insert_rowid()", mapper, 0).value
+      db.executeQuery(2, "SELECT last_insert_rowid()", mapper, emptyList()).value
     }
   }
 
@@ -91,7 +91,7 @@ class TestDb(
       |VALUES (?, ?)
       |
       """.trimMargin(),
-      2,
+      listOf(62, 65),
     ) {
       bindLong(0, employeeId)
       bindLong(1, managerId)
@@ -103,7 +103,7 @@ class TestDb(
         it.next()
         it.getLong(0)!!
       }
-      db.executeQuery(2, "SELECT last_insert_rowid()", mapper, 0).value
+      db.executeQuery(2, "SELECT last_insert_rowid()", mapper, emptyList()).value
     }
   }
 

--- a/extensions/rxjava2-extensions/src/test/kotlin/app/cash/sqldelight/rx2/TestDb.kt
+++ b/extensions/rxjava2-extensions/src/test/kotlin/app/cash/sqldelight/rx2/TestDb.kt
@@ -19,21 +19,21 @@ class TestDb(
   var eveId: Long = 0
 
   init {
-    db.execute(null, "PRAGMA foreign_keys=ON", 0)
+    db.execute(null, "PRAGMA foreign_keys=ON", emptyList())
 
-    db.execute(null, CREATE_EMPLOYEE, 0)
+    db.execute(null, CREATE_EMPLOYEE, emptyList())
     aliceId = employee(Employee("alice", "Alice Allison"))
     bobId = employee(Employee("bob", "Bob Bobberson"))
     eveId = employee(Employee("eve", "Eve Evenson"))
 
-    db.execute(null, CREATE_MANAGER, 0)
+    db.execute(null, CREATE_MANAGER, emptyList())
     manager(eveId, aliceId)
   }
 
   fun <T : Any> createQuery(key: String, query: String, mapper: (SqlCursor) -> T): Query<T> {
     return object : Query<T>(mapper) {
       override fun <R> execute(mapper: (SqlCursor) -> R): QueryResult<R> {
-        return db.executeQuery(null, query, mapper, 0)
+        return db.executeQuery(null, query, mapper, emptyList())
       }
 
       override fun addListener(listener: Listener) {
@@ -62,13 +62,13 @@ class TestDb(
       |VALUES (?, ?)
       |
       """.trimMargin(),
-      2,
+      listOf(54, 57),
     ) {
       bindString(0, employee.username)
       bindString(1, employee.name)
     }
     notify(TABLE_EMPLOYEE)
-    return db.executeQuery(2, "SELECT last_insert_rowid()", ::getLong, 0).value
+    return db.executeQuery(2, "SELECT last_insert_rowid()", ::getLong, emptyList()).value
   }
 
   fun manager(
@@ -82,13 +82,13 @@ class TestDb(
       |VALUES (?, ?)
       |
       """.trimMargin(),
-      2,
+      listOf(62, 65),
     ) {
       bindLong(0, employeeId)
       bindLong(1, managerId)
     }
     notify(TABLE_MANAGER)
-    return db.executeQuery(2, "SELECT last_insert_rowid()", ::getLong, 0).value
+    return db.executeQuery(2, "SELECT last_insert_rowid()", ::getLong, emptyList()).value
   }
 
   companion object {

--- a/extensions/rxjava3-extensions/src/test/kotlin/app/cash/sqldelight/rx3/TestDb.kt
+++ b/extensions/rxjava3-extensions/src/test/kotlin/app/cash/sqldelight/rx3/TestDb.kt
@@ -18,21 +18,21 @@ class TestDb(
   var eveId: Long = 0
 
   init {
-    db.execute(null, "PRAGMA foreign_keys=ON", 0)
+    db.execute(null, "PRAGMA foreign_keys=ON", emptyList())
 
-    db.execute(null, CREATE_EMPLOYEE, 0)
+    db.execute(null, CREATE_EMPLOYEE, emptyList())
     aliceId = employee(Employee("alice", "Alice Allison"))
     bobId = employee(Employee("bob", "Bob Bobberson"))
     eveId = employee(Employee("eve", "Eve Evenson"))
 
-    db.execute(null, CREATE_MANAGER, 0)
+    db.execute(null, CREATE_MANAGER, emptyList())
     manager(eveId, aliceId)
   }
 
   fun <T : Any> createQuery(key: String, query: String, mapper: (SqlCursor) -> T): Query<T> {
     return object : Query<T>(mapper) {
       override fun <R> execute(mapper: (SqlCursor) -> R): QueryResult<R> {
-        return db.executeQuery(null, query, mapper, 0)
+        return db.executeQuery(null, query, mapper, emptyList())
       }
 
       override fun addListener(listener: Listener) {
@@ -61,13 +61,13 @@ class TestDb(
       |VALUES (?, ?)
       |
       """.trimMargin(),
-      2,
+      listOf(54, 57),
     ) {
       bindString(0, employee.username)
       bindString(1, employee.name)
     }
     notify(TABLE_EMPLOYEE)
-    return db.executeQuery(2, "SELECT last_insert_rowid()", ::getLong, 0).value
+    return db.executeQuery(2, "SELECT last_insert_rowid()", ::getLong, emptyList()).value
   }
 
   fun manager(
@@ -81,13 +81,13 @@ class TestDb(
       |VALUES (?, ?)
       |
       """.trimMargin(),
-      2,
+      listOf(62, 65),
     ) {
       bindLong(0, employeeId)
       bindLong(1, managerId)
     }
     notify(TABLE_MANAGER)
-    return db.executeQuery(2, "SELECT last_insert_rowid()", ::getLong, 0).value
+    return db.executeQuery(2, "SELECT last_insert_rowid()", ::getLong, emptyList()).value
   }
 
   companion object {

--- a/runtime/src/commonMain/kotlin/app/cash/sqldelight/Query.kt
+++ b/runtime/src/commonMain/kotlin/app/cash/sqldelight/Query.kt
@@ -95,7 +95,7 @@ private class SimpleQuery<out RowType : Any>(
   mapper: (SqlCursor) -> RowType,
 ) : Query<RowType>(mapper) {
   override fun <R> execute(mapper: (SqlCursor) -> R): QueryResult<R> {
-    return driver.executeQuery(identifier, query, mapper, 0, null)
+    return driver.executeQuery(identifier, query, mapper, emptyList(), null)
   }
 
   override fun toString() = "$fileName:$label"
@@ -118,7 +118,7 @@ private class SimpleExecutableQuery<out RowType : Any>(
   mapper: (SqlCursor) -> RowType,
 ) : ExecutableQuery<RowType>(mapper) {
   override fun <R> execute(mapper: (SqlCursor) -> R): QueryResult<R> {
-    return driver.executeQuery(identifier, query, mapper, 0, null)
+    return driver.executeQuery(identifier, query, mapper, emptyList(), null)
   }
 
   override fun toString() = "$fileName:$label"

--- a/runtime/src/commonMain/kotlin/app/cash/sqldelight/db/SqlDriver.kt
+++ b/runtime/src/commonMain/kotlin/app/cash/sqldelight/db/SqlDriver.kt
@@ -33,7 +33,7 @@ interface SqlDriver : Closeable {
    *   successfully. The generic result of the lambda is returned to the caller, as soon as the
    *   mutual exclusion on the database connection ends. The cursor **must not escape** the block
    *   scope.
-   * @param [parameters] The number of bindable parameters [sql] contains.
+   * @param [parameterIndicess] The indices of bindable parameters [sql] contains.
    * @param [binders] A lambda which is called before execution to bind any parameters to the SQL
    *   statement.
    */
@@ -41,7 +41,7 @@ interface SqlDriver : Closeable {
     identifier: Int?,
     sql: String,
     mapper: (SqlCursor) -> R,
-    parameters: Int,
+    parameterIndices: List<Int>,
     binders: (SqlPreparedStatement.() -> Unit)? = null,
   ): QueryResult<R>
 
@@ -51,7 +51,7 @@ interface SqlDriver : Closeable {
    * @param [identifier] An opaque, unique value that can be used to implement any driver-side
    *   caching of prepared statements. If [identifier] is null, a fresh statement is required.
    * @param [sql] The SQL string to be executed.
-   * @param [parameters] The number of bindable parameters [sql] contains.
+   * @param [parameterIndicess] The indices of bindable parameters [sql] contains.
    * @param [binders] A lambda which is called before execution to bind any parameters to the SQL
    *   statement.
    *
@@ -63,7 +63,7 @@ interface SqlDriver : Closeable {
   fun execute(
     identifier: Int?,
     sql: String,
-    parameters: Int,
+    parameterIndices: List<Int>,
     binders: (SqlPreparedStatement.() -> Unit)? = null,
   ): QueryResult<Long>
 

--- a/runtime/src/commonMain/kotlin/app/cash/sqldelight/logs/LogSqliteDriver.kt
+++ b/runtime/src/commonMain/kotlin/app/cash/sqldelight/logs/LogSqliteDriver.kt
@@ -34,24 +34,24 @@ class LogSqliteDriver(
   override fun execute(
     identifier: Int?,
     sql: String,
-    parameters: Int,
+    parameterIndices: List<Int>,
     binders: (SqlPreparedStatement.() -> Unit)?,
   ): QueryResult<Long> {
     logger("EXECUTE\n $sql")
     logParameters(binders)
-    return sqlDriver.execute(identifier, sql, parameters, binders)
+    return sqlDriver.execute(identifier, sql, parameterIndices, binders)
   }
 
   override fun <R> executeQuery(
     identifier: Int?,
     sql: String,
     mapper: (SqlCursor) -> R,
-    parameters: Int,
+    parameterIndices: List<Int>,
     binders: (SqlPreparedStatement.() -> Unit)?,
   ): QueryResult<R> {
     logger("QUERY\n $sql")
     logParameters(binders)
-    return sqlDriver.executeQuery(identifier, sql, mapper, parameters, binders)
+    return sqlDriver.executeQuery(identifier, sql, mapper, parameterIndices, binders)
   }
 
   override fun newTransaction(): QueryResult<Transacter.Transaction> {

--- a/runtime/src/commonTest/kotlin/com/squareup/sqldelight/logs/LogSqliteDriverTest.kt
+++ b/runtime/src/commonTest/kotlin/com/squareup/sqldelight/logs/LogSqliteDriverTest.kt
@@ -34,7 +34,7 @@ class LogSqliteDriverTest {
   @Test
   fun insertLogsAreCorrect() {
     val insert = { binders: SqlPreparedStatement.() -> Unit ->
-      driver.execute(2, "INSERT INTO test VALUES (?, ?);", 2, binders)
+      driver.execute(2, "INSERT INTO test VALUES (?, ?);", listOf(25, 28), binders)
     }
 
     insert {
@@ -52,7 +52,7 @@ class LogSqliteDriverTest {
   @Test
   fun queryLogsAreCorrect() {
     val query = {
-      driver.executeQuery(3, "SELECT * FROM test", {}, 0)
+      driver.executeQuery(3, "SELECT * FROM test", {}, emptyList())
     }
 
     query()
@@ -66,7 +66,7 @@ class LogSqliteDriverTest {
     transacter.transaction { rollback() }
     transacter.transaction {
       val insert = { binders: SqlPreparedStatement.() -> Unit ->
-        driver.execute(2, "INSERT INTO test VALUES (?, ?);", 2, binders)
+        driver.execute(2, "INSERT INTO test VALUES (?, ?);", listOf(25, 28), binders)
       }
 
       insert {
@@ -91,7 +91,7 @@ class FakeSqlDriver : SqlDriver {
     identifier: Int?,
     sql: String,
     mapper: (SqlCursor) -> R,
-    parameters: Int,
+    parameterIndices: List<Int>,
     binders: (SqlPreparedStatement.() -> Unit)?,
   ): QueryResult<R> {
     return QueryResult.Value(mapper(FakeSqlCursor()))
@@ -100,7 +100,7 @@ class FakeSqlDriver : SqlDriver {
   override fun execute(
     identifier: Int?,
     sql: String,
-    parameters: Int,
+    parameterIndices: List<Int>,
     binders: (SqlPreparedStatement.() -> Unit)?,
   ): QueryResult<Long> {
     return QueryResult.Value(0)

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/PlayerQueries.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/PlayerQueries.kt
@@ -165,7 +165,7 @@ public class PlayerQueries(
     driver.execute(-1595716666, """
         |INSERT INTO player
         |VALUES (?, ?, ?, ?)
-        """.trimMargin(), 4) {
+        """.trimMargin(), listOf(27, 30, 33, 36)) {
           bindString(0, name.name)
           bindLong(1, number)
           bindString(2, team?.let { it.name })
@@ -182,7 +182,7 @@ public class PlayerQueries(
         |UPDATE player
         |SET team = ?
         |WHERE number IN $numberIndexes
-        """.trimMargin(), 1 + number.size) {
+        """.trimMargin(), listOf(listOf(25), number.mapIndexed { index, _ ->  44 + 2 * index }).flatten()) {
           bindString(0, team?.let { it.name })
           number.forEachIndexed { index, number_ ->
             bindLong(index + 1, number_)
@@ -194,11 +194,11 @@ public class PlayerQueries(
   }
 
   public fun foreignKeysOn(): Unit {
-    driver.execute(-1596558949, """PRAGMA foreign_keys = 1""", 0)
+    driver.execute(-1596558949, """PRAGMA foreign_keys = 1""", emptyList())
   }
 
   public fun foreignKeysOff(): Unit {
-    driver.execute(2046279987, """PRAGMA foreign_keys = 0""", 0)
+    driver.execute(2046279987, """PRAGMA foreign_keys = 0""", emptyList())
   }
 
   private inner class InsertAndReturnQuery<out T : Any>(
@@ -213,7 +213,7 @@ public class PlayerQueries(
       driver.execute(-452007405, """
           |INSERT INTO player
           |  VALUES (?, ?, ?, ?)
-          """.trimMargin(), 4) {
+          """.trimMargin(), listOf(29, 32, 35, 38)) {
             bindString(0, name.name)
             bindLong(1, number)
             bindString(2, team?.let { it.name })
@@ -223,7 +223,7 @@ public class PlayerQueries(
           |SELECT *
           |  FROM player
           |  WHERE player.rowid = last_insert_rowid()
-          """.trimMargin(), mapper, 0)
+          """.trimMargin(), mapper, emptyList())
     }
 
     public override fun toString(): String = "Player.sq:insertAndReturn"
@@ -246,7 +246,7 @@ public class PlayerQueries(
     |SELECT *
     |FROM player
     |WHERE team ${ if (team == null) "IS" else "=" } ?
-    """.trimMargin(), mapper, 1) {
+    """.trimMargin(), mapper, listOf(33 + if (team == null) 2 else 1)) {
       bindString(0, team?.let { it.name })
     }
 
@@ -271,7 +271,7 @@ public class PlayerQueries(
           |SELECT *
           |FROM player
           |WHERE number IN $numberIndexes
-          """.trimMargin(), mapper, number.size) {
+          """.trimMargin(), mapper, number.mapIndexed { index, _ -> 38 + 2 * index }) {
             number.forEachIndexed { index, number_ ->
               bindLong(index, number_)
             }

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/TeamQueries.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/TeamQueries.kt
@@ -89,7 +89,7 @@ public class TeamQueries(
     |SELECT name, captain
     |FROM team
     |WHERE coach = ?
-    """.trimMargin(), mapper, 1) {
+    """.trimMargin(), mapper, listOf(45)) {
       bindString(0, coach)
     }
 
@@ -113,7 +113,7 @@ public class TeamQueries(
     |SELECT *
     |FROM team
     |WHERE inner_type ${ if (inner_type == null) "IS" else "=" } ?
-    """.trimMargin(), mapper, 1) {
+    """.trimMargin(), mapper, listOf(37 + if (inner_type == null) 2 else 1)) {
       bindString(0, inner_type?.let { teamAdapter.inner_typeAdapter.encode(it) })
     }
 

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/testmodule/TestDatabaseImpl.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/testmodule/TestDatabaseImpl.kt
@@ -39,7 +39,7 @@ private class TestDatabaseImpl(
       get() = 1
 
     public override fun create(driver: SqlDriver): QueryResult<Unit> {
-      driver.execute(null, "CREATE TABLE `group` (`index` INTEGER PRIMARY KEY NOT NULL)", 0)
+      driver.execute(null, "CREATE TABLE `group` (`index` INTEGER PRIMARY KEY NOT NULL)", emptyList())
       driver.execute(null, """
           |CREATE TABLE player (
           |  name TEXT NOT NULL,
@@ -48,7 +48,7 @@ private class TestDatabaseImpl(
           |  shoots TEXT NOT NULL,
           |  PRIMARY KEY (team, number)
           |)
-          """.trimMargin(), 0)
+          """.trimMargin(), emptyList())
       driver.execute(null, """
           |CREATE TABLE team (
           |  name TEXT PRIMARY KEY NOT NULL,
@@ -56,18 +56,18 @@ private class TestDatabaseImpl(
           |  inner_type TEXT,
           |  coach TEXT NOT NULL
           |)
-          """.trimMargin(), 0)
-      driver.execute(null, "INSERT INTO `group` VALUES (1), (2), (3)", 0)
+          """.trimMargin(), emptyList())
+      driver.execute(null, "INSERT INTO `group` VALUES (1), (2), (3)", emptyList())
       driver.execute(null, """
           |INSERT INTO player
           |VALUES ('Ryan Getzlaf', 15, 'Anaheim Ducks', 'RIGHT'),
           |       ('Erik Karlsson', 65, 'Ottawa Senators', 'RIGHT')
-          """.trimMargin(), 0)
+          """.trimMargin(), emptyList())
       driver.execute(null, """
           |INSERT INTO team
           |VALUES ('Anaheim Ducks', 15, NULL, 'Randy Carlyle'),
           |       ('Ottawa Senators', 65, 'ONE', 'Guy Boucher')
-          """.trimMargin(), 0)
+          """.trimMargin(), emptyList())
       return QueryResult.Unit
     }
 

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/DatabaseGenerator.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/DatabaseGenerator.kt
@@ -197,7 +197,7 @@ internal class DatabaseGenerator(
       sourceFolders.flatMap { it.queryFiles() }
         .sortedBy { it.name }
         .forInitializationStatements(dialect.allowsReferenceCycles) { sqlText ->
-          val statement = if (generateAsync) "$DRIVER_NAME.execute(null, %L, 0).await()" else "$DRIVER_NAME.execute(null, %L, 0)"
+          val statement = if (generateAsync) "$DRIVER_NAME.execute(null, %L, emptyList()).await()" else "$DRIVER_NAME.execute(null, %L, emptyList())"
           createFunction.addStatement(statement, sqlText.toCodeLiteral())
         }
     } else {
@@ -208,7 +208,7 @@ internal class DatabaseGenerator(
       orderedMigrations.flatMap { it.sqlStatements() }
         .filter { it.isSchema() }
         .forEach {
-          val statement = if (generateAsync) "$DRIVER_NAME.execute(null, %L, 0).await()" else "$DRIVER_NAME.execute(null, %L, 0)"
+          val statement = if (generateAsync) "$DRIVER_NAME.execute(null, %L, emptyList()).await()" else "$DRIVER_NAME.execute(null, %L, emptyList())"
           createFunction.addStatement(statement, it.rawSqlText().toCodeLiteral())
         }
     }
@@ -230,7 +230,7 @@ internal class DatabaseGenerator(
         )
         migrationFile.sqlStatements().forEach {
           migrateFunction.addStatement(
-            if (generateAsync) "$DRIVER_NAME.execute(null, %S, 0).await()" else "$DRIVER_NAME.execute(null, %S, 0)",
+            if (generateAsync) "$DRIVER_NAME.execute(null, %S, emptyList()).await()" else "$DRIVER_NAME.execute(null, %S, emptyList())",
             it.rawSqlText(),
           )
         }

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/QueriesTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/QueriesTypeTest.kt
@@ -89,13 +89,13 @@ class QueriesTypeTest {
       |          |  id INTEGER PRIMARY KEY,
       |          |  value TEXT
       |          |)
-      |          ""${'"'}.trimMargin(), 0)
+      |          ""${'"'}.trimMargin(), emptyList())
       |      driver.execute(null, ""${'"'}
       |          |CREATE TABLE other (
       |          |  id INTEGER PRIMARY KEY,
       |          |  value TEXT
       |          |)
-      |          ""${'"'}.trimMargin(), 0)
+      |          ""${'"'}.trimMargin(), emptyList())
       |      return QueryResult.Unit
       |    }
       |
@@ -175,7 +175,7 @@ class QueriesTypeTest {
       |    driver.execute(${insert.id}, ""${'"'}
       |        |INSERT INTO data
       |        |VALUES (?, ?)
-      |        ""${'"'}.trimMargin(), 2) {
+      |        ""${'"'}.trimMargin(), listOf(25, 28)) {
       |          bindLong(0, id)
       |          bindString(1, value_?.let { data_Adapter.value_Adapter.encode(it) })
       |        }
@@ -201,7 +201,7 @@ class QueriesTypeTest {
       |    |SELECT *
       |    |FROM data
       |    |WHERE id = ?
-      |    ""${'"'}.trimMargin(), mapper, 1) {
+      |    ""${'"'}.trimMargin(), mapper, listOf(30)) {
       |      bindLong(0, id)
       |    }
       |
@@ -273,7 +273,7 @@ class QueriesTypeTest {
       |          |  id INTEGER PRIMARY KEY,
       |          |  value TEXT
       |          |)
-      |          ""${'"'}.trimMargin(), 0)
+      |          ""${'"'}.trimMargin(), emptyList())
       |      return QueryResult.Unit
       |    }
       |
@@ -306,7 +306,7 @@ class QueriesTypeTest {
       |    driver.execute(${insert.id}, ""${'"'}
       |        |INSERT INTO data
       |        |VALUES (?, ?)
-      |        ""${'"'}.trimMargin(), 2) {
+      |        ""${'"'}.trimMargin(), listOf(25, 28)) {
       |          bindLong(0, data_.id)
       |          bindString(1, data_.value_?.let { data_Adapter.value_Adapter.encode(it) })
       |        }
@@ -368,7 +368,7 @@ class QueriesTypeTest {
       |          |  id TEXT PRIMARY KEY,
       |          |  value INTEGER NOT NULL
       |          |)
-      |          ""${'"'}.trimMargin(), 0)
+      |          ""${'"'}.trimMargin(), emptyList())
       |      return QueryResult.Unit
       |    }
       |
@@ -448,7 +448,7 @@ class QueriesTypeTest {
       |          |  id,
       |          |  value
       |          |)
-      |          ""${'"'}.trimMargin(), 0)
+      |          ""${'"'}.trimMargin(), emptyList())
       |      return QueryResult.Unit
       |    }
       |
@@ -503,7 +503,7 @@ class QueriesTypeTest {
       |    driver.execute(${insert.id}, ""${'"'}
       |        |INSERT INTO data
       |        |VALUES (?, ?)
-      |        ""${'"'}.trimMargin(), 2) {
+      |        ""${'"'}.trimMargin(), listOf(25, 28)) {
       |          bindLong(0, id)
       |          bindString(1, value_?.let { data_Adapter.value_Adapter.encode(it) })
       |        }
@@ -529,7 +529,7 @@ class QueriesTypeTest {
       |    |SELECT *
       |    |FROM data
       |    |WHERE id = ?
-      |    ""${'"'}.trimMargin(), mapper, 1) {
+      |    ""${'"'}.trimMargin(), mapper, listOf(30)) {
       |      bindLong(0, id)
       |    }
       |
@@ -603,7 +603,7 @@ class QueriesTypeTest {
       |          |  id INTEGER PRIMARY KEY,
       |          |  value TEXT
       |          |)
-      |          ""${'"'}.trimMargin(), 0)
+      |          ""${'"'}.trimMargin(), emptyList())
       |      return QueryResult.Unit
       |    }
       |
@@ -657,7 +657,7 @@ class QueriesTypeTest {
       |    driver.execute(${insert.id}, ""${'"'}
       |        |INSERT INTO search
       |        |VALUES (?, ?)
-      |        ""${'"'}.trimMargin(), 2) {
+      |        ""${'"'}.trimMargin(), listOf(27, 30)) {
       |          bindLong(0, id)
       |          bindString(1, value_)
       |        }
@@ -683,7 +683,7 @@ class QueriesTypeTest {
       |    |SELECT id, offsets(search)
       |    |FROM search
       |    |WHERE search MATCH ?
-      |    ""${'"'}.trimMargin(), mapper, 1) {
+      |    ""${'"'}.trimMargin(), mapper, listOf(58)) {
       |      bindString(0, search)
       |    }
       |

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/QueryWrapperTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/QueryWrapperTest.kt
@@ -62,11 +62,11 @@ class QueryWrapperTest {
       |          |  _id INTEGER NOT NULL PRIMARY KEY,
       |          |  value TEXT
       |          |)
-      |          ""${'"'}.trimMargin(), 0)
+      |          ""${'"'}.trimMargin(), emptyList())
       |      driver.execute(null, ""${'"'}
       |          |INSERT INTO test_table
       |          |VALUES (1, 'test')
-      |          ""${'"'}.trimMargin(), 0)
+      |          ""${'"'}.trimMargin(), emptyList())
       |      return QueryResult.Unit
       |    }
       |
@@ -151,13 +151,13 @@ class QueryWrapperTest {
         |          |  _id INTEGER NOT NULL PRIMARY KEY,
         |          |  value TEXT
         |          |)
-        |          ""${'"'}.trimMargin(), 0)
+        |          ""${'"'}.trimMargin(), emptyList())
         |      driver.execute(null, ""${'"'}
         |          |CREATE TABLE test_table2(
         |          |  _id INTEGER NOT NULL PRIMARY KEY,
         |          |  value TEXT
         |          |)
-        |          ""${'"'}.trimMargin(), 0)
+        |          ""${'"'}.trimMargin(), emptyList())
         |      return QueryResult.Unit
         |    }
         |
@@ -224,12 +224,12 @@ class QueryWrapperTest {
         |          |CREATE TABLE parent(
         |          |  id INTEGER PRIMARY KEY
         |          |)
-        |          ""${'"'}.trimMargin(), 0)
+        |          ""${'"'}.trimMargin(), emptyList())
         |      driver.execute(null, ""${'"'}
         |          |CREATE TABLE child(
         |          |  parent_id INTEGER REFERENCES parent(id)
         |          |)
-        |          ""${'"'}.trimMargin(), 0)
+        |          ""${'"'}.trimMargin(), emptyList())
         |      return QueryResult.Unit
         |    }
         |
@@ -317,13 +317,13 @@ class QueryWrapperTest {
         |          |  id INTEGER PRIMARY KEY,
         |          |  child_id INTEGER REFERENCES child(id)
         |          |)
-        |          ""${'"'}.trimMargin(), 0)
+        |          ""${'"'}.trimMargin(), emptyList())
         |      driver.execute(null, ""${'"'}
         |          |CREATE TABLE child(
         |          |  id INTEGER PRIMARY KEY,
         |          |  parent_id INTEGER REFERENCES parent(id)
         |          |)
-        |          ""${'"'}.trimMargin(), 0)
+        |          ""${'"'}.trimMargin(), emptyList())
         |      return QueryResult.Unit
         |    }
         |
@@ -400,25 +400,25 @@ class QueryWrapperTest {
         |          |CREATE TABLE parent(
         |          |  id INTEGER PRIMARY KEY
         |          |)
-        |          ""${'"'}.trimMargin(), 0)
+        |          ""${'"'}.trimMargin(), emptyList())
         |      driver.execute(null, ""${'"'}
         |          |CREATE TABLE child1(
         |          |  id INTEGER PRIMARY KEY,
         |          |  parent_id INTEGER REFERENCES parent(id)
         |          |)
-        |          ""${'"'}.trimMargin(), 0)
+        |          ""${'"'}.trimMargin(), emptyList())
         |      driver.execute(null, ""${'"'}
         |          |CREATE TABLE child2(
         |          |  id INTEGER PRIMARY KEY,
         |          |  parent_id INTEGER REFERENCES parent(id)
         |          |)
-        |          ""${'"'}.trimMargin(), 0)
+        |          ""${'"'}.trimMargin(), emptyList())
         |      driver.execute(null, ""${'"'}
         |          |CREATE TABLE grandchild(
         |          |  parent1_id INTEGER REFERENCES child1(id),
         |          |  parent2_id INTEGER REFERENCES child2(id)
         |          |)
-        |          ""${'"'}.trimMargin(), 0)
+        |          ""${'"'}.trimMargin(), emptyList())
         |      return QueryResult.Unit
         |    }
         |
@@ -481,12 +481,12 @@ class QueryWrapperTest {
         |      driver.execute(null, ""${'"'}
         |          |CREATE VIEW A AS
         |          |SELECT 1
-        |          ""${'"'}.trimMargin(), 0)
+        |          ""${'"'}.trimMargin(), emptyList())
         |      driver.execute(null, ""${'"'}
         |          |CREATE VIEW B AS
         |          |SELECT *
         |          |FROM A
-        |          ""${'"'}.trimMargin(), 0)
+        |          ""${'"'}.trimMargin(), emptyList())
         |      return QueryResult.Unit
         |    }
         |
@@ -555,15 +555,15 @@ class QueryWrapperTest {
         |          |CREATE TABLE test (
         |          |  value TEXT
         |          |)
-        |          ""${'"'}.trimMargin(), 0)
+        |          ""${'"'}.trimMargin(), emptyList())
         |      driver.execute(null, ""${'"'}
         |          |CREATE TRIGGER A
         |          |BEFORE DELETE ON test
         |          |BEGIN
         |          |INSERT INTO test DEFAULT VALUES;
         |          |END
-        |          ""${'"'}.trimMargin(), 0)
-        |      driver.execute(null, "CREATE INDEX B ON test(value)", 0)
+        |          ""${'"'}.trimMargin(), emptyList())
+        |      driver.execute(null, "CREATE INDEX B ON test(value)", emptyList())
         |      return QueryResult.Unit
         |    }
         |
@@ -651,7 +651,7 @@ class QueryWrapperTest {
         |          |  value2 TEXT,
         |          |  value3 REAL
         |          |)
-        |          ""${'"'}.trimMargin(), 0)
+        |          ""${'"'}.trimMargin(), emptyList())
         |      return QueryResult.Unit
         |    }
         |
@@ -665,13 +665,13 @@ class QueryWrapperTest {
         |            |CREATE TABLE test (
         |            |  value1 TEXT
         |            |)
-        |            ""${'"'}.trimMargin(), 0)
+        |            ""${'"'}.trimMargin(), emptyList())
         |      }
         |      if (oldVersion <= 1 && newVersion > 1) {
-        |        driver.execute(null, "ALTER TABLE test ADD COLUMN value2 TEXT", 0)
+        |        driver.execute(null, "ALTER TABLE test ADD COLUMN value2 TEXT", emptyList())
         |      }
         |      if (oldVersion <= 2 && newVersion > 2) {
-        |        driver.execute(null, "ALTER TABLE test ADD COLUMN value3 REAL", 0)
+        |        driver.execute(null, "ALTER TABLE test ADD COLUMN value3 REAL", emptyList())
         |      }
         |      return QueryResult.Unit
         |    }
@@ -748,7 +748,7 @@ class QueryWrapperTest {
         |          |  special TEXT,
         |          |  url TEXT NOT NULL
         |          |)
-        |          ""${'"'}.trimMargin(), 0)
+        |          ""${'"'}.trimMargin(), emptyList())
         |      driver.execute(null, buildString(75360) {
         |          append(""${'"'}
         |          |INSERT INTO class_ability_test(id, class_id, name, level_id, special, url)
@@ -766,7 +766,7 @@ class QueryWrapperTest {
         """
         |          |  ('class_01_ability_499', 'class_01', 'aaaaaaaaaaaaaaa', 1, NULL, 'https://stuff.example.com/this/is/a/bunch/of/path/data/class_01_ability_499.png')
         |          ""${'"'}.trimMargin())
-        |          }, 0)
+        |          }, emptyList())
         |      return QueryResult.Unit
         |    }
         |

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/async/AsyncQueriesTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/async/AsyncQueriesTypeTest.kt
@@ -91,13 +91,13 @@ class AsyncQueriesTypeTest {
       |          |  id INTEGER PRIMARY KEY,
       |          |  value TEXT
       |          |)
-      |          ""${'"'}.trimMargin(), 0).await()
+      |          ""${'"'}.trimMargin(), emptyList()).await()
       |      driver.execute(null, ""${'"'}
       |          |CREATE TABLE other (
       |          |  id INTEGER PRIMARY KEY,
       |          |  value TEXT
       |          |)
-      |          ""${'"'}.trimMargin(), 0).await()
+      |          ""${'"'}.trimMargin(), emptyList()).await()
       |    }
       |
       |    public override fun migrate(
@@ -177,7 +177,7 @@ class AsyncQueriesTypeTest {
       |    driver.execute(${insert.id}, ""${'"'}
       |        |INSERT INTO data
       |        |VALUES (?, ?)
-      |        ""${'"'}.trimMargin(), 2) {
+      |        ""${'"'}.trimMargin(), listOf(25, 28)) {
       |          bindLong(0, id)
       |          bindString(1, value_?.let { data_Adapter.value_Adapter.encode(it) })
       |        }.await()
@@ -203,7 +203,7 @@ class AsyncQueriesTypeTest {
       |    |SELECT *
       |    |FROM data
       |    |WHERE id = ?
-      |    ""${'"'}.trimMargin(), mapper, 1) {
+      |    ""${'"'}.trimMargin(), mapper, listOf(30)) {
       |      bindLong(0, id)
       |    }
       |

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/async/AsyncQueryWrapperTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/async/AsyncQueryWrapperTest.kt
@@ -84,7 +84,7 @@ class AsyncQueryWrapperTest {
         |          |  value2 TEXT,
         |          |  value3 REAL
         |          |)
-        |          ""${'"'}.trimMargin(), 0).await()
+        |          ""${'"'}.trimMargin(), emptyList()).await()
         |    }
         |
         |    public override fun migrate(
@@ -97,13 +97,13 @@ class AsyncQueryWrapperTest {
         |            |CREATE TABLE test (
         |            |  value1 TEXT
         |            |)
-        |            ""${'"'}.trimMargin(), 0).await()
+        |            ""${'"'}.trimMargin(), emptyList()).await()
         |      }
         |      if (oldVersion <= 1 && newVersion > 1) {
-        |        driver.execute(null, "ALTER TABLE test ADD COLUMN value2 TEXT", 0).await()
+        |        driver.execute(null, "ALTER TABLE test ADD COLUMN value2 TEXT", emptyList()).await()
         |      }
         |      if (oldVersion <= 2 && newVersion > 2) {
-        |        driver.execute(null, "ALTER TABLE test ADD COLUMN value3 REAL", 0).await()
+        |        driver.execute(null, "ALTER TABLE test ADD COLUMN value3 REAL", emptyList()).await()
         |      }
         |    }
         |  }

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/InterfaceGeneration.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/InterfaceGeneration.kt
@@ -832,7 +832,7 @@ class InterfaceGeneration {
       |    public override fun <R> execute(mapper: (SqlCursor) -> R): QueryResult<R> =
       |        driver.executeQuery(null,
       |        ""${'"'}SELECT * FROM song WHERE album_id ${'$'}{ if (album_id == null) "IS" else "=" } ?""${'"'}, mapper,
-      |        1) {
+      |        listOf(35 + (if (album_id == null) 2 else 1))) {
       |      bindLong(0, album_id)
       |    }
       |
@@ -907,7 +907,7 @@ class InterfaceGeneration {
       |    driver.execute(${result.compiledFile.namedMutators[0].id}, ""${'"'}
       |        |INSERT INTO subscriptionEntity(user_id2)
       |        |VALUES (?)
-      |        ""${'"'}.trimMargin(), 1) {
+      |        ""${'"'}.trimMargin(), listOf(49)) {
       |          check(this is JdbcPreparedStatement)
       |          bindLong(0, user_id2.toLong())
       |        }
@@ -935,7 +935,7 @@ class InterfaceGeneration {
       |    |  VALUES (?)
       |    |  RETURNING user_id AS insert_id
       |    |) SELECT insert_id FROM inserted_ids
-      |    ""${'"'}.trimMargin(), mapper, 1) {
+      |    ""${'"'}.trimMargin(), mapper, listOf(73)) {
       |      check(this is JdbcPreparedStatement)
       |      bindString(0, slack_user_id)
       |    }
@@ -1056,7 +1056,7 @@ class InterfaceGeneration {
       |    |)
       |    |SELECT descendants.id, descendants.parent_id
       |    |FROM descendants
-      |    ""${'"'}.trimMargin(), mapper, 1) {
+      |    ""${'"'}.trimMargin(), mapper, listOf(91)) {
       |      bindLong(0, id)
       |    }
       |

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/JavadocTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/JavadocTest.kt
@@ -283,7 +283,7 @@ class JavadocTest {
       |  driver.execute(${insert.id}, ""${'"'}
       |      |INSERT INTO test(value)
       |      |VALUES (?)
-      |      ""${'"'}.trimMargin(), 1) {
+      |      ""${'"'}.trimMargin(), listOf(32)) {
       |        ${testDialect.binderCheck}bindString(0, value_)
       |      }
       |  notifyQueries(${insert.id}) { emit ->
@@ -323,7 +323,7 @@ class JavadocTest {
       |      |UPDATE test
       |      |SET value = ?
       |      |WHERE _id = ?
-      |      ""${'"'}.trimMargin(), 2) {
+      |      ""${'"'}.trimMargin(), listOf(24, 38)) {
       |        bindString(0, value_)
       |        bindLong(1, _id)
       |      }
@@ -359,7 +359,7 @@ class JavadocTest {
       | * Delete all.
       | */
       |public fun deleteAll(): kotlin.Unit {
-      |  driver.execute(${delete.id}, ""${'"'}DELETE FROM test""${'"'}, 0)
+      |  driver.execute(${delete.id}, ""${'"'}DELETE FROM test""${'"'}, emptyList())
       |  notifyQueries(${delete.id}) { emit ->
       |    emit("test")
       |  }

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/MutatorQueryFunctionTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/MutatorQueryFunctionTest.kt
@@ -42,7 +42,7 @@ class MutatorQueryFunctionTest {
       |  driver.execute(${insert.id}, ""${'"'}
       |      |INSERT INTO data
       |      |VALUES (?)
-      |      ""${'"'}.trimMargin(), 1) {
+      |      ""${'"'}.trimMargin(), listOf(25)) {
       |        ${dialect.binderCheck}bindString(0, customTextValue)
       |      }
       |  notifyQueries(${insert.id}) { emit ->
@@ -78,7 +78,7 @@ class MutatorQueryFunctionTest {
       |  driver.execute(${mutator.id}, ""${'"'}
       |      |INSERT INTO data
       |      |VALUES (?, ?)
-      |      ""${'"'}.trimMargin(), 2) {
+      |      ""${'"'}.trimMargin(), listOf(25, 28)) {
       |        bindLong(0, id)
       |        bindString(1, value_?.let { data_Adapter.value_Adapter.encode(it) })
       |      }
@@ -112,7 +112,7 @@ class MutatorQueryFunctionTest {
     assertThat(generator.function().toString()).isEqualTo(
       """
       |public fun deleteData(): kotlin.Unit {
-      |  driver.execute(${mutator.id}, ""${'"'}DELETE FROM data""${'"'}, 0)
+      |  driver.execute(${mutator.id}, ""${'"'}DELETE FROM data""${'"'}, emptyList())
       |  notifyQueries(${mutator.id}) { emit ->
       |    emit("data")
       |  }
@@ -146,7 +146,7 @@ class MutatorQueryFunctionTest {
       |  driver.execute(${mutator.id}, ""${'"'}
       |      |INSERT INTO data
       |      |VALUES (?, ?)
-      |      ""${'"'}.trimMargin(), 2) {
+      |      ""${'"'}.trimMargin(), listOf(25, 28)) {
       |        bindLong(0, data_.id)
       |        bindString(1, data_.value_?.let { data_Adapter.value_Adapter.encode(it) })
       |      }
@@ -185,7 +185,7 @@ class MutatorQueryFunctionTest {
       |      |UPDATE data
       |      |SET value = ?
       |      |WHERE value ${"$"}{ if (oldValue == null) "IS" else "=" } ?
-      |      ""${'"'}.trimMargin(), 2) {
+      |      ""${'"'}.trimMargin(), listOf(24, 39 + (if (oldValue == null) 2 else 1))) {
       |        bindString(0, newValue?.let { data_Adapter.value_Adapter.encode(it) })
       |        bindString(1, oldValue?.let { data_Adapter.value_Adapter.encode(it) })
       |      }
@@ -223,7 +223,7 @@ class MutatorQueryFunctionTest {
       |      |UPDATE data
       |      |SET value = ?
       |      |WHERE value = ?
-      |      ""${'"'}.trimMargin(), 2) {
+      |      ""${'"'}.trimMargin(), listOf(24, 40)) {
       |        bindString(0, newValue?.let { data_Adapter.value_Adapter.encode(it) })
       |        bindString(1, oldValue?.let { data_Adapter.value_Adapter.encode(it) })
       |      }
@@ -260,7 +260,7 @@ class MutatorQueryFunctionTest {
       |  driver.execute(${mutator.id}, ""${'"'}
       |      |INSERT INTO data
       |      |VALUES (?, ?)
-      |      ""${'"'}.trimMargin(), 2) {
+      |      ""${'"'}.trimMargin(), listOf(25, 28)) {
       |        bindLong(0, data_.id)
       |        bindString(1, data_.value_?.let { data_Adapter.value_Adapter.encode(it) })
       |      }
@@ -297,7 +297,7 @@ class MutatorQueryFunctionTest {
       |  driver.execute(${mutator.id}, ""${'"'}
       |      |INSERT INTO data (id)
       |      |VALUES (?)
-      |      ""${'"'}.trimMargin(), 1) {
+      |      ""${'"'}.trimMargin(), listOf(30)) {
       |        bindLong(0, data_.id)
       |      }
       |  notifyQueries(1642410240) { emit ->
@@ -333,7 +333,7 @@ class MutatorQueryFunctionTest {
       |  driver.execute(${mutator.id}, ""${'"'}
       |      |INSERT INTO data (id)
       |      |VALUES (?)
-      |      ""${'"'}.trimMargin(), 1) {
+      |      ""${'"'}.trimMargin(), listOf(30)) {
       |        bindLong(0, id)
       |      }
       |  notifyQueries(1642410240) { emit ->
@@ -372,7 +372,7 @@ class MutatorQueryFunctionTest {
       |      |UPDATE data
       |      |SET value = ?
       |      |WHERE id IN ${"$"}idIndexes
-      |      ""${'"'}.trimMargin(), 1 + id.size) {
+      |      ""${'"'}.trimMargin(), listOf(listOf(24), id.mapIndexed { index, _ -> 38 + 2*index + 1 }).flatten()) {
       |        bindString(0, value_?.let { data_Adapter.value_Adapter.encode(it) })
       |        id.forEachIndexed { index, id_ ->
       |          bindLong(index + 1, id_)
@@ -416,7 +416,7 @@ class MutatorQueryFunctionTest {
       |      |  SELECT CASE WHEN ? IS NULL THEN some_column ELSE ? END
       |      |  FROM some_table
       |      |)
-      |      ""${'"'}.trimMargin(), 2) {
+      |      ""${'"'}.trimMargin(), listOf(57, 89)) {
       |        bindLong(0, some_column)
       |        bindLong(1, some_column)
       |      }
@@ -468,7 +468,7 @@ class MutatorQueryFunctionTest {
       |      |    b = ?,
       |      |    c = ?,
       |      |    d = ?
-      |      ""${'"'}.trimMargin(), 4) {
+      |      ""${'"'}.trimMargin(), listOf(36, 47, 58, 69)) {
       |        bindString(0, a)
       |        bindString(1, b)
       |        bindBytes(2, c?.let { paymentHistoryConfigAdapter.cAdapter.encode(it) })
@@ -516,7 +516,7 @@ class MutatorQueryFunctionTest {
       |  driver.execute(${mutator.id}, ""${'"'}
       |      |UPDATE paymentHistoryConfig
       |      |SET (a, b, c, d) = (?, ?, ?, ?)
-      |      ""${'"'}.trimMargin(), 4) {
+      |      ""${'"'}.trimMargin(), listOf(48, 51, 54, 57)) {
       |        bindString(0, a)
       |        bindString(1, b)
       |        bindBytes(2, c?.let { paymentHistoryConfigAdapter.cAdapter.encode(it) })
@@ -555,7 +555,7 @@ class MutatorQueryFunctionTest {
       |  driver.execute(${insert.id}, ""${'"'}
       |      |INSERT INTO nullableTypes
       |      |VALUES (?, ?)
-      |      ""${'"'}.trimMargin(), 2) {
+      |      ""${'"'}.trimMargin(), listOf(34, 37)) {
       |        bindString(0, nullableTypes.val1?.let { nullableTypesAdapter.val1Adapter.encode(it) })
       |        bindString(1, nullableTypes.val2)
       |      }
@@ -599,7 +599,7 @@ class MutatorQueryFunctionTest {
       |      |INSERT OR REPLACE
       |      |INTO category (rowid, id, name, description)
       |      |VALUES (COALESCE((SELECT rowid FROM category c2 WHERE id = ?), NULL), ?, ?, ?)
-      |      ""${'"'}.trimMargin(), 4) {
+      |      ""${'"'}.trimMargin(), listOf(122, 133, 136, 139)) {
       |        bindString(0, id)
       |        bindString(1, id)
       |        bindString(2, name)
@@ -638,7 +638,7 @@ class MutatorQueryFunctionTest {
     assertThat(generator.function().toString()).isEqualTo(
       """
     |public fun upsert(id: kotlin.String, `data`: java.math.BigDecimal?): kotlin.Unit {
-    |  driver.execute(${mutator.id}, ""${'"'}INSERT INTO example(id, data) VALUES(?, ?) ON CONFLICT(id) DO UPDATE SET data = ?""${'"'}, 3) {
+    |  driver.execute(${mutator.id}, ""${'"'}INSERT INTO example(id, data) VALUES(?, ?) ON CONFLICT(id) DO UPDATE SET data = ?""${'"'}, listOf(37, 40, 80)) {
     |        val data__ = data?.let { exampleAdapter.data_Adapter.encode(it) }
     |        bindString(0, id)
     |        bindString(1, data__)
@@ -678,7 +678,7 @@ class MutatorQueryFunctionTest {
       |  driver.execute(${mutator.id}, ""${'"'}
       |      |INSERT INTO annotation
       |      |VALUES (?, ?)
-      |      ""${'"'}.trimMargin(), 2) {
+      |      ""${'"'}.trimMargin(), listOf(31, 34)) {
       |        bindLong(0, annotation_.id)
       |        bindString(1, annotation_.name)
       |      }

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/MutatorQueryTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/MutatorQueryTypeTest.kt
@@ -41,7 +41,7 @@ class MutatorQueryTypeTest {
       |  driver.execute(${mutator.id}, ""${'"'}
       |      |INSERT INTO data
       |      |VALUES (?, ?)
-      |      ""${'"'}.trimMargin(), 2) {
+      |      ""${'"'}.trimMargin(), listOf(25, 28)) {
       |        bindLong(0, id?.let { data_Adapter.idAdapter.encode(it) })
       |        bindString(1, value_?.let { data_Adapter.value_Adapter.encode(it) })
       |      }
@@ -80,7 +80,7 @@ class MutatorQueryTypeTest {
     |  driver.execute(${mutator.id}, ""${'"'}
     |      |INSERT INTO data
     |      |VALUES (?, ?)
-    |      ""${'"'}.trimMargin(), 2) {
+    |      ""${'"'}.trimMargin(), listOf(25, 28)) {
     |        bindLong(0, data_Adapter.idAdapter.encode(data_.id))
     |        bindString(1, data_.value_?.let { data_Adapter.value_Adapter.encode(it) })
     |      }
@@ -134,7 +134,7 @@ class MutatorQueryTypeTest {
       |      |    link = ?
       |      |WHERE packageName = ?
       |      |  AND className = ?
-      |      ""${'"'}.trimMargin(), 4) {
+      |      ""${'"'}.trimMargin(), listOf(29, 43, 65, 85)) {
       |        bindBoolean(0, deprecated)
       |        bindString(1, link)
       |        bindString(2, packageName)
@@ -179,7 +179,7 @@ class MutatorQueryTypeTest {
       |  driver.execute(${mutator.id}, ""${'"'}
       |      |INSERT INTO data
       |      |VALUES (?, ?)
-      |      ""${'"'}.trimMargin(), 2) {
+      |      ""${'"'}.trimMargin(), listOf(25, 28)) {
       |        bindLong(0, id?.let { data_Adapter.idAdapter.encode(it) })
       |        bindString(1, value_?.let { data_Adapter.value_Adapter.encode(it) })
       |      }
@@ -228,7 +228,7 @@ class MutatorQueryTypeTest {
       |  driver.execute(${mutator.id}, ""${'"'}
       |      |INSERT INTO data
       |      |VALUES (?, ?)
-      |      ""${'"'}.trimMargin(), 2) {
+      |      ""${'"'}.trimMargin(), listOf(25, 28)) {
       |        bindLong(0, id?.let { data_Adapter.idAdapter.encode(it) })
       |        bindString(1, value_?.let { data_Adapter.value_Adapter.encode(it) })
       |      }
@@ -286,7 +286,7 @@ class MutatorQueryTypeTest {
       |  driver.execute(${mutator.id}, ""${'"'}
       |      |INSERT INTO data
       |      |VALUES (?, ?)
-      |      ""${'"'}.trimMargin(), 2) {
+      |      ""${'"'}.trimMargin(), listOf(25, 28)) {
       |        bindLong(0, id?.let { data_Adapter.idAdapter.encode(it) })
       |        bindString(1, value_?.let { data_Adapter.value_Adapter.encode(it) })
       |      }
@@ -324,7 +324,7 @@ class MutatorQueryTypeTest {
       |  driver.execute(${mutator.id}, ""${'"'}
       |      |INSERT INTO data
       |      |VALUES (?, ?)
-      |      ""${'"'}.trimMargin(), 2) {
+      |      ""${'"'}.trimMargin(), listOf(25, 28)) {
       |        bindLong(0, id?.let { data_Adapter.idAdapter.encode(it) })
       |        bindString(1, value_?.let { data_Adapter.value_Adapter.encode(it) })
       |      }
@@ -379,7 +379,7 @@ class MutatorQueryTypeTest {
       |      |  INNER JOIN data AS data2
       |      |  ON data.id = data2.id
       |      |)
-      |      ""${'"'}.trimMargin(), 0)
+      |      ""${'"'}.trimMargin(), emptyList())
       |  notifyQueries(${mutator.id}) { emit ->
       |    emit("data")
       |  }
@@ -414,7 +414,7 @@ class MutatorQueryTypeTest {
       |  driver.execute(${mutator.id}, ""${'"'}
       |      |INSERT INTO data (value)
       |      |VALUES (?)
-      |      ""${'"'}.trimMargin(), 1) {
+      |      ""${'"'}.trimMargin(), listOf(33)) {
       |        bindBytes(0, value_)
       |      }
       |  notifyQueries(208179736) { emit ->
@@ -451,7 +451,7 @@ class MutatorQueryTypeTest {
       |  driver.execute(${mutator.id}, ""${'"'}
       |      |INSERT INTO data (value)
       |      |VALUES (?)
-      |      ""${'"'}.trimMargin(), 1) {
+      |      ""${'"'}.trimMargin(), listOf(33)) {
       |        bindDouble(0, value_)
       |      }
       |  notifyQueries(${mutator.id}) { emit ->
@@ -530,7 +530,7 @@ class MutatorQueryTypeTest {
       |  driver.execute(${mutator.id}, ""${'"'}
       |      |INSERT INTO data
       |      |VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      |      ""${'"'}.trimMargin(), 20) {
+      |      ""${'"'}.trimMargin(), listOf(25, 28, 31, 34, 37, 40, 43, 46, 49, 52, 55, 58, 61, 64, 67, 70, 73, 76, 79, 82)) {
       |        check(this is ${dialect.dialect.runtimeTypes.preparedStatementType})
       |        bindLong(0, if (boolean0) 1L else 0L)
       |        bindLong(1, boolean1?.let { if (it) 1L else 0L })
@@ -629,7 +629,7 @@ class MutatorQueryTypeTest {
       |  driver.execute(${mutator.id}, ""${'"'}
       |      |INSERT INTO data
       |      |VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      |      ""${'"'}.trimMargin(), 20) {
+      |      ""${'"'}.trimMargin(), listOf(25, 28, 31, 34, 37, 40, 43, 46, 49, 52, 55, 58, 61, 64, 67, 70, 73, 76, 79, 82)) {
       |        check(this is ${dialect.dialect.runtimeTypes.preparedStatementType})
       |        bindLong(0, if (boolean0) 1L else 0L)
       |        bindLong(1, boolean1?.let { if (it) 1L else 0L })
@@ -712,7 +712,7 @@ class MutatorQueryTypeTest {
       |  driver.execute(${mutator.id}, ""${'"'}
       |      |INSERT INTO data
       |      |VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      |      ""${'"'}.trimMargin(), 12) {
+      |      ""${'"'}.trimMargin(), listOf(25, 28, 31, 34, 37, 40, 43, 46, 49, 52, 55, 58)) {
       |        check(this is ${dialect.dialect.runtimeTypes.preparedStatementType})
       |        bindLong(0, smallint0.toLong())
       |        bindLong(1, smallint1?.let { it.toLong() })
@@ -778,7 +778,7 @@ class MutatorQueryTypeTest {
       |  deprecated: kotlin.Boolean,
       |  link: kotlin.String,
       |): kotlin.Unit {
-      |  driver.execute(${mutator.id}, ""${'"'}INSERT OR FAIL INTO item(packageName, className, deprecated, link) VALUES (?, ?, ?, ?)""${'"'}, 4) {
+      |  driver.execute(${mutator.id}, ""${'"'}INSERT OR FAIL INTO item(packageName, className, deprecated, link) VALUES (?, ?, ?, ?)""${'"'}, listOf(75, 78, 81, 84)) {
       |        bindString(0, packageName)
       |        bindString(1, className)
       |        bindBoolean(2, deprecated)
@@ -829,7 +829,7 @@ class MutatorQueryTypeTest {
     assertThat(generator.function().toString()).isEqualTo(
       """
     |public fun insertItem(content: kotlin.String?): kotlin.Unit {
-    |  driver.execute(${mutator.id}, ""${'"'}INSERT OR FAIL INTO item_index(content) VALUES (?)""${'"'}, 1) {
+    |  driver.execute(${mutator.id}, ""${'"'}INSERT OR FAIL INTO item_index(content) VALUES (?)""${'"'}, listOf(48)) {
     |        bindString(0, content)
     |      }
     |  notifyQueries(${mutator.id}) { emit ->
@@ -883,7 +883,7 @@ class MutatorQueryTypeTest {
     assertThat(generator.function().toString()).isEqualTo(
       """
     |public fun updateFoobarSelected(selected: kotlin.Boolean, id: kotlin.Long): kotlin.Unit {
-    |  driver.execute(1531606598, ""${'"'}UPDATE OR IGNORE foobar SET selected = ? WHERE id = ?""${'"'}, 2) {
+    |  driver.execute(1531606598, ""${'"'}UPDATE OR IGNORE foobar SET selected = ? WHERE id = ?""${'"'}, listOf(39, 52)) {
     |        bindBoolean(0, selected)
     |        bindLong(1, id)
     |      }
@@ -922,12 +922,12 @@ class MutatorQueryTypeTest {
       |public fun delete(ids: kotlin.collections.Collection<Int>): kotlin.Unit {
       |  transaction {
       |    val idsIndexes = createArguments(count = ids.size)
-      |    driver.execute(null, ""${'"'}DELETE FROM data WHERE id IN ${'$'}idsIndexes""${'"'}, ids.size) {
+      |    driver.execute(null, ""${'"'}DELETE FROM data WHERE id IN ${'$'}idsIndexes""${'"'}, ids.mapIndexed { index, _ -> 29 + 2*index + 1 }) {
       |          ids.forEachIndexed { index, ids_ ->
       |            bindLong(index, data_Adapter.idAdapter.encode(ids_))
       |          }
       |        }
-      |    driver.execute(null, ""${'"'}DELETE FROM data WHERE other IN ${'$'}idsIndexes""${'"'}, ids.size) {
+      |    driver.execute(null, ""${'"'}DELETE FROM data WHERE other IN ${'$'}idsIndexes""${'"'}, ids.mapIndexed { index, _ -> 32 + 2*index + 1 }) {
       |          ids.forEachIndexed { index, ids_ ->
       |            bindLong(index, data_Adapter.idAdapter.encode(ids_))
       |          }

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/PgInsertOnConflictTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/PgInsertOnConflictTest.kt
@@ -39,7 +39,7 @@ class PgInsertOnConflictTest {
             |      |INSERT INTO data
             |      |VALUES (?, ?)
             |      |ON CONFLICT (id) DO UPDATE SET col1 = ?
-            |      ""${'"'}.trimMargin(), 3) {
+            |      ""${'"'}.trimMargin(), listOf(25, 28, 69)) {
             |        check(this is app.cash.sqldelight.driver.jdbc.JdbcPreparedStatement)
             |        bindLong(0, id?.let { it.toLong() })
             |        bindString(1, c1)
@@ -89,7 +89,7 @@ class PgInsertOnConflictTest {
             |      |INSERT INTO data
             |      |VALUES (?, ?, ?, ?)
             |      |ON CONFLICT (id) DO UPDATE SET col1 = ?, col2 = ?
-            |      ""${'"'}.trimMargin(), 6) {
+            |      ""${'"'}.trimMargin(), listOf(25, 28, 31, 34, 75, 85)) {
             |        check(this is app.cash.sqldelight.driver.jdbc.JdbcPreparedStatement)
             |        bindLong(0, id?.let { it.toLong() })
             |        bindString(1, c1)
@@ -142,7 +142,7 @@ class PgInsertOnConflictTest {
             |      |INSERT INTO data
             |      |VALUES (?, ?, ?, ?)
             |      |ON CONFLICT (id) DO UPDATE SET col1 = ?, col2 = ?, col3 = ?
-            |      ""${'"'}.trimMargin(), 7) {
+            |      ""${'"'}.trimMargin(), listOf(25, 28, 31, 34, 75, 85, 95)) {
             |        check(this is app.cash.sqldelight.driver.jdbc.JdbcPreparedStatement)
             |        bindLong(0, id?.let { it.toLong() })
             |        bindString(1, c1)

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/SelectQueryFunctionTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/SelectQueryFunctionTest.kt
@@ -310,7 +310,7 @@ class SelectQueryFunctionTest {
       |        |SELECT *
       |        |FROM data
       |        |WHERE id IN ${"$"}goodIndexes AND id NOT IN ${"$"}badIndexes
-      |        ""${'"'}.trimMargin(), mapper, good.size + bad.size) {
+      |        ""${'"'}.trimMargin(), mapper, listOf(good.mapIndexed { index, _ -> 31 + 2*index + 1 }, bad.mapIndexed { index, _ -> 46 + goodIndexes.length + 2*index + 1 }).flatten()) {
       |          good.forEachIndexed { index, good_ ->
       |            bindLong(index, good_)
       |          }
@@ -396,7 +396,7 @@ class SelectQueryFunctionTest {
       |  |SELECT *
       |  |FROM person
       |  |WHERE first_name = ? AND last_name = ?
-      |  ""${'"'}.trimMargin(), mapper, 2) {
+      |  ""${'"'}.trimMargin(), mapper, listOf(40, 58)) {
       |    bindString(0, name)
       |    bindString(1, name)
       |  }

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/SelectQueryTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/SelectQueryTypeTest.kt
@@ -148,7 +148,7 @@ class SelectQueryTypeTest {
       |  |SELECT *
       |  |FROM data
       |  |WHERE id = ?
-      |  ""${'"'}.trimMargin(), mapper, 1) {
+      |  ""${'"'}.trimMargin(), mapper, listOf(30)) {
       |    bindLong(0, id)
       |  }
       |
@@ -177,7 +177,7 @@ class SelectQueryTypeTest {
       |private inner class SelectWithoutFromQuery<out T : kotlin.Any>(
       |  mapper: (app.cash.sqldelight.db.SqlCursor) -> T,
       |) : app.cash.sqldelight.ExecutableQuery<T>(mapper) {
-      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> R): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(${query.id}, ""${'"'}SELECT 42""${'"'}, mapper, 0)
+      |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> R): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(${query.id}, ""${'"'}SELECT 42""${'"'}, mapper, emptyList())
       |
       |  public override fun toString(): kotlin.String = "Test.sq:selectWithoutFrom"
       |}
@@ -226,7 +226,7 @@ class SelectQueryTypeTest {
       |  |FROM data
       |  |WHERE id = ?
       |  |AND value = ?
-      |  ""${'"'}.trimMargin(), mapper, 2) {
+      |  ""${'"'}.trimMargin(), mapper, listOf(30, 44)) {
       |    bindLong(0, id)
       |    bindString(1, value_)
       |  }
@@ -276,7 +276,7 @@ class SelectQueryTypeTest {
       |        |SELECT *
       |        |FROM data
       |        |WHERE id IN ${"$"}idIndexes
-      |        ""${'"'}.trimMargin(), mapper, id.size) {
+      |        ""${'"'}.trimMargin(), mapper, id.mapIndexed { index, _ -> 31 + 2*index + 1 }) {
       |          id.forEachIndexed { index, id_ ->
       |            bindLong(index, id_)
       |          }
@@ -330,7 +330,7 @@ class SelectQueryTypeTest {
       |        |SELECT *
       |        |FROM data
       |        |WHERE id IN ${"$"}idIndexes AND message != ? AND id IN ${"$"}idIndexes
-      |        ""${'"'}.trimMargin(), mapper, 1 + id.size + id.size) {
+      |        ""${'"'}.trimMargin(), mapper, listOf(id.mapIndexed { index, _ -> 31 + 2*index + 1 }, listOf(47 + idIndexes.length), id.mapIndexed { index, _ -> 59 + idIndexes.length + 2*index + 1 }).flatten()) {
       |          id.forEachIndexed { index, id_ ->
       |            bindLong(index, id_)
       |          }
@@ -381,7 +381,7 @@ class SelectQueryTypeTest {
        |    driver.removeListener(listener, arrayOf("socialFeedItem"))
        |  }
        |
-       |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> R): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(null, ""${'"'}SELECT * FROM socialFeedItem WHERE message IS NOT NULL AND userId ${"$"}{ if (userId == null) "IS" else "=" } ? ORDER BY datetime(creation_time) DESC""${'"'}, mapper, 1) {
+       |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> R): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(null, ""${'"'}SELECT * FROM socialFeedItem WHERE message IS NOT NULL AND userId ${"$"}{ if (userId == null) "IS" else "=" } ? ORDER BY datetime(creation_time) DESC""${'"'}, mapper, listOf(67 + (if (userId == null) 2 else 1))) {
        |    bindString(0, userId)
        |  }
        |
@@ -424,7 +424,7 @@ class SelectQueryTypeTest {
        |    driver.removeListener(listener, arrayOf("socialFeedItem"))
        |  }
        |
-       |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> R): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(${treatNullAsUnknownQuery.id}, ""${'"'}SELECT * FROM socialFeedItem WHERE message IS NOT NULL AND userId = ? ORDER BY datetime(creation_time) DESC""${'"'}, mapper, 1) {
+       |  public override fun <R> execute(mapper: (app.cash.sqldelight.db.SqlCursor) -> R): app.cash.sqldelight.db.QueryResult<R> = driver.executeQuery(${treatNullAsUnknownQuery.id}, ""${'"'}SELECT * FROM socialFeedItem WHERE message IS NOT NULL AND userId = ? ORDER BY datetime(creation_time) DESC""${'"'}, mapper, listOf(68)) {
        |    bindString(0, userId)
        |  }
        |
@@ -476,7 +476,7 @@ class SelectQueryTypeTest {
        |  |SELECT _id, username
        |  |FROM Friend
        |  |WHERE userId${'$'}{ if (userId == null) " IS " else "=" }? OR username=? LIMIT 2
-       |  ""${'"'}.trimMargin(), mapper, 2) {
+       |  ""${'"'}.trimMargin(), mapper, listOf(45 + (if (userId == null) 4 else 1), 59 + (if (userId == null) 4 else 1))) {
        |    bindString(0, userId)
        |    bindString(1, username)
        |  }
@@ -527,7 +527,7 @@ class SelectQueryTypeTest {
        |  |SELECT _id, username
        |  |FROM Friend
        |  |WHERE userId=? OR username=? LIMIT 2
-       |  ""${'"'}.trimMargin(), mapper, 2) {
+       |  ""${'"'}.trimMargin(), mapper, listOf(46, 60)) {
        |    bindString(0, userId)
        |    bindString(1, username)
        |  }
@@ -592,7 +592,7 @@ class SelectQueryTypeTest {
       |  |AND val ${"$"}{ if (val____ == null) "IS NOT" else "!=" } ?
       |  |AND val IS ?
       |  |AND val IS NOT ?
-      |  ""${'"'}.trimMargin(), mapper, 6) {
+      |  ""${'"'}.trimMargin(), mapper, listOf(30 + (if (val_ == null) 2 else 1), 43 + (if (val_ == null) 2 else 1), 54 + (if (val_ == null) 2 else 1) + (if (val___ == null) 6 else 2), 65 + (if (val_ == null) 2 else 1) + (if (val___ == null) 6 else 2) + (if (val____ == null) 6 else 2), 78 + (if (val_ == null) 2 else 1) + (if (val___ == null) 6 else 2) + (if (val____ == null) 6 else 2), 95 + (if (val_ == null) 2 else 1) + (if (val___ == null) 6 else 2) + (if (val____ == null) 6 else 2))) {
       |    bindString(0, val_)
       |    bindString(1, val__)
       |    bindString(2, val___)
@@ -660,7 +660,7 @@ class SelectQueryTypeTest {
       |  |AND val != ?
       |  |AND val IS ?
       |  |AND val IS NOT ?
-      |  ""${'"'}.trimMargin(), mapper, 6) {
+      |  ""${'"'}.trimMargin(), mapper, listOf(31, 44, 57, 70, 83, 100)) {
       |    bindString(0, val_)
       |    bindString(1, val__)
       |    bindString(2, val___)
@@ -714,7 +714,7 @@ class SelectQueryTypeTest {
       |  |SELECT *
       |  |FROM data
       |  |WHERE data MATCH ? AND rowid = ?
-      |  ""${'"'}.trimMargin(), mapper, 2) {
+      |  ""${'"'}.trimMargin(), mapper, listOf(36, 50)) {
       |    bindString(0, data)
       |    bindLong(1, rowid)
       |  }
@@ -765,7 +765,7 @@ class SelectQueryTypeTest {
       |  |SELECT *
       |  |FROM data
       |  |WHERE data MATCH '"one ' || ? || '" * '
-      |  ""${'"'}.trimMargin(), mapper, 1) {
+      |  ""${'"'}.trimMargin(), mapper, listOf(47)) {
       |    bindString(0, value)
       |  }
       |
@@ -826,7 +826,7 @@ class SelectQueryTypeTest {
       |        |  AND id IN ${"$"}idIndexes
       |        |  AND (token != ? OR (name = ? OR ? = 'foo'))
       |        |  AND token IN ${"$"}token_Indexes
-      |        ""${'"'}.trimMargin(), mapper, 4 + id.size + token_.size) {
+      |        ""${'"'}.trimMargin(), mapper, listOf(listOf(33), id.mapIndexed { index, _ -> 47 + 2*index + 1 }, listOf(64 + idIndexes.length, 77 + idIndexes.length, 82 + idIndexes.length), token_.mapIndexed { index, _ -> 109 + idIndexes.length + 2*index + 1 }).flatten()) {
       |          bindString(0, token)
       |          id.forEachIndexed { index, id_ ->
       |            bindLong(index + 1, id_)
@@ -892,7 +892,7 @@ class SelectQueryTypeTest {
       |  |WHERE id ${'$'}{ if (id == null) "IS" else "=" } ? OR id IN child_ids
       |  |LIMIT ?
       |  |OFFSET ?
-      |  ""${'"'}.trimMargin(), mapper, 4) {
+      |  ""${'"'}.trimMargin(), mapper, listOf(49 + (if (id == null) 2 else 1), 81 + (if (id == null) 2 else 1) + (if (id == null) 2 else 1), 108 + (if (id == null) 2 else 1) + (if (id == null) 2 else 1), 117 + (if (id == null) 2 else 1) + (if (id == null) 2 else 1))) {
       |    bindLong(0, id)
       |    bindLong(1, id)
       |    bindLong(2, limit)
@@ -950,7 +950,7 @@ class SelectQueryTypeTest {
       |  |WHERE id = ? OR id IN child_ids
       |  |LIMIT ?
       |  |OFFSET ?
-      |  ""${'"'}.trimMargin(), mapper, 4) {
+      |  ""${'"'}.trimMargin(), mapper, listOf(50, 83, 110, 119)) {
       |    bindLong(0, id)
       |    bindLong(1, id)
       |    bindLong(2, limit)
@@ -1004,7 +1004,7 @@ class SelectQueryTypeTest {
       |        |SELECT *
       |        |FROM data
       |        |WHERE id IN ${'$'}idIndexes
-      |        ""${'"'}.trimMargin(), mapper, id.size) {
+      |        ""${'"'}.trimMargin(), mapper, id.mapIndexed { index, _ -> 31 + 2*index + 1 }) {
       |          id.forEachIndexed { index, id_ ->
       |            bindLong(index, id_?.let { data_Adapter.idAdapter.encode(it) })
       |          }
@@ -1070,7 +1070,7 @@ class SelectQueryTypeTest {
       |  |SELECT *
       |  |FROM data
       |  |WHERE token ${"$"}{ if (token == null) "IS" else "=" } ? OR ? IS NULL
-      |  ""${'"'}.trimMargin(), mapper, 2) {
+      |  ""${'"'}.trimMargin(), mapper, listOf(32 + (if (token == null) 2 else 1), 37 + (if (token == null) 2 else 1))) {
       |    ${binderCheck}bindString(0, token)
       |    bindString(1, token)
       |  }
@@ -1119,7 +1119,7 @@ class SelectQueryTypeTest {
       |  |SELECT *
       |  |FROM data
       |  |WHERE token = ? OR ? IS NULL
-      |  ""${'"'}.trimMargin(), mapper, 2) {
+      |  ""${'"'}.trimMargin(), mapper, listOf(33, 38)) {
       |    ${binderCheck}bindString(0, token)
       |    bindString(1, token)
       |  }
@@ -1416,13 +1416,13 @@ class SelectQueryTypeTest {
       |    driver.execute(${query.idForIndex(0)}, ""${'"'}
       |        |INSERT INTO data (value)
       |        |  VALUES (?)
-      |        ""${'"'}.trimMargin(), 1) {
+      |        ""${'"'}.trimMargin(), listOf(35)) {
       |          bindLong(0, value)
       |        }
       |    driver.execute(${query.idForIndex(1)}, ""${'"'}
       |        |INSERT INTO data (value)
       |        |  VALUES (?)
-      |        ""${'"'}.trimMargin(), 1) {
+      |        ""${'"'}.trimMargin(), listOf(35)) {
       |          bindLong(0, value)
       |        }
       |  }
@@ -1467,13 +1467,13 @@ class SelectQueryTypeTest {
       |    driver.execute(${query.idForIndex(0)}, ""${'"'}
       |        |INSERT INTO data (value)
       |        |  VALUES (?)
-      |        ""${'"'}.trimMargin(), 1) {
+      |        ""${'"'}.trimMargin(), listOf(35)) {
       |          bindLong(0, value_)
       |        }
       |    driver.execute(${query.idForIndex(1)}, ""${'"'}
       |        |INSERT INTO data (value)
       |        |  VALUES (?)
-      |        ""${'"'}.trimMargin(), 1) {
+      |        ""${'"'}.trimMargin(), listOf(35)) {
       |          bindLong(0, value__)
       |        }
       |  }
@@ -1518,13 +1518,13 @@ class SelectQueryTypeTest {
       |    driver.execute(${query.idForIndex(0)}, ""${'"'}
       |        |INSERT INTO data (value)
       |        |  VALUES (?)
-      |        ""${'"'}.trimMargin(), 1) {
+      |        ""${'"'}.trimMargin(), listOf(35)) {
       |          bindLong(0, value_)
       |        }
       |    driver.execute(${query.idForIndex(1)}, ""${'"'}
       |        |INSERT INTO data (value)
       |        |  VALUES (?)
-      |        ""${'"'}.trimMargin(), 1) {
+      |        ""${'"'}.trimMargin(), listOf(35)) {
       |          bindLong(0, value_)
       |        }
       |  }
@@ -1569,13 +1569,13 @@ class SelectQueryTypeTest {
       |    driver.execute(${query.idForIndex(0)}, ""${'"'}
       |        |INSERT INTO data (value)
       |        |  VALUES (?)
-      |        ""${'"'}.trimMargin(), 1) {
+      |        ""${'"'}.trimMargin(), listOf(35)) {
       |          bindLong(0, value_)
       |        }
       |    driver.execute(${query.idForIndex(1)}, ""${'"'}
       |        |INSERT INTO data (value)
       |        |  VALUES (?)
-      |        ""${'"'}.trimMargin(), 1) {
+      |        ""${'"'}.trimMargin(), listOf(35)) {
       |          bindLong(0, value__)
       |        }
       |  }
@@ -1624,13 +1624,13 @@ class SelectQueryTypeTest {
       |    driver.execute(${query.idForIndex(0)}, ""${'"'}
       |        |INSERT INTO data (value)
       |        |  VALUES (?)
-      |        ""${'"'}.trimMargin(), 1) {
+      |        ""${'"'}.trimMargin(), listOf(35)) {
       |          bindLong(0, value_)
       |        }
       |    driver.execute(${query.idForIndex(1)}, ""${'"'}
       |        |INSERT INTO data (value)
       |        |  VALUES (?)
-      |        ""${'"'}.trimMargin(), 1) {
+      |        ""${'"'}.trimMargin(), listOf(35)) {
       |          bindLong(0, value__)
       |        }
       |  }
@@ -1724,7 +1724,7 @@ class SelectQueryTypeTest {
         |    return driver.executeQuery(null, ""${'"'}
         |        |SELECT (SELECT count(*) FROM ComboData WHERE value IN ${"$"}valuesIndexes) +
         |        |(SELECT count(*) FROM ComboData2 WHERE value IN ${"$"}valuesIndexes)
-        |        ""${'"'}.trimMargin(), mapper, values.size + values.size) {
+        |        ""${'"'}.trimMargin(), mapper, listOf(values.mapIndexed { index, _ -> 54 + 2*index + 1 }, values.mapIndexed { index, _ -> 106 + valuesIndexes.length + 2*index + 1 }).flatten()) {
         |          values.forEachIndexed { index, values_ ->
         |            bindString(index, ComboDataAdapter.value_Adapter.encode(values_))
         |          }
@@ -1776,14 +1776,14 @@ class SelectQueryTypeTest {
       |    driver.execute(${query.idForIndex(0)}, ""${'"'}
       |        |INSERT INTO data (value)
       |        |  VALUES (?)
-      |        ""${'"'}.trimMargin(), 1) {
+      |        ""${'"'}.trimMargin(), listOf(35)) {
       |          bindLong(0, value_)
       |        }
       |    driver.executeQuery(${query.idForIndex(1)}, ""${'"'}
       |        |SELECT value
       |        |  FROM data
       |        |  WHERE id = last_insert_rowid()
-      |        ""${'"'}.trimMargin(), mapper, 0)
+      |        ""${'"'}.trimMargin(), mapper, emptyList())
       |  }
       |
       |  public override fun toString(): kotlin.String = "Test.sq:insertAndReturn"

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/async/AsyncMutatorQueryTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/async/AsyncMutatorQueryTypeTest.kt
@@ -35,7 +35,7 @@ class AsyncMutatorQueryTypeTest {
       |  driver.execute(${mutator.id}, ""${'"'}
       |      |INSERT INTO data
       |      |VALUES (?, ?)
-      |      ""${'"'}.trimMargin(), 2) {
+      |      ""${'"'}.trimMargin(), listOf(25, 28)) {
       |        bindLong(0, id?.let { data_Adapter.idAdapter.encode(it) })
       |        bindString(1, value_?.let { data_Adapter.value_Adapter.encode(it) })
       |      }.await()
@@ -79,7 +79,7 @@ class AsyncMutatorQueryTypeTest {
       |  driver.execute(${mutator.id}, ""${'"'}
       |      |INSERT INTO data
       |      |VALUES (?, ?)
-      |      ""${'"'}.trimMargin(), 2) {
+      |      ""${'"'}.trimMargin(), listOf(25, 28)) {
       |        bindLong(0, id?.let { data_Adapter.idAdapter.encode(it) })
       |        bindString(1, value_?.let { data_Adapter.value_Adapter.encode(it) })
       |      }.await()
@@ -129,7 +129,7 @@ class AsyncMutatorQueryTypeTest {
       |  driver.execute(${mutator.id}, ""${'"'}
       |      |INSERT INTO data
       |      |VALUES (?, ?)
-      |      ""${'"'}.trimMargin(), 2) {
+      |      ""${'"'}.trimMargin(), listOf(25, 28)) {
       |        bindLong(0, id?.let { data_Adapter.idAdapter.encode(it) })
       |        bindString(1, value_?.let { data_Adapter.value_Adapter.encode(it) })
       |      }.await()

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/async/AsyncSelectQueryTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/async/AsyncSelectQueryTypeTest.kt
@@ -143,7 +143,7 @@ class AsyncSelectQueryTypeTest {
       |  |SELECT *
       |  |FROM data
       |  |WHERE id = ?
-      |  ""${'"'}.trimMargin(), mapper, 1) {
+      |  ""${'"'}.trimMargin(), mapper, listOf(30)) {
       |    bindLong(0, id)
       |  }
       |
@@ -187,13 +187,13 @@ class AsyncSelectQueryTypeTest {
       |    driver.execute(${query.idForIndex(0)}, ""${'"'}
       |        |INSERT INTO data (value)
       |        |  VALUES (?)
-      |        ""${'"'}.trimMargin(), 1) {
+      |        ""${'"'}.trimMargin(), listOf(35)) {
       |          bindLong(0, value)
       |        }.await()
       |    driver.execute(${query.idForIndex(1)}, ""${'"'}
       |        |INSERT INTO data (value)
       |        |  VALUES (?)
-      |        ""${'"'}.trimMargin(), 1) {
+      |        ""${'"'}.trimMargin(), listOf(35)) {
       |          bindLong(0, value)
       |        }.await()
       |  }
@@ -243,14 +243,14 @@ class AsyncSelectQueryTypeTest {
       |      driver.execute(${query.idForIndex(0)}, ""${'"'}
       |          |INSERT INTO data (value)
       |          |  VALUES (?)
-      |          ""${'"'}.trimMargin(), 1) {
+      |          ""${'"'}.trimMargin(), listOf(35)) {
       |            bindLong(0, value_)
       |          }.await()
       |      driver.executeQuery(${query.idForIndex(1)}, ""${'"'}
       |          |SELECT value
       |          |  FROM data
       |          |  WHERE id = last_insert_rowid()
-      |          ""${'"'}.trimMargin(), mapper, 0)
+      |          ""${'"'}.trimMargin(), mapper, emptyList())
       |    }
       |  }
       |

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/tables/OptimisticLockTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/tables/OptimisticLockTest.kt
@@ -110,7 +110,7 @@ class OptimisticLockTest {
       |      |WHERE
       |      |  id = ? AND
       |      |  version = ?
-      |      ""${'"'}.trimMargin(), 4) {
+      |      ""${'"'}.trimMargin(), listOf(25, 40, 59, 77)) {
       |        check(this is app.cash.sqldelight.driver.jdbc.JdbcPreparedStatement)
       |        bindString(0, text)
       |        bindLong(1, version.version.toLong())

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/triggers/TriggerNotificationTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/triggers/TriggerNotificationTest.kt
@@ -50,7 +50,7 @@ class TriggerNotificationTest {
       |  driver.execute(${mutator.id}, ""${'"'}
       |      |INSERT INTO data
       |      |VALUES (?, ?)
-      |      ""${'"'}.trimMargin(), 2) {
+      |      ""${'"'}.trimMargin(), listOf(25, 28)) {
       |        bindLong(0, id)
       |        bindString(1, value_)
       |      }
@@ -103,7 +103,7 @@ class TriggerNotificationTest {
       |  driver.execute(${mutator.id}, ""${'"'}
       |      |DELETE FROM data
       |      |WHERE id = ?
-      |      ""${'"'}.trimMargin(), 1) {
+      |      ""${'"'}.trimMargin(), listOf(28)) {
       |        bindLong(0, id)
       |      }
       |  notifyQueries(-1854133518) { emit ->
@@ -156,7 +156,7 @@ class TriggerNotificationTest {
       |      |UPDATE data
       |      |SET value = ?
       |      |WHERE id = ?
-      |      ""${'"'}.trimMargin(), 2) {
+      |      ""${'"'}.trimMargin(), listOf(24, 37)) {
       |        bindString(0, value_)
       |        bindLong(1, id)
       |      }
@@ -210,7 +210,7 @@ class TriggerNotificationTest {
       |      |UPDATE data
       |      |SET value = ?
       |      |WHERE id = ?
-      |      ""${'"'}.trimMargin(), 2) {
+      |      ""${'"'}.trimMargin(), listOf(24, 37)) {
       |        bindString(0, value_)
       |        bindLong(1, id)
       |      }
@@ -265,7 +265,7 @@ class TriggerNotificationTest {
       |      |UPDATE data
       |      |SET value = ?
       |      |WHERE id = ?
-      |      ""${'"'}.trimMargin(), 2) {
+      |      ""${'"'}.trimMargin(), listOf(24, 37)) {
       |        bindString(0, value_)
       |        bindLong(1, id)
       |      }
@@ -320,7 +320,7 @@ class TriggerNotificationTest {
       |      |UPDATE data
       |      |SET value = ?
       |      |WHERE id = ?
-      |      ""${'"'}.trimMargin(), 2) {
+      |      ""${'"'}.trimMargin(), listOf(24, 37)) {
       |        bindString(0, value_)
       |        bindLong(1, id)
       |      }
@@ -373,7 +373,7 @@ class TriggerNotificationTest {
       |  driver.execute(${mutator.id}, ""${'"'}
       |      |INSERT INTO data (id, value) VALUES (?, ?)
       |      |ON CONFLICT (id) DO UPDATE SET value = excluded.value
-      |      ""${'"'}.trimMargin(), 2) {
+      |      ""${'"'}.trimMargin(), listOf(37, 40)) {
       |        bindLong(0, id)
       |        bindString(1, value)
       |      }
@@ -427,7 +427,7 @@ class TriggerNotificationTest {
       |  driver.execute(${mutator.id}, ""${'"'}
       |      |INSERT INTO data (id, value) VALUES (?, ?)
       |      |ON CONFLICT (id) DO UPDATE SET value = excluded.value
-      |      ""${'"'}.trimMargin(), 2) {
+      |      ""${'"'}.trimMargin(), listOf(37, 40)) {
       |        bindLong(0, id)
       |        bindString(1, value)
       |      }
@@ -482,7 +482,7 @@ class TriggerNotificationTest {
     assertThat(generator.function().toString()).isEqualTo(
       """
       |public fun deleteAllFoos(): kotlin.Unit {
-      |  driver.execute(${mutator.id}, ""${'"'}DELETE FROM foo""${'"'}, 0)
+      |  driver.execute(${mutator.id}, ""${'"'}DELETE FROM foo""${'"'}, emptyList())
       |  notifyQueries(${mutator.id}) { emit ->
       |    emit("bar")
       |    emit("foo")

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-rename-column/output/com/example/DataQueries.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-rename-column/output/com/example/DataQueries.kt
@@ -13,7 +13,7 @@ public class DataQueries(
     driver.execute(-2118611703, """
         |INSERT INTO test
         |VALUES (?, ?)
-        """.trimMargin(), 2) {
+        """.trimMargin(), listOf(25, 28)) {
           check(this is JdbcPreparedStatement)
           bindString(0, test.third)
           bindString(1, test.second?.let { testAdapter.secondAdapter.encode(it) })

--- a/sqldelight-gradle-plugin/src/test/integration-catalog/src/test/kotlin/app/cash/sqldelight/mysql/integration/MySqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-catalog/src/test/kotlin/app/cash/sqldelight/mysql/integration/MySqlTest.kt
@@ -111,14 +111,14 @@ class MySqlTest {
 
     try {
       transacter.transaction {
-        driver.execute(null, "CREATE TABLE throw_test(some Text)", 0, null)
-        afterRollback { driver.execute(null, "DROP TABLE throw_test", 0, null) }
+        driver.execute(null, "CREATE TABLE throw_test(some Text)", emptyList(), null)
+        afterRollback { driver.execute(null, "DROP TABLE throw_test", emptyList(), null) }
         throw ExpectedException()
       }
       Assert.fail()
     } catch (_: ExpectedException) {
       transacter.transaction {
-        driver.execute(null, "CREATE TABLE throw_test(some Text)", 0, null)
+        driver.execute(null, "CREATE TABLE throw_test(some Text)", emptyList(), null)
       }
     }
   }

--- a/sqldelight-gradle-plugin/src/test/integration-migration-callbacks/src/test/java/app/cash/sqldelight/integration/IntegrationTests.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-migration-callbacks/src/test/java/app/cash/sqldelight/integration/IntegrationTests.kt
@@ -14,9 +14,9 @@ class IntegrationTests {
       driver = database,
       oldVersion = 0,
       newVersion = QueryWrapper.Schema.version,
-      AfterVersion(1) { it.execute(null, "INSERT INTO test (value) VALUES('hello')", 0) },
-      AfterVersion(2) { it.execute(null, "INSERT INTO test2 (value, value2) VALUES('hello2', 'sup2')", 0) },
-      AfterVersion(3) { it.execute(null, "INSERT INTO test2 (new_value, new_value2) VALUES('hello3', 'sup3')", 0) },
+      AfterVersion(1) { it.execute(null, "INSERT INTO test (value) VALUES('hello')", emptyList()) },
+      AfterVersion(2) { it.execute(null, "INSERT INTO test2 (value, value2) VALUES('hello2', 'sup2')", emptyList()) },
+      AfterVersion(3) { it.execute(null, "INSERT INTO test2 (new_value, new_value2) VALUES('hello3', 'sup3')", emptyList()) },
     )
 
     val queryWrapper = QueryWrapper(database)
@@ -39,9 +39,9 @@ class IntegrationTests {
       driver = database,
       oldVersion = 2,
       newVersion = QueryWrapper.Schema.version,
-      AfterVersion(1) { it.execute(null, "INSERT INTO test (value) VALUES('hello')", 0) },
-      AfterVersion(2) { it.execute(null, "INSERT INTO test2 (value, value2) VALUES('hello2', 'sup2')", 0) },
-      AfterVersion(3) { it.execute(null, "INSERT INTO test2 (new_value, new_value2) VALUES('hello3', 'sup3')", 0) },
+      AfterVersion(1) { it.execute(null, "INSERT INTO test (value) VALUES('hello')", emptyList()) },
+      AfterVersion(2) { it.execute(null, "INSERT INTO test2 (value, value2) VALUES('hello2', 'sup2')", emptyList()) },
+      AfterVersion(3) { it.execute(null, "INSERT INTO test2 (new_value, new_value2) VALUES('hello3', 'sup3')", emptyList()) },
     )
 
     val queryWrapper = QueryWrapper(database)
@@ -58,10 +58,10 @@ class IntegrationTests {
       driver = database,
       oldVersion = 0,
       newVersion = QueryWrapper.Schema.version,
-      AfterVersion(1) { it.execute(null, "INSERT INTO test (value) VALUES('hello')", 0) },
-      AfterVersion(2) { it.execute(null, "INSERT INTO test2 (value, value2) VALUES('hello2', 'sup2')", 0) },
-      AfterVersion(3) { it.execute(null, "INSERT INTO test2 (new_value, new_value2) VALUES('hello3', 'sup3')", 0) },
-      AfterVersion(4) { it.execute(null, "INSERT INTO test2 (new_value, new_value2) VALUES('hello4', 'sup4')", 0) },
+      AfterVersion(1) { it.execute(null, "INSERT INTO test (value) VALUES('hello')", emptyList()) },
+      AfterVersion(2) { it.execute(null, "INSERT INTO test2 (value, value2) VALUES('hello2', 'sup2')", emptyList()) },
+      AfterVersion(3) { it.execute(null, "INSERT INTO test2 (new_value, new_value2) VALUES('hello3', 'sup3')", emptyList()) },
+      AfterVersion(4) { it.execute(null, "INSERT INTO test2 (new_value, new_value2) VALUES('hello4', 'sup4')", emptyList()) },
     )
 
     val queryWrapper = QueryWrapper(database)

--- a/sqldelight-gradle-plugin/src/test/integration-mysql-async/src/test/kotlin/app/cash/sqldelight/mysql/integration/async/MySqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-mysql-async/src/test/kotlin/app/cash/sqldelight/mysql/integration/async/MySqlTest.kt
@@ -14,7 +14,7 @@ class MySqlTest {
 
   private fun runTest(block: suspend (MyDatabase) -> Unit) = kotlinx.coroutines.test.runTest {
     val connection = factory.create().awaitSingle()
-    val driver = R2dbcDriver(connection)
+    val driver = R2dbcDriver(connection, replaceParameter = false)
 
     val db = MyDatabase(driver).also { MyDatabase.Schema.awaitCreate(driver) }
     block(db)

--- a/sqldelight-gradle-plugin/src/test/integration-mysql/src/test/kotlin/app/cash/sqldelight/mysql/integration/MySqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-mysql/src/test/kotlin/app/cash/sqldelight/mysql/integration/MySqlTest.kt
@@ -111,14 +111,14 @@ class MySqlTest {
 
     try {
       transacter.transaction {
-        driver.execute(null, "CREATE TABLE throw_test(some Text)", 0, null)
-        afterRollback { driver.execute(null, "DROP TABLE throw_test", 0, null) }
+        driver.execute(null, "CREATE TABLE throw_test(some Text)", emptyList(), null)
+        afterRollback { driver.execute(null, "DROP TABLE throw_test", emptyList(), null) }
         throw ExpectedException()
       }
       Assert.fail()
     } catch (_: ExpectedException) {
       transacter.transaction {
-        driver.execute(null, "CREATE TABLE throw_test(some Text)", 0, null)
+        driver.execute(null, "CREATE TABLE throw_test(some Text)", emptyList(), null)
       }
     }
   }

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql-async/src/test/kotlin/app/cash/sqldelight/postgresql/integration/async/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql-async/src/test/kotlin/app/cash/sqldelight/postgresql/integration/async/PostgreSqlTest.kt
@@ -21,7 +21,7 @@ class PostgreSqlTest {
 
   private fun runTest(block: suspend (MyDatabase) -> Unit) = kotlinx.coroutines.test.runTest {
     val connection = factory.create().awaitSingle()
-    val driver = R2dbcDriver(connection)
+    val driver = R2dbcDriver(connection, replaceParameter = true)
     val db = MyDatabase(driver)
     MyDatabase.Schema.awaitCreate(driver)
     block(db)

--- a/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/tests/MigrationTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/tests/MigrationTest.kt
@@ -261,20 +261,20 @@ class MigrationTest {
       |          |  value TEXT NOT NULL,
       |          |  value2 TEXT
       |          |)
-      |          ""${'"'}.trimMargin(), 0)
+      |          ""${'"'}.trimMargin(), emptyList())
       |      driver.execute(null, ""${'"'}
       |          |CREATE VIEW testView AS
       |          |SELECT *
       |          |FROM test
-      |          ""${'"'}.trimMargin(), 0)
-      |      driver.execute(null, "CREATE INDEX testIndex ON test(value)", 0)
+      |          ""${'"'}.trimMargin(), emptyList())
+      |      driver.execute(null, "CREATE INDEX testIndex ON test(value)", emptyList())
       |      driver.execute(null, ""${'"'}
       |          |CREATE TRIGGER testTrigger
       |          |AFTER DELETE ON test
       |          |BEGIN
       |          |INSERT INTO test VALUES ("1", "2");
       |          |END
-      |          ""${'"'}.trimMargin(), 0)
+      |          ""${'"'}.trimMargin(), emptyList())
       |      return QueryResult.Unit
       |    }
       |
@@ -284,20 +284,20 @@ class MigrationTest {
       |      newVersion: Int,
       |    ): QueryResult<Unit> {
       |      if (oldVersion <= 1 && newVersion > 1) {
-      |        driver.execute(null, "ALTER TABLE test ADD COLUMN value2 TEXT", 0)
-      |        driver.execute(null, "CREATE INDEX testIndex ON test(value)", 0)
+      |        driver.execute(null, "ALTER TABLE test ADD COLUMN value2 TEXT", emptyList())
+      |        driver.execute(null, "CREATE INDEX testIndex ON test(value)", emptyList())
       |        driver.execute(null, ""${'"'}
       |            |CREATE TRIGGER testTrigger
       |            |AFTER DELETE ON test
       |            |BEGIN
       |            |INSERT INTO test VALUES ("1", "2");
       |            |END
-      |            ""${'"'}.trimMargin(), 0)
+      |            ""${'"'}.trimMargin(), emptyList())
       |        driver.execute(null, ""${'"'}
       |            |CREATE VIEW testView AS
       |            |SELECT *
       |            |FROM test
-      |            ""${'"'}.trimMargin(), 0)
+      |            ""${'"'}.trimMargin(), emptyList())
       |      }
       |      return QueryResult.Unit
       |    }

--- a/sqldelight-gradle-plugin/src/test/multithreaded-sqlite/src/main/kotlin/com/example/db/DbHelper.kt
+++ b/sqldelight-gradle-plugin/src/test/multithreaded-sqlite/src/main/kotlin/com/example/db/DbHelper.kt
@@ -53,21 +53,21 @@ class DbHelper(
         check(cursor.next())
         return cursor.getLong(0)!!.toInt()
       }
-      return driver.executeQuery(null, "PRAGMA user_version;", ::mapper, 0, null).value
+      return driver.executeQuery(null, "PRAGMA user_version;", ::mapper, emptyList(), null).value
     }
     set(value) {
-      driver.execute(null, "PRAGMA user_version = $value;", 0, null)
+      driver.execute(null, "PRAGMA user_version = $value;", emptyList(), null)
     }
 
   var journalMode: String = journalMode
     private set(value) {
-      driver.execute(null, "PRAGMA journal_mode = $value;", 0, null)
+      driver.execute(null, "PRAGMA journal_mode = $value;", emptyList(), null)
       field = value
     }
 
   var foreignKeys: Boolean = foreignKeys
     set(value) {
-      driver.execute(null, "PRAGMA foreign_keys = ${if (value) 1 else 0};", 0, null)
+      driver.execute(null, "PRAGMA foreign_keys = ${if (value) 1 else 0};", emptyList(), null)
       field = value
     }
 }


### PR DESCRIPTION
Change the code gen to calculate argument index lists instead of counting arguments.

This allows the driver to receive the list of question marks indices at runtime and replace them with other placeholders like $n if necessary. Drivers which only require the number of arguments but don't need to replace any question marks can still use the lists' length.

The R2dbc Driver may use numbered arguments like $n or unnumbered arguments like ? depending on the underlying database. Therefore it has received an additional argument to decide if the parameters are to be replaced with numbered arguments.