### PR TITLE
paging refresh initial load fix

### DIFF
--- a/extensions/androidx-paging3/src/commonMain/kotlin/app/cash/sqldelight/paging3/OffsetQueryPagingSource.kt
+++ b/extensions/androidx-paging3/src/commonMain/kotlin/app/cash/sqldelight/paging3/OffsetQueryPagingSource.kt
@@ -54,7 +54,7 @@ internal class OffsetQueryPagingSource<RowType : Any>(
       val offset = when (params) {
         is PagingSourceLoadParamsPrepend<*> -> maxOf(0, key - params.loadSize)
         is PagingSourceLoadParamsAppend<*> -> key
-        is PagingSourceLoadParamsRefresh<*> -> if (key >= count) maxOf(0, count - params.loadSize) else key
+        is PagingSourceLoadParamsRefresh<*> -> if (key >= count - params.loadSize) maxOf(0, count - params.loadSize) else key
         else -> error("Unknown PagingSourceLoadParams ${params::class}")
       }
       val data = queryProvider(limit, offset)

--- a/extensions/androidx-paging3/src/commonTest/kotlin/app/cash/sqldelight/paging3/OffsetQueryPagingSourceTest.kt
+++ b/extensions/androidx-paging3/src/commonTest/kotlin/app/cash/sqldelight/paging3/OffsetQueryPagingSourceTest.kt
@@ -163,6 +163,15 @@ abstract class BaseOffsetQueryPagingSourceTest : DbTest {
   }
 
   @Test
+  fun invalidInitialKey_keyOnLastPage_returnsLastPage() = runDbTest {
+    insertItems(ITEMS_LIST)
+    val result = pagingSource.refresh(key = 90) as PagingSourceLoadResultPage<Int, TestItem>
+
+    // should load the last page
+    assertContentEquals(ITEMS_LIST.subList(85, 100), result.data)
+  }
+
+  @Test
   fun invalidInitialKey_negativeKey() = runDbTest {
     insertItems(ITEMS_LIST)
     // should throw error when initial key is negative


### PR DESCRIPTION
If items are removed then the initial key for a refresh may be close enough to the end of the list that fewer than a screens-worth of items may be loaded causing the UI to jump. Changed to handle similarly to the case where the initial key larger than count and load loadSize items from the end.