### PR TITLE
Fixes 5501 insert object escaped column

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/TreeUtil.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/TreeUtil.kt
@@ -190,7 +190,7 @@ private fun PsiElement.rangesToReplace(): List<Pair<IntRange, String>> {
               separator = ", ",
               prefix = "${parent!!.tableName.node.text} (",
               postfix = ")",
-            ) { it.name },
+            ) { it.node.text },
           ),
         )
       }


### PR DESCRIPTION
fix #5501

* Update to use `it.node.text` as this has access to the dialect escape character
* Add compiler query test