### PR TITLE
Fix 5519 var args with r2dbc driver

### DIFF
--- a/drivers/r2dbc-driver/src/main/kotlin/app/cash/sqldelight/driver/r2dbc/R2dbcDriver.kt
+++ b/drivers/r2dbc-driver/src/main/kotlin/app/cash/sqldelight/driver/r2dbc/R2dbcDriver.kt
@@ -131,6 +131,17 @@ class R2dbcDriver(
       transaction = enclosingTransaction
     }
   }
+
+  override fun createArguments(count: Int): String {
+    if (count == 0) return "()"
+    return buildString(count * 2 + 1) {
+      append("($1")
+      repeat(count - 1) { index ->
+        append(",$${index + 2}")
+      }
+      append(')')
+    }
+  }
 }
 
 /**

--- a/runtime/api/runtime.api
+++ b/runtime/api/runtime.api
@@ -186,6 +186,7 @@ public abstract interface class app/cash/sqldelight/db/SqlCursor {
 
 public abstract interface class app/cash/sqldelight/db/SqlDriver : java/io/Closeable {
 	public abstract fun addListener ([Ljava/lang/String;Lapp/cash/sqldelight/Query$Listener;)V
+	public abstract fun createArguments (I)Ljava/lang/String;
 	public abstract fun currentTransaction ()Lapp/cash/sqldelight/Transacter$Transaction;
 	public abstract fun execute (Ljava/lang/Integer;Ljava/lang/String;ILkotlin/jvm/functions/Function1;)Lapp/cash/sqldelight/db/QueryResult;
 	public abstract fun executeQuery (Ljava/lang/Integer;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/functions/Function1;)Lapp/cash/sqldelight/db/QueryResult;
@@ -195,6 +196,7 @@ public abstract interface class app/cash/sqldelight/db/SqlDriver : java/io/Close
 }
 
 public final class app/cash/sqldelight/db/SqlDriver$DefaultImpls {
+	public static fun createArguments (Lapp/cash/sqldelight/db/SqlDriver;I)Ljava/lang/String;
 	public static synthetic fun execute$default (Lapp/cash/sqldelight/db/SqlDriver;Ljava/lang/Integer;Ljava/lang/String;ILkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lapp/cash/sqldelight/db/QueryResult;
 	public static synthetic fun executeQuery$default (Lapp/cash/sqldelight/db/SqlDriver;Ljava/lang/Integer;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lapp/cash/sqldelight/db/QueryResult;
 }
@@ -217,6 +219,7 @@ public final class app/cash/sqldelight/logs/LogSqliteDriver : app/cash/sqldeligh
 	public fun <init> (Lapp/cash/sqldelight/db/SqlDriver;Lkotlin/jvm/functions/Function1;)V
 	public fun addListener ([Ljava/lang/String;Lapp/cash/sqldelight/Query$Listener;)V
 	public fun close ()V
+	public fun createArguments (I)Ljava/lang/String;
 	public fun currentTransaction ()Lapp/cash/sqldelight/Transacter$Transaction;
 	public fun execute (Ljava/lang/Integer;Ljava/lang/String;ILkotlin/jvm/functions/Function1;)Lapp/cash/sqldelight/db/QueryResult;
 	public fun executeQuery (Ljava/lang/Integer;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/functions/Function1;)Lapp/cash/sqldelight/db/QueryResult;

--- a/runtime/src/commonMain/kotlin/app/cash/sqldelight/Transacter.kt
+++ b/runtime/src/commonMain/kotlin/app/cash/sqldelight/Transacter.kt
@@ -328,15 +328,7 @@ abstract class BaseTransacterImpl(protected val driver: SqlDriver) {
    * For internal use, creates a string in the format (?, ?, ?) where there are [count] question marks.
    */
   protected fun createArguments(count: Int): String {
-    if (count == 0) return "()"
-
-    return buildString(count * 2 + 1) {
-      append("(?")
-      repeat(count - 1) {
-        append(",?")
-      }
-      append(')')
-    }
+    return driver.createArguments(count)
   }
 }
 

--- a/runtime/src/commonMain/kotlin/app/cash/sqldelight/db/SqlDriver.kt
+++ b/runtime/src/commonMain/kotlin/app/cash/sqldelight/db/SqlDriver.kt
@@ -86,4 +86,15 @@ interface SqlDriver : Closeable {
   fun removeListener(vararg queryKeys: String, listener: Query.Listener)
 
   fun notifyListeners(vararg queryKeys: String)
+
+  fun createArguments(count: Int): String {
+    if (count == 0) return "()"
+    return buildString(count * 2 + 1) {
+      append("(?")
+      repeat(count - 1) {
+        append(",?")
+      }
+      append(')')
+    }
+  }
 }


### PR DESCRIPTION
fix #5519 

🦥 In Progress 

```
select:
SELECT *
FROM X WHERE col1 IN ?;
```
I think - the only place in SqlDelight that generates Sql at runtime to expand var args to `IN (?, ?,...)

🛞 The Driver should be responsible for any specific implementation of runtime argument binding 
⚡ Transacter feels like the wrong place for generating runtime sql

Keep existing createArguments as there is a lot of test code generated and forward to Driver implementation

* Adds createArguments is part of Driver behaviour - R2dbc has specific bind argument and reference by position and index
* Add default implementation for `?` binding
* Update Transacter to forward to Driver.createArguments

Note: This is different than the fix for https://github.com/sqldelight/sqldelight/pull/5319 where the expansion of var args can be down at compile time. 

TODO: Add integration test as is runtime generated sql
