### PR TITLE
Fix issue with Pragma stmt overload clash

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/SqlDelightQueriesFile.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/SqlDelightQueriesFile.kt
@@ -101,7 +101,8 @@ class SqlDelightQueriesFile(
           it.statement.deleteStmtLimited == null &&
           it.statement.insertStmt == null &&
           it.statement.updateStmtLimited == null &&
-          it.statement.compoundSelectStmt == null
+          it.statement.compoundSelectStmt == null &&
+          it.statement.pragmaStmt?.pragmaValue != null
       }
       .map { NamedExecute(it.identifier, it.statement) }
 


### PR DESCRIPTION
This fixes issue #4468 
If the pragma statement doesn't have a value associated with it we should consider that this will be a return only.