### PR TITLE
K2 Klib name fix for "runtime" module

### DIFF
--- a/runtime/build.gradle
+++ b/runtime/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompileCommon
+
 plugins {
   alias(libs.plugins.publish)
   alias(libs.plugins.dokka)
@@ -16,6 +18,16 @@ apiValidation {
 }
 
 kotlin {
+  metadata {
+    compilations.configureEach {
+      compileTaskProvider.configure {
+        if (it instanceof KotlinCompileCommon) {
+          moduleName = "${project.group}:${project.name}_$name"
+        }
+      }
+    }
+  }
+
   applyDefaultHierarchyTemplate {
     it.common {
       it.group("nonJvm") {


### PR DESCRIPTION
There is an issue in the K2 compiler where the name of the generated Klib can sometimes not be unique which causes a clash when compiling direct or transitive dependencies. This is particularly problematic when using Compose Multiplatform alongside SQLDelight as the collision breaks any Compose runtime import.

Reported compilation error (particularly on native):
```w: KLIB resolver: The same 'unique_name=runtime_commonMain' found in more than one library: .../build/kotlinTransformedMetadataLibraries/commonMain/org.jetbrains.compose.runtime-runtime-1.7.1-commonMain-9pDeVQ.klib, .../build/kotlinTransformedMetadataLibraries/nativeMain/app.cash.sqldelight-runtime-2.0.2-commonMain-lSMntQ.klib```

Tracked Issues:
https://youtrack.jetbrains.com/issue/KT-69701/Gradle-module-name-is-passed-inconsistently-to-different-types-of-compilations
https://youtrack.jetbrains.com/issue/KT-66568/w-KLIB-resolver-The-same-uniquename...-found-in-more-than-one-library

The fix here is taken from the recommendation of the JetBrains team mentioned in the aforementioned YouTrack issues. This same fix could be applied to other modules, but the `runtime` module was the critical module I needed to fix for my projects.