### PR TITLE
Execute `DriverInitializer` before `GenerateSchemaTask`

### DIFF
--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/VerifyMigrationTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/VerifyMigrationTask.kt
@@ -202,21 +202,21 @@ abstract class VerifyMigrationTask : SqlDelightWorkerTask() {
         lastMigrationVersion = actual
       }
     }
-
-    private fun MapProperty<String, String>.toProperties(): Properties {
-      val connectionProperties = Properties()
-      get().forEach { (key, value) ->
-        connectionProperties[key] = value
-      }
-      return connectionProperties
-    }
   }
 }
 
 /**
  * Allows consumers to configure and register (with [DriverManager]) their custom drivers prior to
- * running migration verification task.
+ * running VerifyMigrationTask and GenerateSchemaTask tasks.
  */
 interface DriverInitializer {
   fun execute(properties: SqlDelightDatabaseProperties, driverProperties: Properties)
+}
+
+fun MapProperty<String, String>.toProperties(): Properties {
+  val properties = Properties()
+  get().forEach { (key, value) ->
+    properties[key] = value
+  }
+  return properties
 }

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/VerifyMigrationTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/VerifyMigrationTask.kt
@@ -213,7 +213,7 @@ interface DriverInitializer {
   fun execute(properties: SqlDelightDatabaseProperties, driverProperties: Properties)
 }
 
-fun MapProperty<String, String>.toProperties(): Properties {
+internal fun MapProperty<String, String>.toProperties(): Properties {
   val properties = Properties()
   get().forEach { (key, value) ->
     properties[key] = value

--- a/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/tests/GenerateSchemaTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/tests/GenerateSchemaTest.kt
@@ -99,6 +99,7 @@ class GenerateSchemaTest {
 
     // verify
     assertThat(output.output).contains("DriverInitializerImpl executed!")
+    assertThat(output.output).contains("CustomDriver is used for connection.")
     assertThat(output.output).contains("BUILD SUCCESSFUL")
     assertThat(schemaFile.exists())
       .isTrue()

--- a/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/tests/GenerateSchemaTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/tests/GenerateSchemaTest.kt
@@ -86,4 +86,23 @@ class GenerateSchemaTest {
     // verify
     assertThat(schemaFile.exists()).isTrue()
   }
+
+  @Test fun `driver initializer is executed`() {
+    val fixtureRoot = File("src/test/migration-driver-initializer")
+    val schemaFile = File(fixtureRoot, "src/main/sqldelight/databases/2.db")
+    if (schemaFile.exists()) schemaFile.delete()
+
+    val output = GradleRunner.create()
+      .withCommonConfiguration(fixtureRoot)
+      .withArguments("clean", "generateMainDatabaseSchema", "--stacktrace")
+      .build()
+
+    // verify
+    assertThat(output.output).contains("DriverInitializerImpl executed!")
+    assertThat(output.output).contains("BUILD SUCCESSFUL")
+    assertThat(schemaFile.exists())
+      .isTrue()
+
+    schemaFile.delete()
+  }
 }

--- a/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/tests/MigrationTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/tests/MigrationTest.kt
@@ -44,6 +44,7 @@ class MigrationTest {
       .build()
 
     assertThat(output.output).contains("DriverInitializerImpl executed!")
+    assertThat(output.output).contains("CustomDriver is used for connection.")
     assertThat(output.output).contains("BUILD SUCCESSFUL")
   }
 

--- a/sqldelight-gradle-plugin/src/test/migration-driver-initializer/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/migration-driver-initializer/build.gradle
@@ -8,6 +8,7 @@ sqldelight {
     Database {
       packageName = "com.example"
       verifyMigrations = true
+      schemaOutputDirectory = file('src/main/sqldelight/databases')
 
       dependencies.add(configurationName, project(":driverInit"))
     }

--- a/sqldelight-gradle-plugin/src/test/migration-driver-initializer/driverInit/build.gradle.kts
+++ b/sqldelight-gradle-plugin/src/test/migration-driver-initializer/driverInit/build.gradle.kts
@@ -3,5 +3,7 @@ plugins {
 }
 
 dependencies {
+  compileOnly(libs.sqliteJdbc)
+
   implementation(libs.plugins.sqldelight.map { "${it.pluginId}:${it.pluginId}.gradle.plugin:${it.version}" })
 }

--- a/sqldelight-gradle-plugin/src/test/migration-driver-initializer/driverInit/src/main/kotlin/DriverInitializerImpl.kt
+++ b/sqldelight-gradle-plugin/src/test/migration-driver-initializer/driverInit/src/main/kotlin/DriverInitializerImpl.kt
@@ -1,6 +1,5 @@
 import app.cash.sqldelight.core.SqlDelightDatabaseProperties
 import app.cash.sqldelight.gradle.DriverInitializer
-import java.io.File
 import java.sql.Connection
 import java.sql.Driver
 import java.sql.DriverManager

--- a/sqldelight-gradle-plugin/src/test/migration-driver-initializer/driverInit/src/main/kotlin/DriverInitializerImpl.kt
+++ b/sqldelight-gradle-plugin/src/test/migration-driver-initializer/driverInit/src/main/kotlin/DriverInitializerImpl.kt
@@ -1,9 +1,58 @@
 import app.cash.sqldelight.core.SqlDelightDatabaseProperties
 import app.cash.sqldelight.gradle.DriverInitializer
+import java.io.File
+import java.sql.Connection
+import java.sql.Driver
+import java.sql.DriverManager
+import java.sql.DriverPropertyInfo
 import java.util.Properties
+import java.util.logging.Logger
+import org.sqlite.JDBC
 
 class DriverInitializerImpl : DriverInitializer {
   override fun execute(properties: SqlDelightDatabaseProperties, driverProperties: Properties) {
     println("DriverInitializerImpl executed!")
+
+    val customDriver = CustomDriver()
+
+    val driverList = DriverManager.getDrivers().toList()
+    for (driver in driverList) {
+      DriverManager.deregisterDriver(driver)
+    }
+
+    DriverManager.registerDriver(customDriver)
   }
+}
+
+/**
+ * Wrapper around JDBC
+ */
+class CustomDriver : Driver {
+
+  private val wrappedDriver: JDBC = JDBC()
+
+  override fun acceptsURL(url: String?): Boolean =
+    wrappedDriver.acceptsURL(url)
+
+  override fun connect(url: String?, props: Properties?): Connection {
+    // test that we use the registered custom driver to connect to sqlite dbs during gradle tasks
+    println("CustomDriver is used for connection.")
+    val connection = wrappedDriver.connect(url, props)
+    return connection
+  }
+
+  override fun getMajorVersion(): Int =
+    wrappedDriver.majorVersion
+
+  override fun getMinorVersion(): Int =
+    wrappedDriver.minorVersion
+
+  override fun getPropertyInfo(url: String?, info: Properties?): Array<DriverPropertyInfo> =
+    wrappedDriver.getPropertyInfo(url, info)
+
+  override fun jdbcCompliant(): Boolean =
+    wrappedDriver.jdbcCompliant()
+
+  override fun getParentLogger(): Logger =
+    wrappedDriver.parentLogger
 }


### PR DESCRIPTION
This PR extends the work done for the VerifyMigrationTask in https://github.com/sqldelight/sqldelight/pull/3986 to the `GenerateSchemaTask`.

I [added a test](https://github.com/sqldelight/sqldelight/commit/4670689a8825d52b0b0012e8d9596a53a7c160c8), and also [expanded](https://github.com/sqldelight/sqldelight/commit/8ae0a8d67f63df7c283fba85b177ebcdd3c60362) the existing test added in the previous PR to actually test for our use case which is using a custom driver to connect to the sqlite db during these tasks.