### PR TITLE
Fix SqlDelightModule type resolver order

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/SqlDelightFile.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/SqlDelightFile.kt
@@ -45,11 +45,11 @@ abstract class SqlDelightFile(
     get() = SqlDelightProjectService.getInstance(project).generateAsync
 
   internal val typeResolver: TypeResolver by lazy {
-    var parentResolver: TypeResolver = AnsiSqlTypeResolver
+    var resolver: TypeResolver = dialect.typeResolver(AnsiSqlTypeResolver)
     ServiceLoader.load(SqlDelightModule::class.java, dialect::class.java.classLoader).forEach {
-      parentResolver = it.typeResolver(parentResolver)
+      resolver = it.typeResolver(resolver)
     }
-    dialect.typeResolver(parentResolver)
+    resolver
   }
 
   val packageName: String? by lazy {


### PR DESCRIPTION
Issue when looking into SqlDelightModules for potential use with PostgreSql Extensions - noticed that the typeResolver order is incorrect when loading a module `DialectTypeResolver -> ModuleTypeResolver -> AnsiTypeResolver` .

Currently it worked for Sqlite JsonModule as only added functions and not any types 

Fix returns the typeResolver and parent resolver(s) composed of either:

`DialectTypeResolver -> AnsiTypeResolver` - no SqlDelightModule

`ModuleTypeResolver -> DialectTypeResolver -> AnsiTypeResolver` - with SqlDelightModule

This ensures that the Module TypeResolver methods are called first and can delegate to the dialect parent resolver for any inherited types and then the Ansi Resolver