### PR TITLE
Add PostgreSql TSRANGE/TSTZRANGE support

### DIFF
--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlType.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlType.kt
@@ -23,6 +23,10 @@ enum class PostgreSqlType(override val javaType: TypeName) : DialectType {
   NUMERIC(ClassName("java.math", "BigDecimal")),
   JSON(STRING),
   TSVECTOR(STRING),
+  TSTZRANGE(STRING),
+  TSRANGE(STRING),
+  TSMULTIRANGE(STRING),
+  TSTZMULTIRANGE(STRING),
   XML(STRING),
   ;
 
@@ -38,7 +42,7 @@ enum class PostgreSqlType(override val javaType: TypeName) : DialectType {
       )
 
       NUMERIC -> CodeBlock.of("bindBigDecimal(%L, %L)\n", columnIndex, value)
-      INTERVAL, JSON, TSVECTOR -> CodeBlock.of(
+      INTERVAL, JSON, TSVECTOR, TSTZRANGE, TSRANGE, TSMULTIRANGE, TSTZMULTIRANGE -> CodeBlock.of(
         "bindObject(%L, %L, %M)\n",
         columnIndex,
         value,
@@ -59,9 +63,9 @@ enum class PostgreSqlType(override val javaType: TypeName) : DialectType {
         SMALL_INT -> "$cursorName.getShort($columnIndex)"
         INTEGER -> "$cursorName.getInt($columnIndex)"
         BIG_INT -> "$cursorName.getLong($columnIndex)"
-        DATE, TIME, TIMESTAMP, TIMESTAMP_TIMEZONE, UUID -> "$cursorName.getObject<%T>($columnIndex)"
+        DATE, TIME, TIMESTAMP, TIMESTAMP_TIMEZONE, INTERVAL, UUID -> "$cursorName.getObject<%T>($columnIndex)"
         NUMERIC -> "$cursorName.getBigDecimal($columnIndex)"
-        JSON, INTERVAL, TSVECTOR, XML -> "$cursorName.getString($columnIndex)"
+        INTERVAL, JSON, TSVECTOR, TSTZRANGE, TSRANGE, TSMULTIRANGE, TSTZMULTIRANGE, XML -> "$cursorName.getString($columnIndex)"
       },
       javaType,
     )

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlType.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlType.kt
@@ -63,7 +63,7 @@ enum class PostgreSqlType(override val javaType: TypeName) : DialectType {
         SMALL_INT -> "$cursorName.getShort($columnIndex)"
         INTEGER -> "$cursorName.getInt($columnIndex)"
         BIG_INT -> "$cursorName.getLong($columnIndex)"
-        DATE, TIME, TIMESTAMP, TIMESTAMP_TIMEZONE, INTERVAL, UUID -> "$cursorName.getObject<%T>($columnIndex)"
+        DATE, TIME, TIMESTAMP, TIMESTAMP_TIMEZONE, UUID -> "$cursorName.getObject<%T>($columnIndex)"
         NUMERIC -> "$cursorName.getBigDecimal($columnIndex)"
         INTERVAL, JSON, TSVECTOR, TSTZRANGE, TSRANGE, TSMULTIRANGE, TSTZMULTIRANGE, XML -> "$cursorName.getString($columnIndex)"
       },

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
@@ -77,6 +77,10 @@ open class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : Ty
         booleanDataType != null -> BOOLEAN
         blobDataType != null -> BLOB
         tsvectorDataType != null -> PostgreSqlType.TSVECTOR
+        tsrange != null -> PostgreSqlType.TSRANGE
+        tstzrange != null -> PostgreSqlType.TSTZRANGE
+        tsmultirange != null -> PostgreSqlType.TSMULTIRANGE
+        tstzmultirange != null -> PostgreSqlType.TSTZMULTIRANGE
         xmlDataType != null -> PostgreSqlType.XML
         else -> throw IllegalArgumentException("Unknown kotlin type for sql type ${this.text}")
       },
@@ -133,6 +137,14 @@ open class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : Ty
     }
     "max" -> encapsulatingTypePreferringKotlin(exprList, SMALL_INT, PostgreSqlType.INTEGER, INTEGER, BIG_INT, REAL, PostgreSqlType.NUMERIC, TEXT, BLOB, TIMESTAMP_TIMEZONE, TIMESTAMP, DATE).asNullable()
     "min" -> encapsulatingTypePreferringKotlin(exprList, BLOB, TEXT, SMALL_INT, INTEGER, PostgreSqlType.INTEGER, BIG_INT, REAL, PostgreSqlType.NUMERIC, TIMESTAMP_TIMEZONE, TIMESTAMP, DATE).asNullable()
+    "lower", "upper" -> {
+      val exprType = encapsulatingTypePreferringKotlin(exprList, TEXT, PostgreSqlType.TSRANGE, PostgreSqlType.TSTZRANGE)
+      when (exprType.dialectType) {
+        PostgreSqlType.TSRANGE -> IntermediateType(PostgreSqlType.TIMESTAMP).nullableIf(exprType.javaType.isNullable)
+        PostgreSqlType.TSTZRANGE -> IntermediateType(PostgreSqlType.TIMESTAMP_TIMEZONE).nullableIf(exprType.javaType.isNullable)
+        else -> exprType
+      }
+    }
     "sum" -> {
       val type = resolvedType(exprList.single())
       when (type.dialectType) {
@@ -196,6 +208,19 @@ open class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : Ty
     "rank", "dense_rank", "row_number" -> IntermediateType(INTEGER)
     "ntile" -> IntermediateType(INTEGER).asNullable()
     "lag", "lead", "first_value", "last_value", "nth_value" -> encapsulatingTypePreferringKotlin(exprList, SMALL_INT, PostgreSqlType.INTEGER, INTEGER, BIG_INT, REAL, PostgreSqlType.NUMERIC, TEXT, TIMESTAMP_TIMEZONE, TIMESTAMP, DATE).asNullable()
+    "isempty", "lower_inc", "upper_inc", "lower_inf", "upper_inf" -> IntermediateType(BOOLEAN)
+    "range_merge" -> encapsulatingTypePreferringKotlin(exprList, PostgreSqlType.TSRANGE, PostgreSqlType.TSTZRANGE, PostgreSqlType.TSMULTIRANGE, PostgreSqlType.TSTZRANGE)
+    "tsrange" -> IntermediateType(PostgreSqlType.TSRANGE)
+    "tstzrange" -> IntermediateType(PostgreSqlType.TSTZRANGE)
+    "tsmultirange" -> IntermediateType(PostgreSqlType.TSMULTIRANGE)
+    "tstzmultirange" -> IntermediateType(PostgreSqlType.TSTZMULTIRANGE)
+    "range_agg" -> {
+      when (resolvedType(exprList[0]).dialectType) {
+        PostgreSqlType.TSRANGE, PostgreSqlType.TSMULTIRANGE -> IntermediateType(PostgreSqlType.TSMULTIRANGE)
+        PostgreSqlType.TSTZRANGE, PostgreSqlType.TSTZMULTIRANGE -> IntermediateType(PostgreSqlType.TSTZMULTIRANGE)
+        else -> error("type not supported for range_agg, use TSRANGE, TSMULTIRANGE, TSTZRANGE, TSTZMULTIRANGE")
+      }
+    }
     else -> null
   }
 
@@ -304,7 +329,14 @@ open class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : Ty
           IntermediateType(PostgreSqlType.JSON)
         }
       }
-      matchOperatorExpression != null || regexMatchOperatorExpression != null || containsOperatorExpression != null || booleanNotExpression != null -> {
+      rangeOperatorExpression != null -> {
+        IntermediateType(BOOLEAN)
+      }
+      matchOperatorExpression != null ||
+        regexMatchOperatorExpression != null ||
+        booleanNotExpression != null ||
+        containsOperatorExpression != null ||
+        overlapsOperatorExpression != null -> {
         IntermediateType(BOOLEAN)
       }
       atTimeZoneOperatorExpression != null -> {
@@ -350,6 +382,10 @@ open class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : Ty
       PostgreSqlType.TIME,
       PostgreSqlType.JSON,
       PostgreSqlType.TSVECTOR,
+      PostgreSqlType.TSRANGE,
+      PostgreSqlType.TSTZRANGE,
+      PostgreSqlType.TSMULTIRANGE,
+      PostgreSqlType.TSTZMULTIRANGE,
       BOOLEAN, // is last as expected that boolean expression resolve to boolean
     )
     private val binaryExprChildTypesResolvingToBool = TokenSet.create(

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -176,6 +176,10 @@ type_name ::= (
   json_data_type |
   blob_data_type |
   tsvector_data_type |
+  tstzrange |
+  tsrange |
+  tsmultirange |
+  tstzmultirange |
   xml_data_type
 ) [ '[]' ] {
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlTypeNameImpl"
@@ -188,8 +192,12 @@ bind_parameter ::= DEFAULT | ( '?' | ':' {identifier} ) {
   implements = "com.alecstrong.sql.psi.core.psi.SqlBindParameter"
   override = true
 }
+
+constraint_exclude_operators ::= '&&' | '='
+
 table_constraint ::= [ CONSTRAINT {identifier} ] (
   ( PRIMARY KEY | UNIQUE ) [{index_name}] LP {indexed_column} [ LP {signed_number} RP ] ( COMMA {indexed_column} [ LP {signed_number} RP ] ) * RP [ {conflict_clause} ] [comment_type] |
+  'EXCLUDE' USING index_method LP <<expr '-1'>> WITH constraint_exclude_operators ( COMMA <<expr '-1'>> WITH constraint_exclude_operators ) * RP [ WHERE LP <<expr '-1'>> RP ] |
   {check_constraint} |
   FOREIGN KEY LP {column_name} ( COMMA {column_name} ) * RP {foreign_key_clause}
 ) {
@@ -266,6 +274,14 @@ timestamp_expression ::= 'TIMESTAMP' [ (WITH | WITHOUT) 'TIME' 'ZONE' ] {string_
 date_expression ::= 'DATE' {string_literal}
 
 time_expression ::= 'TIME' {string_literal}
+
+tsrange ::= 'TSRANGE'
+
+tstzrange ::= 'TSTZRANGE'
+
+tsmultirange ::= 'TSMULTIRANGE'
+
+tstzmultirange ::= 'TSTZMULTIRANGE'
 
 with_clause_auxiliary_stmt ::= {compound_select_stmt} | delete_stmt_limited | insert_stmt | update_stmt_limited {
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlWithClauseAuxiliaryStmtImpl"
@@ -448,7 +464,7 @@ compound_select_stmt ::= [ {with_clause} ] {select_stmt}  ( {compound_operator} 
   override = true
 }
 
-extension_expr ::= extract_temporal_expression | double_colon_cast_operator_expression | contains_operator_expression | at_time_zone_operator_expression | regex_match_operator_expression | match_operator_expression | json_function_stmt | array_agg_stmt| string_agg_stmt | json_expression | boolean_not_expression | window_function_expr {
+extension_expr ::= overlaps_operator_expression | range_operator_expression | extract_temporal_expression | double_colon_cast_operator_expression | contains_operator_expression | at_time_zone_operator_expression | regex_match_operator_expression | match_operator_expression | json_function_stmt | array_agg_stmt| string_agg_stmt | json_expression | boolean_not_expression | window_function_expr {
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlExtensionExprImpl"
   implements = "com.alecstrong.sql.psi.core.psi.SqlExtensionExpr"
   override = true
@@ -499,25 +515,37 @@ json_expression ::= {column_expr} ( jsona_binary_operator | jsonb_binary_operato
   mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.JsonExpressionMixin"
   pin = 2
 }
+
 jsona_binary_operator ::= '->' | '->>' | '#>' | '#>>'
 jsonb_binary_operator ::= '#-'
 jsonb_boolean_operator ::= '@?' | '??|' | '??&' | '??'
-contains_operator ::= '@>' | '<@' | '&&'
+contains_operator ::= '@>' | '<@'
 match_operator ::= '@@'
+overlaps_operator ::= '&&'
+range_boolean_operator ::= '<<' | '>>' | '&>' | '&<' | '-|-'
+regex_match_operator ::=  '~~*' | '~*' | '!~~*' | '!~*' | '~~' | '~' | '!~~' | '!~'
 
-contains_operator_expression ::= ( {function_expr} | {column_expr} ) contains_operator <<expr '-1'>> {
+contains_operator_expression ::= ( {bind_expr} | {literal_expr} | {cast_expr} | {function_expr} | {column_expr} ) contains_operator <<expr '-1'>> {
   mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.ContainsOperatorExpressionMixin"
   pin = 2
 }
 
-match_operator_expression ::= ( {function_expr} | {column_expr} ) match_operator <<expr '-1'>> {
+match_operator_expression ::= ( {bind_expr} | {literal_expr} | {cast_expr} | {function_expr} | {column_expr} ) match_operator <<expr '-1'>> {
   mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.MatchOperatorExpressionMixin"
   pin = 2
 }
 
-regex_match_operator ::=  '~~*' | '~*' | '!~~*' | '!~*' | '~~' | '~' | '!~~' | '!~'
+overlaps_operator_expression ::= ( {bind_expr} | {literal_expr} | {cast_expr} | {function_expr} | {column_expr} ) overlaps_operator <<expr '-1'>> {
+  mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.OverlapsOperatorExpressionMixin"
+  pin = 2
+}
 
-regex_match_operator_expression ::= ( {function_expr} | {column_expr} ) regex_match_operator <<expr '-1'>> {
+range_operator_expression ::= ( {bind_expr} | {literal_expr} | {cast_expr} | {function_expr} | {column_expr} ) range_boolean_operator <<expr '-1'>> {
+  mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.RangeOperatorExpressionMixin"
+  pin = 2
+}
+
+regex_match_operator_expression ::= ( {bind_expr} | {literal_expr} | {cast_expr} | {function_expr} | {column_expr} ) regex_match_operator <<expr '-1'>> {
   mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.RegExMatchOperatorExpressionMixin"
   pin = 2
 }

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/OverlapsOperatorExpressionMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/OverlapsOperatorExpressionMixin.kt
@@ -1,0 +1,32 @@
+package app.cash.sqldelight.dialects.postgresql.grammar.mixins
+
+import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlOverlapsOperatorExpression
+import com.alecstrong.sql.psi.core.SqlAnnotationHolder
+import com.alecstrong.sql.psi.core.psi.SqlBinaryExpr
+import com.alecstrong.sql.psi.core.psi.SqlColumnDef
+import com.alecstrong.sql.psi.core.psi.SqlColumnName
+import com.alecstrong.sql.psi.core.psi.SqlCompositeElementImpl
+import com.alecstrong.sql.psi.core.psi.SqlExpr
+import com.intellij.lang.ASTNode
+
+/**
+ * Overlaps operator '&&' for Array, TsRange, TsTzRange
+ */
+internal abstract class OverlapsOperatorExpressionMixin(node: ASTNode) :
+  SqlCompositeElementImpl(node),
+  SqlBinaryExpr,
+  PostgreSqlOverlapsOperatorExpression {
+
+  override fun annotate(annotationHolder: SqlAnnotationHolder) {
+    val columnType = ((firstChild.firstChild.reference?.resolve() as? SqlColumnName)?.parent as? SqlColumnDef)?.columnType?.typeName?.text
+    when {
+      columnType == null || columnType == "TSRANGE" || columnType == "TSTZRANGE" || columnType == "TSMULTIRANGE" || columnType == "TSTZMULTIRANGE" -> super.annotate(annotationHolder)
+      columnType.endsWith("[]") -> super.annotate(annotationHolder)
+      else -> annotationHolder.createErrorAnnotation(firstChild.firstChild, "expression must be ARRAY, TSRANGE, TSTZRANGE, TSMULTIRANGE, TSTZMULTIRANGE.")
+    }
+    super.annotate(annotationHolder)
+  }
+  override fun getExprList(): List<SqlExpr> {
+    return children.filterIsInstance<SqlExpr>()
+  }
+}

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/RangeOperatorExpressionMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/RangeOperatorExpressionMixin.kt
@@ -1,0 +1,31 @@
+package app.cash.sqldelight.dialects.postgresql.grammar.mixins
+
+import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlRangeOperatorExpression
+import com.alecstrong.sql.psi.core.SqlAnnotationHolder
+import com.alecstrong.sql.psi.core.psi.SqlBinaryExpr
+import com.alecstrong.sql.psi.core.psi.SqlColumnDef
+import com.alecstrong.sql.psi.core.psi.SqlColumnName
+import com.alecstrong.sql.psi.core.psi.SqlCompositeElementImpl
+import com.alecstrong.sql.psi.core.psi.SqlExpr
+import com.intellij.lang.ASTNode
+
+/**
+ * Operators '<<' | '>>' | '&>' | '&<' | '-|-' for TsRange, TsTzRange, TSMULTIRANGE, TSTZMULTIRANGE
+ */
+internal abstract class RangeOperatorExpressionMixin(node: ASTNode) :
+  SqlCompositeElementImpl(node),
+  SqlBinaryExpr,
+  PostgreSqlRangeOperatorExpression {
+
+  override fun annotate(annotationHolder: SqlAnnotationHolder) {
+    val columnType = ((firstChild.firstChild.reference?.resolve() as? SqlColumnName)?.parent as? SqlColumnDef)?.columnType?.typeName?.text
+    when (columnType) {
+      null, "TSRANGE", "TSTZRANGE", "TSMULTIRANGE", "TSTZMULTIRANGE" -> super.annotate(annotationHolder)
+      else -> annotationHolder.createErrorAnnotation(firstChild.firstChild, "expression must be TSRANGE, TSTZRANGE, TSMULTIRANGE, TSTZMULTIRANGE")
+    }
+    super.annotate(annotationHolder)
+  }
+  override fun getExprList(): List<SqlExpr> {
+    return children.filterIsInstance<SqlExpr>()
+  }
+}

--- a/dialects/postgresql/src/test/kotlin/app/cash/sqldelight/dialects/postgres/PostgreSqlFixturesTest.kt
+++ b/dialects/postgresql/src/test/kotlin/app/cash/sqldelight/dialects/postgres/PostgreSqlFixturesTest.kt
@@ -19,7 +19,7 @@ class PostgreSqlFixturesTest(name: String, fixtureRoot: File) : FixturesTest(nam
     "CREATE VIEW IF NOT EXISTS" to "CREATE OR REPLACE VIEW",
     "id TEXT GENERATED ALWAYS AS (2) UNIQUE NOT NULL" to "id TEXT GENERATED ALWAYS AS (2) STORED UNIQUE NOT NULL",
     "'(', ')', ',', '.', <binary like operator real>, BETWEEN or IN expected, got ','"
-      to "'#-', '(', ')', ',', '.', '::', <binary like operator real>, <contains operator real>, <jsona binary operator real>, <jsonb boolean operator real>, <regex match operator real>, '@@', AT, BETWEEN or IN expected, got ','",
+      to "'#-', '&&', '(', ')', ',', '.', '::', <binary like operator real>, <contains operator real>, <jsona binary operator real>, <jsonb boolean operator real>, <range boolean operator real>, <regex match operator real>, '@@', AT, BETWEEN or IN expected, got ','",
   )
 
   override fun setupDialect() {

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/ts-ranges/Test.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/ts-ranges/Test.s
@@ -1,0 +1,59 @@
+CREATE TABLE Schedules(
+  slot TSTZRANGE NOT NULL CHECK(
+      date_part('minute', LOWER(slot)) IN (00, 30)
+      AND
+      date_part('minute', UPPER(slot)) IN (00, 30)),
+    duration INT GENERATED ALWAYS AS (
+      EXTRACT (epoch FROM UPPER(slot) - LOWER(slot))/60
+  ) STORED CHECK(duration IN (30, 60, 90, 120)),
+  EXCLUDE USING GIST(slot WITH &&)
+);
+
+CREATE TABLE Reservations (
+  room TEXT,
+  during TSTZRANGE,
+  CONSTRAINT no_rooms_overlap EXCLUDE USING GIST (room WITH =, during WITH &&)
+);
+
+CREATE TABLE Ranges (
+  id INTEGER,
+  ts_1 TSRANGE,
+  ts_2 TSRANGE,
+  tst_1 TSTZRANGE,
+  tst_2 TSTZRANGE,
+  tsm_1 TSMULTIRANGE,
+  tsm_2 TSMULTIRANGE,
+  tstm_1 TSTZMULTIRANGE,
+  tstm_2 TSTZMULTIRANGE
+);
+
+SELECT CURRENT_TIMESTAMP + INTERVAL '1 day' <@ tstzmultirange(
+  tstzrange(CURRENT_TIMESTAMP, CURRENT_TIMESTAMP + INTERVAL '2 day' ),
+  tstzrange(CURRENT_TIMESTAMP + INTERVAL '3 day' , CURRENT_TIMESTAMP + INTERVAL '6 day')
+);
+
+SELECT *
+FROM Ranges
+WHERE ts_1 <@ ts_2;
+
+SELECT ts_2 @> ts_1, tst_2 @> tst_1, tsm_2 @> tsm_1, tstm_2 @> tstm_1,
+ts_2 && ts_1, tst_2 && tst_1, tsm_2 && tsm_1, tstm_2 && tstm_1
+FROM Ranges;
+
+SELECT ts_1 && ts_2, ts_1 << ts_2, ts_1 >> ts_2, ts_1 &> ts_2, ts_1 &< ts_2, ts_1 -|- ts_2, ts_1 * ts_2, ts_1 + ts_2, ts_1 - ts_2,
+tst_1 && tst_2, tst_1 << tst_2, tst_1 >> tst_2, tst_1 &> tst_2, tst_1 &< tst_2, tst_1 -|- tst_2, tst_1 * tst_2, tst_1 + tst_2, tst_1 - tst_2,
+tsm_1 && tsm_2, tsm_1 << tsm_2, tsm_1 >> tsm_2, tsm_1 &> tsm_2, tsm_1 &< tsm_2, tsm_1 -|- tsm_2, tsm_1 * tsm_2, tsm_1 + tsm_2, tsm_1 - tsm_2,
+tstm_1 && tstm_2, tstm_1 << tstm_2, tstm_1 >> tstm_2, tstm_1 &> tstm_2, tstm_1 &< tstm_2, tstm_1 -|- tstm_2, tstm_1 * tstm_2, tstm_1 + tstm_2, tstm_1 - tstm_2
+FROM Ranges;
+
+SELECT datemultirange(tsrange('2021-06-01', '2021-06-30', '[]')) - range_agg(during) AS availability
+FROM Reservations
+WHERE during && tsrange('2021-06-01', '2021-06-30', '[]');
+
+SELECT tstzmultirange(tstzrange('2010-01-01 14:30:00', '2010-01-01 15:30:00', '[]')) - range_agg(tst_1)
+FROM Ranges
+WHERE tst_2 && tstzrange('2010-01-01 14:30:00', '2010-01-01 15:30:00', '[]');
+
+--error[col 7]: expression must be ARRAY, JSONB, TSVECTOR, TSRANGE, TSTZRANGE, TSMULTIRANGE, TSTZMULTIRANGE.
+SELECT id @> ts_1
+FROM Ranges;

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/TemporalRanges.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/TemporalRanges.sq
@@ -1,0 +1,28 @@
+CREATE TABLE Appointment(
+  slot TSTZRANGE NOT NULL CHECK( date_part('minute', LOWER(slot)) IN (0, 30) AND date_part('minute', UPPER(slot)) IN (0, 30)),
+  duration INT NOT NULL GENERATED ALWAYS AS ( EXTRACT (epoch FROM UPPER(slot) - LOWER(slot)) / 60 ) STORED CHECK(duration IN (30, 60, 90, 120)),
+  EXCLUDE USING GIST(slot WITH &&)
+);
+
+appointments:
+SELECT LOWER(slot) AS begin, UPPER(slot) AS end, duration
+FROM Appointment;
+
+insert:
+INSERT INTO Appointment (slot) VALUES(?);
+
+selectAvailableAppointments:
+SELECT tstzmultirange(?::tstzmultirange) - range_agg(slot) AS availability
+FROM Appointment
+WHERE slot && tstzrange(?::tstzrange);
+
+selectAppointmentContainsRange:
+SELECT slot <@ tstzrange(CURRENT_TIMESTAMP, CURRENT_TIMESTAMP + INTERVAL '2 day') AS isContained
+FROM Appointment;
+
+selectMultiRangeContainsTimestamp:
+SELECT tstzmultirange(
+  tstzrange(CURRENT_TIMESTAMP, CURRENT_TIMESTAMP + INTERVAL '2 day' ),
+  tstzrange(CURRENT_TIMESTAMP + INTERVAL '3 day' , CURRENT_TIMESTAMP + INTERVAL '6 day'))
+  @> CURRENT_TIMESTAMP + INTERVAL '1 day';
+

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
@@ -1113,4 +1113,34 @@ class PostgreSqlTest {
       assertThat(first().total_sales).isEqualTo(BigDecimal("1000.50"))
     }
   }
+
+  @Test
+  fun testSelectAppointments() {
+    val slotBegin = LocalDateTime.of(2009, 1, 1, 9, 0).atOffset(ZoneOffset.UTC)
+    val slotEnd = slotBegin.plusMinutes(30)
+
+    database.temporalRangesQueries.insert("[$slotBegin, $slotEnd)")
+    database.temporalRangesQueries.insert("[$slotEnd, ${slotEnd.plusMinutes(30)})")
+
+    with(database.temporalRangesQueries.appointments().executeAsList()) {
+      assertThat(first().begin).isEqualTo(slotBegin)
+      assertThat(first().end).isEqualTo(slotEnd)
+    }
+
+    val multiRangeSlots = "{[$slotBegin, $slotEnd), [$slotEnd, ${slotEnd.plusMinutes(30)})}"
+    with(database.temporalRangesQueries.selectAvailableAppointments(multiRangeSlots, "[$slotBegin, $slotEnd)").executeAsList()) {
+      assertThat(first()).isEqualTo("""{["2009-01-01 09:30:00+00","2009-01-01 10:00:00+00")}""")
+    }
+
+    with(database.temporalRangesQueries.selectAppointmentContainsRange().executeAsList()) {
+      assertThat(first()).isFalse()
+    }
+  }
+
+  @Test
+  fun testSelectContainsTemporalRange() {
+    with(database.temporalRangesQueries.selectMultiRangeContainsTimestamp().executeAsList()) {
+      assertThat(first()).isTrue()
+    }
+  }
 }


### PR DESCRIPTION
Add some support for TS Range type https://www.postgresql.org/docs/16/rangetypes.html

#RANGETYPES-EXAMPLES

Types are mapped to string representations as there is no client side data type such as a range that is compatible (Kotlin ranges only implement open/closed on upper bounds). This is consistent with JSON, TSVECTOR, INTERVAL types and uses OTHER type to bind the literal value for INSERTS and String for results (Ideally there would be a type mapping for the PostgreSql JDBC driver to use the PgObject type, however only `PostgreSqlType` is available to map types for both Jdbc/R2dbc ).

Note: Bind parameters for ranges must be cast e.g.

```sql
SELECT ?::tstzmultirange - range_agg(slot) AS availability                                                                                                                               FROM Appointment
WHERE slot && ?::tstzrange;
```                                                                                                                          
Range functions https://www.postgresql.org/docs/16/functions-range.html are used to work with ranges e.g extract lower and upper values to the client types `LocalDateTime` and `OffSetDateTime` e.g.

```sql
INSERT INTO room_reservation VALUES
    ('123A', '[2010-01-01 14:00, 2010-01-01 15:00)');
```

```sql

CREATE TABLE TsRanges(
  slot_ts TSRANGE NOT NULL,
  slot_tsz TSTZRANGE
);

SELECT LOWER(slot_ts) AS begin_ts, UPPER(slot_ts) AS end_ts,
LOWER(slot_tsz) AS begin_tsz, UPPER(slot_tsz) AS end_tsz,
EXTRACT (epoch FROM UPPER(slot_ts) - LOWER(slot_ts)) / 60
FROM TsRanges;

SELECT isempty(slot_ts),
 lower_inc(slot_ts), upper_inc(slot_ts),
 lower_inf(slot_ts), upper_inf(slot_ts),
 range_merge(slot_tsz, slot_tsz)
FROM TsRanges;
```

Also  add basic support for `EXCLUDE` table constraints for range supported indexes

```sql
CREATE TABLE Reservations (
    start_time TSTZRANGE,
    finish_time TSTZRANGE,
    CONSTRAINT no_screening_time_overlap EXCLUDE USING GIST (finish_time WITH =, start_time WITH &&)
);
```

MultiRange support (Postgresql 14 or higher)

Allows useful arithmetic on ranges  
e.g identify the available time slots that are not occupied by any appointments within a specified time range.
```sql
SELECT tsmultirange(tsrange('2010-01-01 14:30:00', '2010-01-01 15:30:00', '[]'))
 - range_agg(appointment_dates)
FROM Appointments
WHERE appointment_dates && tsrange('2010-01-01 14:30:00', '2010-01-01 15:30:00', '[]');
```

Updated the type resolver precedence order such that a `SqlBinaryExpr` must return a `Boolean` if one of the arguments is `Boolean`
e.g Otherwise `SELECT '2011-01-10'::timestamp <@ '[2011-01-01,2011-03-01)'::tsrange`  would resolve as a TimeStamp and not Boolean
