### PR TITLE
Add maven relocation pom files

### DIFF
--- a/.github/workflows/PublishRelocation.yml
+++ b/.github/workflows/PublishRelocation.yml
@@ -1,0 +1,27 @@
+name: Publish relocation pom files
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish_relocation_poms:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2.3.1
+        with:
+          distribution: 'zulu'
+          java-version: 11
+
+      - name: Publish relocation pom files
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY }}
+        run: ./gradlew publishRelocationPublicationToMavenCentralRepository --no-daemon
+
+env:
+  GRADLE_OPTS: -Dorg.gradle.configureondemand=true -Dorg.gradle.parallel=false -Dkotlin.incremental=false -Dorg.gradle.jvmargs="-Xmx3g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"

--- a/gradle/gradle-mvn-push.gradle
+++ b/gradle/gradle-mvn-push.gradle
@@ -18,14 +18,14 @@ publishing {
       relocation(MavenPublication) {
         pom {
           // Old artifact coordinates
-          groupId = "com.squareup"
+          groupId = "com.squareup.sqldelight"
           artifactId = POM_ARTIFACT_ID
           version = "2.0.0"
 
           distributionManagement {
             relocation {
               // New artifact coordinates
-              groupId = "app.cash"
+              groupId = "app.cash.sqldelight"
               artifactId = POM_ARTIFACT_ID
               version = "2.0.0"
               message = "groupId has been changed"

--- a/gradle/gradle-mvn-push.gradle
+++ b/gradle/gradle-mvn-push.gradle
@@ -12,4 +12,31 @@ publishing {
             url = "${rootProject.buildDir}/localMaven"
         }
     }
+
+    publications {
+    // Specify relocation POM
+      relocation(MavenPublication) {
+        pom {
+          // Old artifact coordinates
+          groupId = "com.squareup"
+          artifactId = POM_ARTIFACT_ID
+          version = "2.0.0"
+
+          distributionManagement {
+            relocation {
+              // New artifact coordinates
+              groupId = "app.cash"
+              artifactId = POM_ARTIFACT_ID
+              version = "2.0.0"
+              message = "groupId has been changed"
+            }
+          }
+        }
+      }
+  }
+}
+
+tasks.withType(AbstractArchiveTask).configureEach {
+    setPreserveFileTimestamps false
+    setReproducibleFileOrder true
 }


### PR DESCRIPTION
Fixes #4518 
Gradle does support it out of the box, so this is easier than creating pom files manually for all artifacts: https://docs.gradle.org/current/userguide/publishing_maven.html#publishing_maven:retroactive_relocation

I just don't remember, if we changed some artifact names, but #3214 isn't fixed, so AFAIK we did't change old names.

I also created a SINGLE run, manually workflow to actually publish the relocation pom files. Alternatively, you need to publish it manually.