### PR TITLE
Add pragma function capability to sqlite

### DIFF
--- a/dialects/sqlite-3-18/src/main/kotlin/app/cash/sqldelight/dialects/sqlite_3_18/grammar/mixins/PragmaFunctionValidatorMixin.kt
+++ b/dialects/sqlite-3-18/src/main/kotlin/app/cash/sqldelight/dialects/sqlite_3_18/grammar/mixins/PragmaFunctionValidatorMixin.kt
@@ -1,0 +1,43 @@
+package app.cash.sqldelight.dialects.sqlite_3_18.grammar.mixins
+
+import com.alecstrong.sql.psi.core.SqlAnnotationHolder
+import com.alecstrong.sql.psi.core.psi.SqlCompositeElement
+import com.alecstrong.sql.psi.core.psi.SqlTypes
+import com.alecstrong.sql.psi.core.psi.impl.SqlPragmaNameImpl
+import com.intellij.lang.ASTNode
+import com.intellij.psi.tree.TokenSet
+
+internal abstract class PragmaFunctionValidatorMixin(node: ASTNode) : SqlPragmaNameImpl(node) {
+    private fun SqlCompositeElement.annotateReservedKeywords(annotationHolder: SqlAnnotationHolder) {
+        children.filterIsInstance<SqlCompositeElement>().forEach {
+            it.annotateReservedKeywords(annotationHolder)
+        }
+        node.getChildren(TokenSet.create(SqlTypes.ID)).forEach {
+            if (it.text !in acceptedKeys) {
+                annotationHolder.createErrorAnnotation(this, "not a valid pragma function")
+            }
+        }
+    }
+    override fun annotate(annotationHolder: SqlAnnotationHolder) {
+        annotateReservedKeywords(annotationHolder)
+        super.annotate(annotationHolder)
+    }
+
+    companion object {
+        // This list is providing the names for all pragma functions that we should support.
+        // For more information please look at the list of pragma https://www.sqlite.org/pragma.html#syntax
+        private val acceptedKeys = setOf(
+                "pragma_application_id",
+                "pragma_cache_size",
+                "pragma_cache_spill",
+                "pragma_compile_options",
+                "pragma_count_changes",
+                "pragma_cell_size_check",
+                "pragma_freelist_count",
+                "pragma_max_page_count",
+                "pragma_page_size",
+                "pragma_page_count",
+                "pragma_user_version",
+        )
+    }
+}

--- a/dialects/sqlite-3-18/src/main/kotlin/app/cash/sqldelight/dialects/sqlite_3_18/grammar/sqlite.bnf
+++ b/dialects/sqlite-3-18/src/main/kotlin/app/cash/sqldelight/dialects/sqlite_3_18/grammar/sqlite.bnf
@@ -12,9 +12,22 @@
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.DIGIT"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.DOT"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.TABLE"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.LP"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.RP"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.SELECT"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.DISTINCT"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.ALL"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.COMMA"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.FROM"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.WHERE"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.HAVING"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.VALUES"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.FOR"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.SEPARATOR"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.MULTIPLY"
   ]
 }
-overrides ::= type_name | bind_parameter | alter_table_stmt
+overrides ::= type_name | bind_parameter | alter_table_stmt | select_stmt
 
 type_name ::= text_data_type | blob_data_type | int_data_type | real_data_type {
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlTypeNameImpl"
@@ -39,4 +52,15 @@ alter_table_stmt ::= ALTER TABLE [ {database_name} DOT ] {table_name} {alter_tab
   stubClass = "com.alecstrong.sql.psi.core.psi.mixins.AlterTableStmtStub"
   pin = 1
   override = true
+}
+
+select_stmt ::= SELECT [ DISTINCT | ALL ] {result_column} ( COMMA {result_column} ) * [ FROM ([ database_name DOT ] pragma_function_expr | {join_clause})] [ WHERE <<expr '-1'>> ] [{group_by}] [ HAVING <<expr '-1'>> ] | VALUES {values_expression} ( COMMA {values_expression} ) * {
+  extends = "com.alecstrong.sql.psi.core.psi.impl.SqlSelectStmtImpl"
+  implements = "com.alecstrong.sql.psi.core.psi.SqlSelectStmt"
+  override = true
+  pin = 1
+}
+
+pragma_function_expr ::= {pragma_name} LP [ [ DISTINCT ] <<expr'-1'>> ( ( COMMA | FROM | FOR | SEPARATOR )  <<expr'-1'>> ) * | MULTIPLY ] RP {
+  mixin = "app.cash.sqldelight.dialects.sqlite_3_18.grammar.mixins.PragmaFunctionValidatorMixin"
 }

--- a/dialects/sqlite-3-18/src/main/kotlin/app/cash/sqldelight/dialects/sqlite_3_18/grammar/sqlite.bnf
+++ b/dialects/sqlite-3-18/src/main/kotlin/app/cash/sqldelight/dialects/sqlite_3_18/grammar/sqlite.bnf
@@ -54,7 +54,7 @@ alter_table_stmt ::= ALTER TABLE [ {database_name} DOT ] {table_name} {alter_tab
   override = true
 }
 
-select_stmt ::= SELECT [ DISTINCT | ALL ] {result_column} ( COMMA {result_column} ) * [ FROM ([ database_name DOT ] pragma_function_expr | {join_clause})] [ WHERE <<expr '-1'>> ] [{group_by}] [ HAVING <<expr '-1'>> ] | VALUES {values_expression} ( COMMA {values_expression} ) * {
+select_stmt ::= SELECT [ DISTINCT | ALL ] {result_column} ( COMMA {result_column} ) * [ FROM ([ {database_name} DOT ] pragma_function_expr | {join_clause})] [ WHERE <<expr '-1'>> ] [{group_by}] [ HAVING <<expr '-1'>> ] | VALUES {values_expression} ( COMMA {values_expression} ) * {
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlSelectStmtImpl"
   implements = "com.alecstrong.sql.psi.core.psi.SqlSelectStmt"
   override = true

--- a/dialects/sqlite-3-18/src/test/fixtures_sqlite_3_18/pragma-statements/Test.s
+++ b/dialects/sqlite-3-18/src/test/fixtures_sqlite_3_18/pragma-statements/Test.s
@@ -1,0 +1,2 @@
+SELECT * FROM pragma_freelist_count();
+SELECT * FROM pragma_freelist_counter(); -- failure

--- a/dialects/sqlite-3-18/src/test/fixtures_sqlite_3_18/pragma-statements/failure.txt
+++ b/dialects/sqlite-3-18/src/test/fixtures_sqlite_3_18/pragma-statements/failure.txt
@@ -1,0 +1,1 @@
+Test.s line 2:14 - not a valid pragma function

--- a/dialects/sqlite-3-25/src/main/kotlin/app/cash/sqldelight/dialects/sqlite_3_25/grammar/sqlite.bnf
+++ b/dialects/sqlite-3-25/src/main/kotlin/app/cash/sqldelight/dialects/sqlite_3_25/grammar/sqlite.bnf
@@ -54,11 +54,15 @@ result_column ::= ( MULTIPLY
   implements = "com.alecstrong.sql.psi.core.psi.SqlResultColumn"
   override = true
 }
-select_stmt ::= SELECT [ DISTINCT | ALL ] {result_column} ( COMMA {result_column} ) * [ FROM {join_clause} ] [ WHERE <<expr '-1'>> ] [{group_by}] [ HAVING <<expr '-1'>> ] [ WINDOW window_name AS window_defn ( COMMA window_name AS window_defn ) * ] | VALUES {values_expression} ( COMMA {values_expression} ) * {
+select_stmt ::= SELECT [ DISTINCT | ALL ] {result_column} ( COMMA {result_column} ) * [ FROM ([ {database_name} DOT ] pragma_function_expr | {join_clause}) ] [ WHERE <<expr '-1'>> ] [{group_by}] [ HAVING <<expr '-1'>> ] [ WINDOW window_name AS window_defn ( COMMA window_name AS window_defn ) * ] | VALUES {values_expression} ( COMMA {values_expression} ) * {
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlSelectStmtImpl"
   implements = "com.alecstrong.sql.psi.core.psi.SqlSelectStmt"
   override = true
   pin = 1
+}
+
+pragma_function_expr ::= {pragma_name} LP [ [ DISTINCT ] <<expr'-1'>> ( ( COMMA | FROM | FOR | SEPARATOR )  <<expr'-1'>> ) * | MULTIPLY ] RP {
+  mixin = "app.cash.sqldelight.dialects.sqlite_3_18.grammar.mixins.PragmaNamed"
 }
 
 alter_table_rename_column ::= RENAME [ COLUMN ] {column_name} TO {column_alias} {


### PR DESCRIPTION
Sqlite has had the ability to use pragma functions since 3.16.0, for sqldelight we should add the ability to use the same functions. For more information about pragma functions please look at: https://www.sqlite.org/pragma.html#pragma_functions
Add the ability to use PRAGMA functions within sql select statements.