### PR TITLE
Compiler: Improve error message such that path links are clickable with the correct line & char position.

### DIFF
--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/core/SqlDelightEnvironment.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/core/SqlDelightEnvironment.kt
@@ -219,7 +219,7 @@ class SqlDelightEnvironment(
   }
 
   private fun errorMessage(element: PsiElement, message: String): String =
-    "${element.containingFile.virtualFile.path}: (${element.lineStart}, ${element.charPositionInLine}): $message\n${detailText(element)}"
+    "${element.containingFile.virtualFile.path}:${element.lineStart}:${element.charPositionInLine} $message\n${detailText(element)}"
 
   private fun detailText(element: PsiElement) = try {
     val context = context(element) ?: element

--- a/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/integrations/VariantTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/integrations/VariantTest.kt
@@ -21,7 +21,7 @@ class VariantTest {
       .buildAndFail()
     assertThat(result.output).contains(
       """
-      MainTable.sq: (8, 12): No column found with name some_column1
+      MainTable.sq:8:12 No column found with name some_column1
       8    SELECT _id, some_column1
                        ^^^^^^^^^^^^
       9    FROM some_table
@@ -49,7 +49,7 @@ class VariantTest {
       .buildAndFail()
     assertThat(result.output).contains(
       """
-      src/minApi21DemoDebug/sqldelight/com/sample/demo/debug/DemoDebug.sq: (8, 5): No table found with name full_table
+      src/minApi21DemoDebug/sqldelight/com/sample/demo/debug/DemoDebug.sq:8:5 No table found with name full_table
       7    SELECT *
       8    FROM full_table
                 ^^^^^^^^^^

--- a/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/tests/FailureTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/tests/FailureTest.kt
@@ -18,7 +18,7 @@ class FailureTest {
     assertThat(output.output).contains("Compiling with dialect app.cash.sqldelight.dialects.sqlite_3_18.SqliteDialect")
     assertThat(output.output).contains(
       """
-      |NoPackage.sq: (1, 0): SqlDelight files must be placed in a package directory.
+      |NoPackage.sq:1:0 SqlDelight files must be placed in a package directory.
       |1    CREATE TABLE test (
       |2      value TEXT
       |3    );
@@ -37,7 +37,7 @@ class FailureTest {
 
     assertThat(output.output).contains(
       """
-      |Test1.sq: (2, 7): <type name real> expected, got 'BIGINT'
+      |Test1.sq:2:7 <type name real> expected, got 'BIGINT'
       |1    CREATE TABLE test1(
       |2    	value	BIGINT
       |     	     	^^^^^^

--- a/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/tests/MigrationTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/tests/MigrationTest.kt
@@ -140,7 +140,7 @@ class MigrationTest {
 
     assertThat(output.output).contains(
       """
-      |1.sqm: (1, 5): TABLE expected, got 'TABE'
+      |1.sqm:1:5 TABLE expected, got 'TABE'
       |1    ALTER TABE test ADD COLUMN value2 TEXT
       """.trimMargin(),
     )
@@ -154,7 +154,7 @@ class MigrationTest {
 
     assertThat(output.output).contains(
       """
-      |1.sqm: (5, 22): No column found with name new_column
+      |1.sqm:5:22 No column found with name new_column
       |5    INSERT INTO test (id, new_column)
       |                           ^^^^^^^^^^
       |6    VALUES ("hello", "world")
@@ -240,7 +240,7 @@ class MigrationTest {
       .withArguments("clean", "generateSqlDelightInterface", "--stacktrace", "--debug")
       .buildAndFail()
 
-    assertThat(output.output).contains("1.sqm: (1, 12): No table found with name test")
+    assertThat(output.output).contains("1.sqm:1:12 No table found with name test")
   }
 
   @Test fun `compilation succeeds when verifyMigrations is set to false but the migrations are incomplete`() {


### PR DESCRIPTION
You can click on it from the Terminal but it does not get the correct line/offset.

<img width="589" alt="Screenshot 2025-01-05 at 20 13 05" src="https://github.com/user-attachments/assets/db2b5ab8-2d8a-4867-bba2-df28188d7a2a" />

I don't know how many times I've clicked on it and always landing on the very first line. The formatting is also consistent now with the Kotlin Compiler:

<img width="529" alt="Screenshot 2025-01-05 at 20 14 14" src="https://github.com/user-attachments/assets/077d914b-2461-411d-bf3d-ec406a9765f2" />
