### PR TITLE
Add bindTimestamp with non-default Calendar to JdbcPreparedStatement

### DIFF
--- a/drivers/jdbc-driver/src/main/kotlin/app/cash/sqldelight/driver/jdbc/JdbcDriver.kt
+++ b/drivers/jdbc-driver/src/main/kotlin/app/cash/sqldelight/driver/jdbc/JdbcDriver.kt
@@ -279,12 +279,12 @@ class JdbcPreparedStatement(
     preparedStatement.setTime(index, date)
   }
 
-  fun bindTimestamp(index: Int, timestamp: java.sql.Timestamp?) {
-    preparedStatement.setTimestamp(index, timestamp)
-  }
-
-  fun bindTimestamp(index: Int, timestamp: java.sql.Timestamp?, calendar: java.util.Calendar) {
-    preparedStatement.setTimestamp(index, timestamp, calendar)
+  fun bindTimestamp(index: Int, timestamp: java.sql.Timestamp?, calendar: java.util.Calendar? = null) {
+    if (calendar == null) {
+      preparedStatement.setTimestamp(index, timestamp)
+    } else {
+      preparedStatement.setTimestamp(index, timestamp, calendar)
+    }
   }
 
   fun <R> executeQuery(mapper: (SqlCursor) -> R): R {

--- a/drivers/jdbc-driver/src/main/kotlin/app/cash/sqldelight/driver/jdbc/JdbcDriver.kt
+++ b/drivers/jdbc-driver/src/main/kotlin/app/cash/sqldelight/driver/jdbc/JdbcDriver.kt
@@ -272,18 +272,18 @@ class JdbcPreparedStatement(
   }
 
   fun bindDate(index: Int, date: java.sql.Date?) {
-    preparedStatement.setDate(index, date)
+    preparedStatement.setDate(index + 1, date)
   }
 
   fun bindTime(index: Int, date: java.sql.Time?) {
-    preparedStatement.setTime(index, date)
+    preparedStatement.setTime(index + 1, date)
   }
 
   fun bindTimestamp(index: Int, timestamp: java.sql.Timestamp?, calendar: java.util.Calendar? = null) {
     if (calendar == null) {
-      preparedStatement.setTimestamp(index, timestamp)
+      preparedStatement.setTimestamp(index + 1, timestamp)
     } else {
-      preparedStatement.setTimestamp(index, timestamp, calendar)
+      preparedStatement.setTimestamp(index + 1, timestamp, calendar)
     }
   }
 

--- a/drivers/jdbc-driver/src/main/kotlin/app/cash/sqldelight/driver/jdbc/JdbcDriver.kt
+++ b/drivers/jdbc-driver/src/main/kotlin/app/cash/sqldelight/driver/jdbc/JdbcDriver.kt
@@ -283,6 +283,10 @@ class JdbcPreparedStatement(
     preparedStatement.setTimestamp(index, timestamp)
   }
 
+  fun bindTimestamp(index: Int, timestamp: java.sql.Timestamp?, calendar: java.util.Calendar) {
+    preparedStatement.setTimestamp(index, timestamp, calendar)
+  }
+
   fun <R> executeQuery(mapper: (SqlCursor) -> R): R {
     try {
       return preparedStatement.executeQuery()


### PR DESCRIPTION
The suggested (See: https://stackoverflow.com/a/6627999) way to save Instant into Postgresql with JDBC is:

```
val instant = java.time.Instant.now()
val ts = java.sql.Timestamp.from(instant);
val tzUTC = java.util.Calendar.getInstance(TimeZone.getTimeZone("UTC"));
ps.setTimestamp(col, ts, tzUTC);   // column is TIMESTAMPTZ!
```

Currently it can't be done with JdbcPreparedStatement.

This PR is meant to improve this aspect of JdbcPreparedStatement.