### PR TITLE
Support SqlDelight modules to implement PostgreSql extensions

### DIFF
--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlType.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlType.kt
@@ -10,7 +10,8 @@ import com.squareup.kotlinpoet.SHORT
 import com.squareup.kotlinpoet.STRING
 import com.squareup.kotlinpoet.TypeName
 
-internal enum class PostgreSqlType(override val javaType: TypeName) : DialectType {
+enum class PostgreSqlType(override val javaType: TypeName) : DialectType {
+  BIT(STRING),
   SMALL_INT(SHORT),
   INTEGER(INT),
   BIG_INT(LONG),
@@ -28,6 +29,7 @@ internal enum class PostgreSqlType(override val javaType: TypeName) : DialectTyp
 
   override fun prepareStatementBinder(columnIndex: CodeBlock, value: CodeBlock): CodeBlock {
     return when (this) {
+      BIT -> CodeBlock.of("bindString(%L, %L)\n", columnIndex, value)
       SMALL_INT -> CodeBlock.of("bindShort(%L, %L)\n", columnIndex, value)
       INTEGER -> CodeBlock.of("bindInt(%L, %L)\n", columnIndex, value)
       BIG_INT -> CodeBlock.of("bindLong(%L, %L)\n", columnIndex, value)
@@ -61,7 +63,7 @@ internal enum class PostgreSqlType(override val javaType: TypeName) : DialectTyp
         BIG_INT -> "$cursorName.getLong($columnIndex)"
         DATE, TIME, TIMESTAMP, TIMESTAMP_TIMEZONE, INTERVAL, UUID -> "$cursorName.getObject<%T>($columnIndex)"
         NUMERIC -> "$cursorName.getBigDecimal($columnIndex)"
-        JSON, TSVECTOR, XML -> "$cursorName.getString($columnIndex)"
+        BIT, JSON, TSVECTOR, XML -> "$cursorName.getString($columnIndex)"
       },
       javaType,
     )

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
@@ -48,7 +48,7 @@ import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.asTypeName
 
-class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : TypeResolver by parentResolver {
+open class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : TypeResolver by parentResolver {
   override fun definitionType(typeName: SqlTypeName): IntermediateType = with(typeName) {
     check(this is PostgreSqlTypeName)
     val type = IntermediateType(
@@ -250,6 +250,11 @@ class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : TypeRes
     }
   }
 
+  // dialects or modules would need to extend this if they add types that use operators in binaryExprChildTypesResolvingToBool
+  protected open fun booleanBinaryExprTypes(): Array<DialectType> {
+    return booleanBinaryExprTypes
+  }
+
   private fun SqlExpr.postgreSqlType(): IntermediateType = when (this) {
     is SqlIsExpr -> IntermediateType(BOOLEAN)
     is SqlBinaryExpr -> {
@@ -262,23 +267,7 @@ class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : TypeRes
             (this is SqlBinaryAddExpr || this is SqlBinaryMultExpr || this is SqlBinaryPipeExpr) &&
               exprListNullability.any { it }
           },
-          SMALL_INT,
-          PostgreSqlType.INTEGER,
-          INTEGER,
-          BIG_INT,
-          REAL,
-          PostgreSqlType.NUMERIC,
-          TEXT,
-          BLOB,
-          BOOLEAN,
-          DATE,
-          PostgreSqlType.UUID,
-          PostgreSqlType.INTERVAL,
-          PostgreSqlType.TIMESTAMP_TIMEZONE,
-          PostgreSqlType.TIMESTAMP,
-          PostgreSqlType.TIME,
-          PostgreSqlType.JSON,
-          PostgreSqlType.TSVECTOR,
+          typeOrder = booleanBinaryExprTypes(),
         )
       }
     }
@@ -343,6 +332,26 @@ class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : TypeRes
   }
 
   companion object {
+
+    private val booleanBinaryExprTypes: Array<DialectType> = arrayOf(
+      SMALL_INT,
+      PostgreSqlType.INTEGER,
+      INTEGER,
+      BIG_INT,
+      REAL,
+      PostgreSqlType.NUMERIC,
+      TEXT,
+      BLOB,
+      DATE,
+      PostgreSqlType.UUID,
+      PostgreSqlType.INTERVAL,
+      PostgreSqlType.TIMESTAMP_TIMEZONE,
+      PostgreSqlType.TIMESTAMP,
+      PostgreSqlType.TIME,
+      PostgreSqlType.JSON,
+      PostgreSqlType.TSVECTOR,
+      BOOLEAN, // is last as expected that boolean expression resolve to boolean
+    )
     private val binaryExprChildTypesResolvingToBool = TokenSet.create(
       SqlTypes.EQ,
       SqlTypes.EQ2,

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -157,6 +157,7 @@ default_constraint ::= [ NOT NULL | NULL ] DEFAULT (
 }
 
 type_name ::= (
+  bit_data_type |
   small_int_data_type |
   int_data_type |
   big_int_data_type |
@@ -222,6 +223,7 @@ generated_clause ::= GENERATED ( (ALWAYS AS LP <<expr '-1'>> RP 'STORED') | ( (A
   override = true
 }
 
+bit_data_type ::= 'BIT' [ LP {signed_number} RP ]
 small_int_data_type ::= 'SMALLINT' | 'INT2'
 int_data_type ::= 'INTEGER' | 'INT' | 'INT4'
 big_int_data_type ::= 'BIGINT' | 'INT8'


### PR DESCRIPTION
🐙 Use the SqlDelight module service loader (see [sqlite json-module](https://github.com/sqldelight/sqldelight/tree/master/dialects/sqlite/json-module) to implement Postgresql 3rd party extensions - rather than add in the  PostgreSql grammar or having to create a new sub dialect.

🧪 Example extension modules using these changes:

bm25 - text search - https://github.com/griffio/sqldelight-bm25-module-app
pgvector - vector embeddings - https://github.com/griffio/sqldelight-pgvector-module-app
postgis - ever popular - https://github.com/griffio/sqldelight-postgis-module-app

* Open `PostgreSqlTypeResolver` for inheritance to allow calling into subclasses - delegation is not enough 
* Make `PostgreSqlType` public for modules to access existing PostgreSql types
* Add `booleanBinaryExprTypes` as modules can add binary operator types
* Add BIT type - could make this a separate change - as used in a module