### PR TITLE
Notify queries when executing group statements with result

### DIFF
--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/PlayerQueries.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/PlayerQueries.kt
@@ -252,6 +252,10 @@ public class PlayerQueries(
           |  FROM player
           |  WHERE player.rowid = last_insert_rowid()
           """.trimMargin(), mapper, 0)
+    } .also {
+      notifyQueries(781_651_682) { emit ->
+        emit("player")
+      }
     }
 
     override fun toString(): String = "Player.sq:insertAndReturn"

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/ExecuteQueryGenerator.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/ExecuteQueryGenerator.kt
@@ -2,17 +2,8 @@ package app.cash.sqldelight.core.compiler
 
 import app.cash.sqldelight.core.capitalize
 import app.cash.sqldelight.core.compiler.model.NamedExecute
-import app.cash.sqldelight.core.compiler.model.NamedMutator
 import app.cash.sqldelight.core.lang.argumentType
-import app.cash.sqldelight.core.lang.psi.StmtIdentifierMixin
-import app.cash.sqldelight.core.lang.util.TableNameElement
-import app.cash.sqldelight.core.psi.SqlDelightStmtClojureStmtList
-import com.alecstrong.sql.psi.core.psi.SqlDeleteStmtLimited
-import com.alecstrong.sql.psi.core.psi.SqlInsertStmt
-import com.alecstrong.sql.psi.core.psi.SqlUpdateStmtLimited
-import com.intellij.psi.util.PsiTreeUtil
 import com.squareup.kotlinpoet.ClassName
-import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.KModifier.SUSPEND
@@ -22,51 +13,6 @@ import com.squareup.kotlinpoet.PropertySpec
 open class ExecuteQueryGenerator(
   private val query: NamedExecute,
 ) : QueryGenerator(query) {
-  internal open fun tablesUpdated(): List<TableNameElement> {
-    if (query.statement is SqlDelightStmtClojureStmtList) {
-      return PsiTreeUtil.findChildrenOfAnyType(
-        query.statement,
-        SqlUpdateStmtLimited::class.java,
-        SqlDeleteStmtLimited::class.java,
-        SqlInsertStmt::class.java,
-      ).flatMap {
-        MutatorQueryGenerator(
-          when (it) {
-            is SqlUpdateStmtLimited -> NamedMutator.Update(it, query.identifier as StmtIdentifierMixin)
-            is SqlDeleteStmtLimited -> NamedMutator.Delete(it, query.identifier as StmtIdentifierMixin)
-            is SqlInsertStmt -> NamedMutator.Insert(it, query.identifier as StmtIdentifierMixin)
-            else -> throw IllegalArgumentException("Unexpected statement $it")
-          },
-        ).tablesUpdated()
-      }.distinctBy { it.name }
-    }
-    return emptyList()
-  }
-
-  private fun FunSpec.Builder.notifyQueries(): FunSpec.Builder {
-    val tablesUpdated = tablesUpdated()
-
-    if (tablesUpdated.isEmpty()) return this
-
-    // The list of affected tables:
-    // notifyQueries { emit ->
-    //     emit("players")
-    //     emit("teams")
-    // }
-    addCode(
-      CodeBlock.builder()
-        .beginControlFlow("notifyQueries(%L) { emit ->", query.id)
-        .apply {
-          tablesUpdated.sortedBy { it.name }.forEach {
-            addStatement("emit(\"${it.name}\")")
-          }
-        }
-        .endControlFlow()
-        .build(),
-    )
-
-    return this
-  }
 
   /**
    * The public api to execute [query]
@@ -74,7 +20,6 @@ open class ExecuteQueryGenerator(
   fun function(): FunSpec {
     return interfaceFunction()
       .addCode(executeBlock())
-      .notifyQueries()
       .build()
   }
 

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/QueriesTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/QueriesTypeTest.kt
@@ -876,7 +876,8 @@ class QueriesTypeTest {
 
     val dataQueries = File(result.outputDirectory, "com/example/DataQueries.kt")
     assertThat(result.compilerOutput).containsKey(dataQueries)
-    assertThat(result.compilerOutput[dataQueries].toString()).isEqualTo(
+    val queryString = result.compilerOutput[dataQueries].toString()
+    assertThat(queryString).isEqualTo(
       """
       |package com.example
       |
@@ -906,6 +907,10 @@ class QueriesTypeTest {
       |          |  VALUES (NULL)
       |          ""${'"'}.trimMargin(), 0)
       |      driver.executeQuery(${query.idForIndex(1).withUnderscores}, ""${'"'}SELECT last_insert_rowid()""${'"'}, mapper, 0)
+      |    } .also {
+      |      notifyQueries(${query.id.withUnderscores}) { emit ->
+      |        emit("data")
+      |      }
       |    }
       |
       |    override fun toString(): String = "Data.sq:insertAndReturn"

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/SelectQueryTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/SelectQueryTypeTest.kt
@@ -1728,6 +1728,10 @@ class SelectQueryTypeTest {
       |        |  VALUES (NULL)
       |        ""${'"'}.trimMargin(), 0)
       |    driver.executeQuery(${query.idForIndex(1).withUnderscores}, ""${'"'}SELECT last_insert_rowid()""${'"'}, mapper, 0)
+      |  } .also {
+      |    notifyQueries(${query.id.withUnderscores}) { emit ->
+      |      emit("data")
+      |    }
       |  }
       |
       |  override fun toString(): kotlin.String = "Test.sq:insertAndReturn"
@@ -1878,6 +1882,10 @@ class SelectQueryTypeTest {
       |        |  FROM data
       |        |  WHERE id = last_insert_rowid()
       |        ""${'"'}.trimMargin(), mapper, 0)
+      |  } .also {
+      |    notifyQueries(${query.id.withUnderscores}) { emit ->
+      |      emit("data")
+      |    }
       |  }
       |
       |  override fun toString(): kotlin.String = "Test.sq:insertAndReturn"

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/async/AsyncSelectQueryTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/async/AsyncSelectQueryTypeTest.kt
@@ -252,6 +252,10 @@ class AsyncSelectQueryTypeTest {
       |          |  FROM data
       |          |  WHERE id = last_insert_rowid()
       |          ""${'"'}.trimMargin(), mapper, 0).await()
+      |    } .also {
+      |      notifyQueries(${query.id.withUnderscores}) { emit ->
+      |        emit("data")
+      |      }
       |    }
       |  }
       |


### PR DESCRIPTION
Fixes:
- #4975 
- #3743
- #4618
- #5001 

-----

### Proposed solution

By modifying the `QueryGenerator` to make sure all child classes have access to `tablesUpdated()`, and centralising the query notification into the `executeBlock` function, make sure the following is added to the generated code of grouped statements.
```kotlin
} .also {
    notifyQueries(queryId) { emit ->
      // emit table names
    }
}
```
I am not completely sure of this approach and I'd love some feedback before I dedicate more time into it.

### To be solved yet

Annoying space before `.also {`. I'll learn a bit more of Kotlinpoet :)

### Questions

- What's the importance of the Query ID? I noticed in some tests it is hardcoded, in some it figures it out from the compiler. I can modify the `notifyQueriesBlock()` to accept the QueryId and make it match one of the statements.

### Remark

I am not sure about the `executeBlock`. I find its control flow a bit hard to follow and I'd love to simplify a bit and maybe link the `QueryGenerator`'s implementations more closely to implement it depending on what the query looks like, instead of having too many ifs and elses.
