### PR TITLE
Add cache cleanup workflow

### DIFF
--- a/.github/workflows/CleanBranchCache.yml
+++ b/.github/workflows/CleanBranchCache.yml
@@ -1,0 +1,34 @@
+name: cleanup caches by a branch
+on:
+  pull_request:
+    types:
+      - closed
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+        
+      - name: Cleanup
+        run: |
+          gh extension install actions/gh-actions-cache
+          
+          REPO=$
+          BRANCH=$
+
+          echo "Fetching list of cache key"
+          cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH | cut -f 1 )
+
+          ## Setting this to not fail the workflow while deleting cache keys. 
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
+          done
+          echo "Done"
+        env:
+          GH_TOKEN: $

--- a/.github/workflows/CleanCaches.yml
+++ b/.github/workflows/CleanCaches.yml
@@ -1,4 +1,4 @@
-name: cleanup caches by a branch
+name: Cleanup Caches
 on:
   pull_request:
     types:
@@ -8,16 +8,13 @@ on:
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    
     steps:
-      - name: Check out code
-        uses: actions/checkout@v3
-        
       - name: Cleanup
         run: |
           gh extension install actions/gh-actions-cache
-          
-          REPO=$
-          BRANCH=$
 
           echo "Fetching list of cache key"
           cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH | cut -f 1 )
@@ -31,4 +28,6 @@ jobs:
           done
           echo "Done"
         env:
-          GH_TOKEN: $
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ github.ref_name }}

--- a/.github/workflows/CleanCaches.yml
+++ b/.github/workflows/CleanCaches.yml
@@ -1,8 +1,5 @@
 name: Cleanup Caches
 on:
-  pull_request:
-    types:
-      - closed
   workflow_dispatch:
 
 jobs:
@@ -10,19 +7,17 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: write
-    
+
     steps:
       - name: Cleanup
         run: |
           gh extension install actions/gh-actions-cache
-
-          echo "Fetching list of cache key"
-          cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH | cut -f 1 )
-
+          echo "Fetching list of cache key for $BRANCH"
+          cacheKeys=$(gh actions-cache list -R $REPO -B $BRANCH | cut -f 1 )
           ## Setting this to not fail the workflow while deleting cache keys. 
           set +e
           echo "Deleting caches..."
-          for cacheKey in $cacheKeysForPR
+          for cacheKey in $cacheKeys
           do
               gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
           done


### PR DESCRIPTION
The current windows workflows fails. I can't reproduce it locally nor in a fork: https://github.com/hfhbd/sqldelight/actions/runs/3900494050/jobs/6661220465
One possible option: Broken caches. Instead deleting all caches manually there is a workflow now. 
This workflow also removes caches from a closed PR.