### PR TITLE
Support PostgreSql UnNest Array to rows 

### DIFF
--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -453,6 +453,41 @@ join_operator ::= ( COMMA [ lateral ]
   override = true
 }
 
+unnest_table_function ::= 'unnest' {
+  mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.TableFunctionNameMixin"
+  implements = [
+         "com.alecstrong.sql.psi.core.psi.NamedElement";
+         "com.alecstrong.sql.psi.core.psi.SqlCompositeElement"
+       ]
+}
+
+table_function_column_alias ::= ID | STRING {
+  mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.TableFunctionColumnAliasMixin"
+  implements = [
+       "com.alecstrong.sql.psi.core.psi.NamedElement";
+       "com.alecstrong.sql.psi.core.psi.SqlCompositeElement"
+     ]
+}
+
+table_function_table_alias ::= ID | STRING {
+ mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.TableFunctionTableAliasMixin"
+  implements = [
+       "com.alecstrong.sql.psi.core.psi.NamedElement";
+       "com.alecstrong.sql.psi.core.psi.SqlCompositeElement"
+     ]
+}
+
+table_function_alias_name ::= table_function_table_alias [ LP table_function_column_alias ( COMMA table_function_column_alias ) * RP ]
+
+table_or_subquery ::= ( unnest_table_function LP <<expr '-1'>> ( COMMA <<expr '-1'>> ) * RP [ AS table_function_alias_name ]
+                      | [ {database_name} DOT ] {table_name} [ [ AS ] {table_alias} ] [ INDEXED BY {index_name} | NOT INDEXED ]
+                      | LP ( {table_or_subquery} ( COMMA {table_or_subquery} ) * | {join_clause} ) RP
+                      | LP {compound_select_stmt} RP [ [ AS ] {table_alias} ] ) {
+  mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.TableOrSubqueryMixin"
+  implements = "com.alecstrong.sql.psi.core.psi.SqlTableOrSubquery"
+  override = true
+}
+
 join_clause ::= {table_or_subquery} ( {join_operator} {table_or_subquery} [ {join_constraint} ] ) * {
   mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.SqlJoinClauseMixin"
   override = true

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/TableFunctionColumnAliasMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/TableFunctionColumnAliasMixin.kt
@@ -1,0 +1,45 @@
+package app.cash.sqldelight.dialects.postgresql.grammar.mixins
+
+import app.cash.sqldelight.dialect.api.TableFunctionRowType
+import app.cash.sqldelight.dialects.postgresql.grammar.PostgreSqlParser
+import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlTableFunctionAliasName
+import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlTableFunctionColumnAlias
+import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlTypeName
+import com.alecstrong.sql.psi.core.psi.SqlColumnDef
+import com.alecstrong.sql.psi.core.psi.SqlColumnExpr
+import com.alecstrong.sql.psi.core.psi.SqlNamedElementImpl
+import com.alecstrong.sql.psi.core.psi.SqlTypeName
+import com.intellij.lang.ASTNode
+import com.intellij.lang.PsiBuilder
+
+/**
+ * Return the columns data types (e.g. TEXT[]) as table row types (e.g. TEXT) by zipping sqldefcolumns and row alias columns together
+ * and finding the current node. e.g. zip these nodes - UNNEST(a, b) AS x(y, z).
+ * Create a delegate of PostgreSqlTypeName to remove the `[]` from the columnType node so the resolver will create the non-array table row type
+ */
+internal abstract class TableFunctionColumnAliasMixin(
+  node: ASTNode,
+) : SqlNamedElementImpl(node),
+  TableFunctionRowType {
+  override fun columnType(): SqlTypeName {
+    val column = parent.parent.children.filterIsInstance<SqlColumnExpr>()
+      .map { (it.columnName.reference!!.resolve()!!.parent as SqlColumnDef).columnType.typeName }
+      .zip(
+        parent.parent.children.filterIsInstance<PostgreSqlTableFunctionAliasName>()
+          .flatMap { it.children.filterIsInstance<PostgreSqlTableFunctionColumnAlias>() },
+      )
+      .first { it.second.node == node }
+    return TableRowSqlTypeName(column.first as PostgreSqlTypeName)
+  }
+
+  override val parseRule: (PsiBuilder, Int) -> Boolean = PostgreSqlParser::table_function_column_alias_real
+}
+
+/**
+ * Delegate that returns single node column type without "[]" for resolving to non-array Intermediate type
+ */
+private class TableRowSqlTypeName(private val columnSqlTypeName: PostgreSqlTypeName) : PostgreSqlTypeName by columnSqlTypeName {
+  override fun getNode(): ASTNode {
+    return columnSqlTypeName.node.firstChildNode // take data type and ignore last nodes "[" "]"
+  }
+}

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/TableFunctionNameMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/TableFunctionNameMixin.kt
@@ -1,0 +1,13 @@
+package app.cash.sqldelight.dialects.postgresql.grammar.mixins
+
+import app.cash.sqldelight.dialects.postgresql.grammar.PostgreSqlParser
+import com.alecstrong.sql.psi.core.psi.SqlNamedElementImpl
+import com.intellij.lang.ASTNode
+import com.intellij.lang.PsiBuilder
+
+internal abstract class TableFunctionNameMixin(
+  node: ASTNode,
+) : SqlNamedElementImpl(node) {
+
+  override val parseRule: (builder: PsiBuilder, level: Int) -> Boolean = PostgreSqlParser::unnest_table_function_real
+}

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/TableFunctionTableAliasMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/TableFunctionTableAliasMixin.kt
@@ -8,6 +8,19 @@ internal abstract class TableFunctionTableAliasMixin(
   node: ASTNode,
 ) : SqlTableAliasImpl(node) {
   override fun source(): PsiElement {
-    return (parent.parent.parent as SqlJoinClauseMixin).queryExposed().first().table!!
+    // return (parent.parent.parent as SqlJoinClauseMixin).queryExposed().first().table!!
+    return (parent.parent.parent as SqlJoinClauseMixin).tablesAvailable(this).map { it.tableName }.first()
   }
 }
+
+//
+//
+// //return (parent.parent.parent as SqlJoinClauseMixin).queryExposed().first().table!!
+// val tableOrSubquery = PsiTreeUtil.getParentOfType(this, PostgreSqlTableOrSubquery::class.java)
+// if (tableOrSubquery != null && tableOrSubquery.unnestTableFunction != null) {
+//  // Return the UNNEST function itself as the source
+//  return tableOrSubquery.unnestTableFunction!!
+// }
+//
+// // Fallback to default implementation if not in an UNNEST context
+// return this

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/TableFunctionTableAliasMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/TableFunctionTableAliasMixin.kt
@@ -1,0 +1,13 @@
+package app.cash.sqldelight.dialects.postgresql.grammar.mixins
+
+import com.alecstrong.sql.psi.core.psi.impl.SqlTableAliasImpl
+import com.intellij.lang.ASTNode
+import com.intellij.psi.PsiElement
+
+internal abstract class TableFunctionTableAliasMixin(
+  node: ASTNode,
+) : SqlTableAliasImpl(node) {
+  override fun source(): PsiElement {
+    return (parent.parent.parent as SqlJoinClauseMixin).queryExposed().first().table!!
+  }
+}

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/TableFunctionTableAliasMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/TableFunctionTableAliasMixin.kt
@@ -8,19 +8,6 @@ internal abstract class TableFunctionTableAliasMixin(
   node: ASTNode,
 ) : SqlTableAliasImpl(node) {
   override fun source(): PsiElement {
-    // return (parent.parent.parent as SqlJoinClauseMixin).queryExposed().first().table!!
-    return (parent.parent.parent as SqlJoinClauseMixin).tablesAvailable(this).map { it.tableName }.first()
+    return (parent.parent.parent as SqlJoinClauseMixin).tablesAvailable(this).map { it.tableName }.first() // TODO fix
   }
 }
-
-//
-//
-// //return (parent.parent.parent as SqlJoinClauseMixin).queryExposed().first().table!!
-// val tableOrSubquery = PsiTreeUtil.getParentOfType(this, PostgreSqlTableOrSubquery::class.java)
-// if (tableOrSubquery != null && tableOrSubquery.unnestTableFunction != null) {
-//  // Return the UNNEST function itself as the source
-//  return tableOrSubquery.unnestTableFunction!!
-// }
-//
-// // Fallback to default implementation if not in an UNNEST context
-// return this

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/TableOrSubqueryMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/TableOrSubqueryMixin.kt
@@ -1,0 +1,77 @@
+package app.cash.sqldelight.dialects.postgresql.grammar.mixins
+
+import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlTableFunctionAliasName
+import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlTableFunctionColumnAlias
+import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlTableFunctionTableAlias
+import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlTableOrSubquery
+import com.alecstrong.sql.psi.core.ModifiableFileLazy
+import com.alecstrong.sql.psi.core.psi.LazyQuery
+import com.alecstrong.sql.psi.core.psi.QueryElement
+import com.alecstrong.sql.psi.core.psi.QueryElement.QueryResult
+import com.alecstrong.sql.psi.core.psi.SqlColumnName
+import com.alecstrong.sql.psi.core.psi.SqlExpr
+import com.alecstrong.sql.psi.core.psi.SqlJoinClause
+import com.alecstrong.sql.psi.core.psi.impl.SqlTableOrSubqueryImpl
+import com.intellij.lang.ASTNode
+import com.intellij.psi.PsiElement
+
+internal abstract class TableOrSubqueryMixin(node: ASTNode) :
+  SqlTableOrSubqueryImpl(node),
+  PostgreSqlTableOrSubquery {
+  private val queryExposed = ModifiableFileLazy lazy@{
+    if (unnestTableFunction != null) {
+      val tableFunctionAlias = children.filterIsInstance<PostgreSqlTableFunctionAliasName>().firstOrNull()
+      if (tableFunctionAlias != null) {
+        val tableFunctionAliasName = tableFunctionAlias.children.filterIsInstance<PostgreSqlTableFunctionTableAlias>().single()
+        val aliasColumns: List<PostgreSqlTableFunctionColumnAlias> = tableFunctionAlias.children.filterIsInstance<PostgreSqlTableFunctionColumnAlias>()
+        return@lazy listOf(
+          QueryResult(
+            table = tableFunctionAliasName,
+            columns = aliasColumns.map { QueryElement.QueryColumn(it) },
+          ),
+        )
+      }
+      return@lazy listOf(
+        QueryResult(
+          table = unnestTableFunction,
+          columns = children.filterIsInstance<SqlExpr>().map { QueryElement.QueryColumn(unnestTableFunction!!) },
+        ),
+      )
+    }
+    super.queryExposed()
+  }
+  override fun tablesAvailable(child: PsiElement): Collection<LazyQuery> {
+    if (unnestTableFunction != null) {
+      val tableFunctionAlias = children.filterIsInstance<PostgreSqlTableFunctionAliasName>().single()
+      val tableName = tableFunctionAlias.children.filterIsInstance<PostgreSqlTableFunctionTableAlias>().single()
+      return super.tablesAvailable(child) + LazyQuery(tableName) {
+        QueryResult(
+          tableName,
+          emptyList(),
+        )
+      }
+    } else {
+      return super.tablesAvailable(child)
+    }
+  }
+
+  override fun queryExposed() = queryExposed.forFile(containingFile)
+
+  override fun queryAvailable(child: PsiElement): Collection<QueryResult> {
+    if (child is SqlColumnName || child is PostgreSqlTableFunctionAliasName) {
+      return tablesAvailable(child).map {
+        val tableFunctionAlias = children.filterIsInstance<PostgreSqlTableFunctionAliasName>().single()
+        val tableName = tableFunctionAlias.children.filterIsInstance<PostgreSqlTableFunctionTableAlias>().single()
+        QueryResult(
+          tableName,
+          it.query.columns,
+        )
+      }
+    }
+    if (child is SqlExpr) {
+      val parent = parent as SqlJoinClause
+      return parent.tableOrSubqueryList.takeWhile { it != this }.flatMap { it.queryExposed() }
+    }
+    return super.queryAvailable(child)
+  }
+}

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/TableOrSubqueryMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/TableOrSubqueryMixin.kt
@@ -101,7 +101,7 @@ internal abstract class TableOrSubqueryMixin(node: ASTNode) :
         // In a JOIN, tables mentioned earlier are available to later parts
         val availableTables = parent.tableOrSubqueryList.takeWhile { it != this }
         if (availableTables.isNotEmpty()) {
-          return availableTables.flatMap { it.queryExposed() } + super.queryAvailable(child)
+          return availableTables.flatMap { it.queryExposed() }
         }
       }
 

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/TableOrSubqueryMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/TableOrSubqueryMixin.kt
@@ -18,60 +18,97 @@ import com.intellij.psi.PsiElement
 internal abstract class TableOrSubqueryMixin(node: ASTNode) :
   SqlTableOrSubqueryImpl(node),
   PostgreSqlTableOrSubquery {
+
   private val queryExposed = ModifiableFileLazy lazy@{
     if (unnestTableFunction != null) {
       val tableFunctionAlias = children.filterIsInstance<PostgreSqlTableFunctionAliasName>().firstOrNull()
+
       if (tableFunctionAlias != null) {
+        // Case with AS alias(columns) - e.g., UNNEST(business.locations) AS loc(zip)
         val tableFunctionAliasName = tableFunctionAlias.children.filterIsInstance<PostgreSqlTableFunctionTableAlias>().single()
-        val aliasColumns: List<PostgreSqlTableFunctionColumnAlias> = tableFunctionAlias.children.filterIsInstance<PostgreSqlTableFunctionColumnAlias>()
+        val aliasColumns = tableFunctionAlias.children.filterIsInstance<PostgreSqlTableFunctionColumnAlias>()
+
         return@lazy listOf(
           QueryResult(
             table = tableFunctionAliasName,
             columns = aliasColumns.map { QueryElement.QueryColumn(it) },
           ),
         )
-      }
-      return@lazy listOf(
-        QueryResult(
-          table = unnestTableFunction,
-          columns = children.filterIsInstance<SqlExpr>().map { QueryElement.QueryColumn(unnestTableFunction!!) },
-        ),
-      )
-    }
-    super.queryExposed()
-  }
-  override fun tablesAvailable(child: PsiElement): Collection<LazyQuery> {
-    if (unnestTableFunction != null) {
-      val tableFunctionAlias = children.filterIsInstance<PostgreSqlTableFunctionAliasName>().single()
-      val tableName = tableFunctionAlias.children.filterIsInstance<PostgreSqlTableFunctionTableAlias>().single()
-      return super.tablesAvailable(child) + LazyQuery(tableName) {
-        QueryResult(
-          tableName,
-          emptyList(),
+      } else {
+        // Case without column aliases - e.g., UNNEST(business.locations) AS r
+        return@lazy listOf(
+          QueryResult(
+            table = unnestTableFunction,
+            columns = listOf(QueryElement.QueryColumn(unnestTableFunction!!)),
+          ),
         )
       }
-    } else {
-      return super.tablesAvailable(child)
     }
+
+    // Default to parent implementation for non-UNNEST cases
+    super.queryExposed()
   }
 
   override fun queryExposed() = queryExposed.forFile(containingFile)
 
-  override fun queryAvailable(child: PsiElement): Collection<QueryResult> {
-    if (child is SqlColumnName || child is PostgreSqlTableFunctionAliasName) {
-      return tablesAvailable(child).map {
-        val tableFunctionAlias = children.filterIsInstance<PostgreSqlTableFunctionAliasName>().single()
+  override fun tablesAvailable(child: PsiElement): Collection<LazyQuery> {
+    if (unnestTableFunction != null) {
+      val tableFunctionAlias = children.filterIsInstance<PostgreSqlTableFunctionAliasName>().firstOrNull()
+
+      if (tableFunctionAlias != null) {
         val tableName = tableFunctionAlias.children.filterIsInstance<PostgreSqlTableFunctionTableAlias>().single()
-        QueryResult(
-          tableName,
-          it.query.columns,
-        )
+        val aliasColumns = tableFunctionAlias.children.filterIsInstance<PostgreSqlTableFunctionColumnAlias>()
+
+        // Include both parent tables and the UNNEST table
+        return super.tablesAvailable(child) + LazyQuery(tableName) {
+          QueryResult(
+            table = tableName,
+            columns = aliasColumns.map { QueryElement.QueryColumn(it) },
+          )
+        }
+      } else {
+        // Handle case when UNNEST is used without column aliases
+        return super.tablesAvailable(child) + LazyQuery(unnestTableFunction!!) {
+          QueryResult(
+            table = unnestTableFunction!!,
+            columns = listOf(QueryElement.QueryColumn(unnestTableFunction!!)),
+          )
+        }
       }
     }
-    if (child is SqlExpr) {
-      val parent = parent as SqlJoinClause
-      return parent.tableOrSubqueryList.takeWhile { it != this }.flatMap { it.queryExposed() }
+
+    return super.tablesAvailable(child)
+  }
+
+  override fun queryAvailable(child: PsiElement): Collection<QueryResult> {
+    // For column references within the UNNEST clause
+    if (child is SqlColumnName) {
+      // Return both the UNNEST table and any tables from outer scopes
+      return tablesAvailable(child).map { it.query }
     }
+
+    // For table alias references
+    if (child is PostgreSqlTableFunctionAliasName || child is PostgreSqlTableFunctionTableAlias) {
+      return tablesAvailable(child).map { it.query }
+    }
+
+    // For expressions within the UNNEST clause
+    if (child is SqlExpr) {
+      val parent = parent
+
+      // Handle expressions in JOIN clauses
+      if (parent is SqlJoinClause) {
+        // In a JOIN, tables mentioned earlier are available to later parts
+        val availableTables = parent.tableOrSubqueryList.takeWhile { it != this }
+        if (availableTables.isNotEmpty()) {
+          return availableTables.flatMap { it.queryExposed() } + super.queryAvailable(child)
+        }
+      }
+
+      // Include tables from outer scopes for subqueries
+      return super.queryAvailable(child)
+    }
+
     return super.queryAvailable(child)
   }
 }

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/unnest/Test.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/unnest/Test.s
@@ -42,3 +42,7 @@ WHERE EXISTS (
    SELECT 1
    FROM UNNEST(U.aa) AS r(a)
    WHERE LOWER(r.a) LIKE '%' || LOWER('a') || '%');
+
+SELECT DISTINCT b.*
+FROM U b
+JOIN LATERAL UNNEST(b.aa) AS r(a) ON r.a ILIKE '%' || 'a' || '%';

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/unnest/Test.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/unnest/Test.s
@@ -35,3 +35,10 @@ WHERE (a, b) IN (
   SELECT *
   FROM UNNEST(?::TEXT[], ?::INTEGER[]) AS d(a, b)
 );
+
+SELECT *
+FROM U
+WHERE EXISTS (
+   SELECT 1
+   FROM UNNEST(U.aa) AS r(a)
+   WHERE LOWER(r.a) LIKE '%' || LOWER('a') || '%');

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/unnest/Test.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/unnest/Test.s
@@ -1,0 +1,37 @@
+CREATE TABLE U (
+  aa TEXT[] NOT NULL,
+  bb INTEGER[] NOT NULL
+);
+
+CREATE TABLE P (
+  a TEXT NOT NULL,
+  b INTEGER NOT NULL
+);
+
+SELECT UNNEST('{1,2}'::INTEGER[]);
+
+SELECT *
+FROM UNNEST('{1,2}'::INTEGER[], '{"foo","bar","baz"}'::TEXT[]);
+
+SELECT UNNEST(aa)
+FROM U;
+
+SELECT r.a
+FROM U, UNNEST(aa) AS r(a);
+
+SELECT r.a, r.b
+FROM U, UNNEST(aa, bb) AS r(a, b);
+
+INSERT INTO P (a, b)
+SELECT * FROM UNNEST(?::TEXT[], ?::INTEGER[]) AS i(a, b);
+
+UPDATE P
+SET b = u.b
+FROM UNNEST(?::TEXT[], ?::INTEGER[]) AS u(a, b)
+WHERE P.a = u.a;
+
+DELETE FROM P
+WHERE (a, b) IN (
+  SELECT *
+  FROM UNNEST(?::TEXT[], ?::INTEGER[]) AS d(a, b)
+);

--- a/sqldelight-compiler/dialect/src/main/kotlin/app/cash/sqldelight/dialect/api/TableFunctionRowType.kt
+++ b/sqldelight-compiler/dialect/src/main/kotlin/app/cash/sqldelight/dialect/api/TableFunctionRowType.kt
@@ -1,0 +1,8 @@
+package app.cash.sqldelight.dialect.api
+
+import com.alecstrong.sql.psi.core.psi.SqlAnnotatedElement
+import com.alecstrong.sql.psi.core.psi.SqlTypeName
+
+interface TableFunctionRowType : SqlAnnotatedElement {
+  fun columnType(): SqlTypeName
+}

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/TreeUtil.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/TreeUtil.kt
@@ -26,6 +26,7 @@ import app.cash.sqldelight.dialect.api.IntermediateType
 import app.cash.sqldelight.dialect.api.PrimitiveType
 import app.cash.sqldelight.dialect.api.PrimitiveType.INTEGER
 import app.cash.sqldelight.dialect.api.PrimitiveType.TEXT
+import app.cash.sqldelight.dialect.api.TableFunctionRowType
 import app.cash.sqldelight.dialect.grammar.mixins.BindParameterMixin
 import com.alecstrong.sql.psi.core.psi.AliasElement
 import com.alecstrong.sql.psi.core.psi.SqlAnnotatedElement
@@ -82,6 +83,7 @@ internal fun PsiElement.type(): IntermediateType = when (this) {
       }
     }
   }
+  is TableFunctionRowType -> (sqFile().typeResolver.definitionType(columnType()).asNullable())
   is SqlExpr -> sqFile().typeResolver.resolvedType(this)
   is SqlResultColumn -> sqFile().typeResolver.resolvedType(expr!!)
   else -> throw IllegalStateException("Cannot get function type for psi type ${this.javaClass}")

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Unnest.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Unnest.sq
@@ -20,7 +20,7 @@ FROM Business, UNNEST(zipcodes, headcounts) AS location(zipcode, headcount);
 selectLocation:
 SELECT name, location.zipcode
 FROM Business, UNNEST(zipcodes) AS location(zipcode)
-  WHERE LOWER(location.zipcode) LIKE '%' || LOWER(:zipcode) || '%';
+  WHERE LOWER(location.zipcode) LIKE '%' || LOWER(:zipcode::TEXT) || '%';
 
 selectHeadcount:
 SELECT name, UNNEST(headcounts) AS headcount
@@ -53,4 +53,4 @@ FROM Business
 WHERE EXISTS (
    SELECT 1
    FROM UNNEST(Business.zipcodes) AS location(zipcode)
-   WHERE LOWER(location.zipcode) LIKE '%' || LOWER(?) || '%');
+   WHERE LOWER(location.zipcode) LIKE '%' || LOWER(?::TEXT) || '%');

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Unnest.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Unnest.sq
@@ -1,0 +1,48 @@
+CREATE TABLE Business(
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    zipcodes TEXT[] NOT NULL,
+    headcounts INTEGER[] NOT NULL
+);
+
+CREATE TABLE UserProfile (
+   name TEXT NOT NULL,
+   age INTEGER NOT NULL
+);
+
+insertBusiness:
+INSERT INTO Business (name, zipcodes, headcounts) VALUES (?, ?, ?);
+
+selectBusinesses:
+SELECT name, location.headcount, location.zipcode
+FROM Business, UNNEST(zipcodes, headcounts) AS location(zipcode, headcount);
+
+selectLocation:
+SELECT name, location.zipcode
+FROM Business, UNNEST(zipcodes) AS location(zipcode)
+  WHERE LOWER(location.zipcode) LIKE '%' || LOWER(:zipcode) || '%';
+
+selectHeadcount:
+SELECT name, UNNEST(headcounts) AS headcount
+FROM Business
+ORDER BY headcount DESC;
+
+selectUserProfiles:
+SELECT * FROM UserProfile ORDER BY name;
+
+insertUsers:
+INSERT INTO UserProfile (name, age)
+SELECT * FROM UNNEST(?::TEXT[], ?::INTEGER[]) AS u(name, age);
+
+updateUsersAge:
+UPDATE UserProfile
+SET age = updates.updated_age
+FROM UNNEST(?::TEXT[], ?::INTEGER[]) AS updates(name, updated_age)
+WHERE UserProfile.name = updates.name;
+
+deleteUsers:
+DELETE FROM UserProfile
+WHERE (name, age) IN (
+  SELECT *
+  FROM UNNEST(?::TEXT[], ?::INTEGER[]) AS u(name, age)
+);

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Unnest.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Unnest.sq
@@ -46,3 +46,11 @@ WHERE (name, age) IN (
   SELECT *
   FROM UNNEST(?::TEXT[], ?::INTEGER[]) AS u(name, age)
 );
+
+selectBusinessExists:
+SELECT *
+FROM Business
+WHERE EXISTS (
+   SELECT 1
+   FROM UNNEST(Business.zipcodes) AS location(zipcode)
+   WHERE LOWER(location.zipcode) LIKE '%' || LOWER(?) || '%');

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
@@ -1145,6 +1145,56 @@ class PostgreSqlTest {
   }
 
   @Test
+  fun testUnnestSelect() {
+    database.unnestQueries.insertBusiness("Ok Burger", arrayOf("A12345", "AB5522", "T74134"), arrayOf(76, 12, 18))
+    with(database.unnestQueries.selectHeadcount().executeAsList()) {
+      assertThat(first().headcount).isEqualTo(76)
+    }
+  }
+
+  @Test
+  fun testUnnestSelectFrom() {
+    database.unnestQueries.insertBusiness("Ok Burger", arrayOf("A12345", "AB5522", "T74134"), arrayOf(6, 12, 18))
+    with(database.unnestQueries.selectBusinesses().executeAsList()) {
+      assertThat(first().name).isEqualTo("Ok Burger")
+      assertThat(first().zipcode).isEqualTo("A12345")
+      assertThat(first().headcount).isEqualTo(6)
+    }
+    with(database.unnestQueries.selectLocation("AB5522").executeAsList()) {
+      assertThat(first().name).isEqualTo("Ok Burger")
+    }
+  }
+
+  @Test
+  fun testUnnestInsertSelect() {
+    database.unnestQueries.insertUsers(arrayOf("Aaaa", "Bbbb", "Cccc"), arrayOf(32, 21, 65))
+    with(database.unnestQueries.selectUserProfiles().executeAsList()) {
+      assertThat(first().name).isEqualTo("Aaaa")
+      assertThat(first().age).isEqualTo(32)
+    }
+  }
+
+  @Test
+  fun testUnnestUpdate() {
+    database.unnestQueries.insertUsers(arrayOf("Aaaa", "Bbbb", "Cccc"), arrayOf(32, 21, 65))
+    database.unnestQueries.updateUsersAge(arrayOf("Aaaa"), arrayOf(39))
+    with(database.unnestQueries.selectUserProfiles().executeAsList()) {
+      assertThat(first().name).isEqualTo("Aaaa")
+      assertThat(first().age).isEqualTo(39)
+    }
+  }
+
+  @Test
+  fun testUnnestDelete() {
+    database.unnestQueries.insertUsers(arrayOf("Aaaa", "Bbbb", "Cccc"), arrayOf(32, 21, 65))
+    database.unnestQueries.deleteUsers(arrayOf("Aaaa"), arrayOf(32))
+    with(database.unnestQueries.selectUserProfiles().executeAsList()) {
+      assertThat(first().name).isEqualTo("Bbbb")
+      assertThat(first().age).isEqualTo(21)
+    }
+  }
+
+  @Test
   fun testUnnestWhere() {
     database.unnestQueries.insertBusiness("Ok Burger", arrayOf("A12345", "AB5522", "T74134"), arrayOf(6, 12, 18))
     database.unnestQueries.insertBusiness("Donut Hut", arrayOf("N12345", "QB7536", "P31879"), arrayOf(6, 12, 18))

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
@@ -1143,4 +1143,13 @@ class PostgreSqlTest {
       assertThat(first()).isTrue()
     }
   }
+
+  @Test
+  fun testUnnestWhere() {
+    database.unnestQueries.insertBusiness("Ok Burger", arrayOf("A12345", "AB5522", "T74134"), arrayOf(6, 12, 18))
+    database.unnestQueries.insertBusiness("Donut Hut", arrayOf("N12345", "QB7536", "P31879"), arrayOf(6, 12, 18))
+    with(database.unnestQueries.selectBusinessExists("P31879").executeAsList()) {
+      assertThat(first().name).isEqualTo("Donut Hut")
+    }
+  }
 }


### PR DESCRIPTION
Support `Unnest` Function - expand an array to a set of rows

fixes #5346 

🪹 🏗️ Work
🚧 🪺 In Progress  

* Add "unnest" to PostgreSql.bnf
* Add mixins to help with column resolving as there are new aliases used by "unnest" in `FROM`
* Update PostresqResolver to handle converting Array<T> to T - this was not supported by IntermediateType
* Add TableFunctionRowType to allow new concept of nested type to row type - not an actual table
* Add fixture and integration tests

Prototype use project https://github.com/griffio/sqldelight-postgres-unnest

* PostgreSQL allows a function (e.g unnest) to be written directly as a member of the FROM list. Allows multiple arrays to be unnested
* SELECT unnest() allows a single array to be unnested

Examples:

Allows  "Array DML" - e.g bulk inserts, updates and deletes

```sql

CREATE TABLE Business(
    id SERIAL PRIMARY KEY,
    name TEXT NOT NULL,
    zipcodes TEXT[] NOT NULL,
    headcounts INTEGER[] NOT NULL
);

CREATE TABLE Users (
   name TEXT NOT NULL,
   age INTEGER NOT NULL
);

select:
SELECT name, location.headcount, location.zipcode
FROM Business, UNNEST(zipcodes, headcounts) AS location(zipcode, headcount);

counts:
SELECT name, UNNEST(headcounts) AS headcount
FROM Business
ORDER BY headcount DESC;

array:
SELECT unnest('{1,2}'::INTEGER);

insertUsers:
INSERT INTO Users (name, age)
SELECT * FROM UNNEST(?::TEXT[], ?::INTEGER[])  AS u(name, age); 
// currently must explicitly add alias columns due to wildcard expansion in SqlDelight

updateUsers:
UPDATE Users
SET age = updates.updated_age
FROM UNNEST(?::TEXT[], ?::INTEGER[]) AS updates(name, updated_age)
WHERE Users.name = updates.name;

deleteUsers:
DELETE FROM Users
WHERE (name, age) IN (
  SELECT *
  FROM UNNEST(?::TEXT[], ?::INTEGER[]) AS u(name, age)
);

selectLocations:
SELECT DISTINCT b.*
FROM Business b
JOIN LATERAL UNNEST(b.zipcodes) AS loc(zipcode) ON loc.zipcode ILIKE '%' || :query || '%';

selectBusinessExists:
SELECT *
FROM business
WHERE EXISTS (
    SELECT 1
    FROM unnest(locations) AS loc 
    WHERE lower(loc) LIKE '%' || LOWER(:query::TEXT) || '%'
);
```

* TODO
  * Add current limitations and problems 
    * PostgreSql allows functions declared after `FROM` e.g. `FROM upper('a')` or `FROM unnest(...)`
      * This is not supported in SqlDelight and is the actual issue 

