### PR TITLE
Use SPDX identifier in POMs

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,8 +7,8 @@ POM_SCM_URL=https://github.com/sqldelight/sqldelight/
 POM_SCM_CONNECTION=scm:git:git://github.com/sqldelight/sqldelight.git
 POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/sqldelight/sqldelight.git
 
-POM_LICENCE_NAME=The Apache Software License, Version 2.0
-POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
+POM_LICENCE_NAME=Apache-2.0
+POM_LICENCE_URL=https://www.apache.org/licenses/LICENSE-2.0.txt
 POM_LICENCE_DIST=repo
 
 POM_DEVELOPER_ID=square


### PR DESCRIPTION
This replaces the custom name with an SPDX identifier to enable tooling to automatically detect the correct license. Using an SPDX identifier is recommended [by the official Maven documentation](https://maven.apache.org/pom.html#Licenses).

See https://spdx.org/licenses/Apache-2.0.html