### PR TITLE
Fix Postgresql to_json

### DIFF
--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
@@ -295,6 +295,8 @@ class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : TypeRes
     }
     is PostgreSqlAtTimeZoneOperator -> IntermediateType(TEXT)
     is PostgreSqlExtensionExpr -> when {
+      jsonFunctionStmt != null -> IntermediateType(PostgreSqlType.JSON)
+
       arrayAggStmt != null -> {
         val typeForArray = (arrayAggStmt as AggregateExpressionMixin).expr.postgreSqlType() // same as resolvedType(expr)
         arrayIntermediateType(typeForArray)

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -438,7 +438,7 @@ compound_select_stmt ::= [ {with_clause} ] {select_stmt}  ( {compound_operator} 
   override = true
 }
 
-extension_expr ::= extract_temporal_expression | double_colon_cast_operator_expression | contains_operator_expression | at_time_zone_operator_expression | regex_match_operator_expression | match_operator_expression | array_agg_stmt| string_agg_stmt | json_expression | boolean_not_expression | window_function_expr {
+extension_expr ::= extract_temporal_expression | double_colon_cast_operator_expression | contains_operator_expression | at_time_zone_operator_expression | regex_match_operator_expression | match_operator_expression | json_function_stmt | array_agg_stmt| string_agg_stmt | json_expression | boolean_not_expression | window_function_expr {
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlExtensionExprImpl"
   implements = "com.alecstrong.sql.psi.core.psi.SqlExtensionExpr"
   override = true
@@ -596,6 +596,8 @@ truncate_descendant ::= {table_name} ['*'] ( COMMA {table_name} ['*'] ) *
 truncate_option ::= truncate_option_identity | truncate_option_cascade
 truncate_option_identity ::= ( 'RESTART' | 'CONTINUE' ) 'IDENTITY'
 truncate_option_cascade ::=  'CASCADE' | 'RESTRICT'
+
+json_function_stmt ::= ( 'row_to_json' | 'json_agg' | 'to_json' | 'to_jsonb' ) LP ( {table_alias} | {table_name} ) RP
 
 string_agg_stmt ::= 'string_agg' LP [ ALL | DISTINCT ] <<expr '-1'>> COMMA string_literal [ ORDER BY {ordering_term} ( COMMA {ordering_term} ) * ] RP
 [ 'FILTER' LP WHERE <<expr '-1'>> RP ] {

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/json_functions/Test.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/json_functions/Test.s
@@ -1,6 +1,7 @@
 CREATE TABLE myTable(
     data JSON NOT NULL,
-    datab JSONB NOT NULL
+    datab JSONB NOT NULL,
+    t TEXT NOT NULL
 );
 
 SELECT
@@ -24,3 +25,23 @@ FROM myTable;
 
 SELECT data ->> 'a', datab -> 'b', data #> '{aa}', datab #>> '{bb}', datab || datab, datab - 'b', datab - 1, datab @@ '$.b[*] > 0'
 FROM myTable;
+
+SELECT row_to_json(myTable) FROM myTable;
+
+SELECT json_agg(myTable) FROM myTable;
+
+SELECT to_json(myTable) FROM myTable;
+
+SELECT to_jsonb(myTable.t) FROM myTable;
+
+WITH myTable_cte AS (
+  SELECT t FROM myTable
+)
+SELECT row_to_json(myTable_cte) FROM myTable_cte;
+
+SELECT to_jsonb('Hello World'::text);
+
+SELECT row_to_json(r)
+FROM (
+  SELECT t FROM myTable
+) r;

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Json.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Json.sq
@@ -1,3 +1,8 @@
+CREATE TABLE TestJsonFunc(
+    id INTEGER NOT NULL,
+    t TEXT NOT NULL
+);
+
 CREATE TABLE TestJson(
   data JSON NOT NULL,
   datab JSONB NOT NULL,
@@ -56,3 +61,14 @@ selectJsonbContains:
 SELECT *
 FROM TestJson
 WHERE datab ?? ?;
+
+insertJsonFunc:
+INSERT INTO TestJsonFunc (id, t) VALUES (?, ?);
+
+selectJsonFunc:
+SELECT to_json(tjf), to_json(tjf.t), to_jsonb(tjf), row_to_json(tjf)
+FROM TestJsonFunc tjf
+WHERE tjf.id = ?;
+
+selectJsonAgg:
+SELECT json_agg(TestJsonFunc) FROM TestJsonFunc;

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
@@ -831,6 +831,17 @@ class PostgreSqlTest {
   }
 
   @Test
+  fun testSelectJsonFuncs() {
+    database.jsonQueries.insertJsonFunc(1, "a")
+    with(database.jsonQueries.selectJsonFunc(1).executeAsOne()) {
+      assertThat(expr).isEqualTo("""{"id":1,"t":"a"}""")
+      assertThat(to_json).isEqualTo(""""a"""")
+      assertThat(expr_).isEqualTo("""{"t": "a", "id": 1}""")
+      assertThat(expr__).isEqualTo("""{"id":1,"t":"a"}""")
+    }
+  }
+
+  @Test
   fun testUpdateSetFromId() {
     database.updatesQueries.insertTest(31)
     database.updatesQueries.insertTest2("X")


### PR DESCRIPTION
🚧 💔 Fix some of the existing JSON functions that use table/alias references. Currently broken.

e.g returns json representation of row tuples or value

```sql
SELECT row_to_json(myTable) FROM myTable;

SELECT json_agg(myTable) FROM myTable;

SELECT to_json(myTable) FROM myTable;

SELECT to_jsonb(myTable.t) FROM myTable;

SELECT to_jsonb('Hello World'::text);

WITH myTable_cte AS (
  SELECT t FROM myTable
)
SELECT row_to_json(myTable_cte) FROM myTable_cte;
```

* Add a rule `json_function_stmt` to match table/aliases on functions
  * functions like `to_json` use either a column or table  - the function resolver will stay the same
* Add fixture tests
* Add integration test

TODO - create an issue for this PR