### PR TITLE
Fix sql-psi.0.5.0

### DIFF
--- a/dialects/hsql/src/main/kotlin/app/cash/sqldelight/dialects/hsql/grammar/hsql.bnf
+++ b/dialects/hsql/src/main/kotlin/app/cash/sqldelight/dialects/hsql/grammar/hsql.bnf
@@ -66,9 +66,9 @@ type_name ::= (
 }
 column_constraint ::= [ CONSTRAINT {identifier} ] (
   'AUTO_INCREMENT' |
-  PRIMARY KEY [ ASC | DESC ] {conflict_clause} |
-  NOT NULL {conflict_clause} |
-  UNIQUE {conflict_clause} |
+  PRIMARY KEY [ ASC | DESC ] [ {conflict_clause} ] |
+  NOT NULL [ {conflict_clause} ] |
+  UNIQUE [ {conflict_clause} ] |
   {check_constraint} |
   generated_clause |
   {default_constraint} |

--- a/dialects/mysql/src/main/kotlin/app/cash/sqldelight/dialects/mysql/grammar/MySql.bnf
+++ b/dialects/mysql/src/main/kotlin/app/cash/sqldelight/dialects/mysql/grammar/MySql.bnf
@@ -98,9 +98,9 @@ enum_set_type
 }
 column_constraint ::= [ CONSTRAINT {identifier} ] (
   'AUTO_INCREMENT' |
-  PRIMARY KEY [ ASC | DESC ] {conflict_clause} |
-  [ NOT ] NULL {conflict_clause} |
-  UNIQUE {conflict_clause} |
+  PRIMARY KEY [ ASC | DESC ] [ {conflict_clause} ] |
+  [ NOT ] NULL [ {conflict_clause} ] |
+  UNIQUE [ {conflict_clause} ] |
   {check_constraint} |
   default_constraint |
   COLLATE {collation_name} |
@@ -121,7 +121,7 @@ bind_parameter ::= DEFAULT | ( '?' | ':' {identifier} ) {
   override = true
 }
 table_constraint ::= [ CONSTRAINT {identifier} ] (
-  ( PRIMARY KEY | [ UNIQUE | 'FULLTEXT' ] KEY | [ UNIQUE | 'FULLTEXT' ] [ INDEX ] ) [{index_name}] LP {indexed_column} [ LP {signed_number} RP ] ( COMMA {indexed_column} [ LP {signed_number} RP ] ) * RP {conflict_clause} [comment_type] |
+  ( PRIMARY KEY | [ UNIQUE | 'FULLTEXT' ] KEY | [ UNIQUE | 'FULLTEXT' ] [ INDEX ] ) [{index_name}] LP {indexed_column} [ LP {signed_number} RP ] ( COMMA {indexed_column} [ LP {signed_number} RP ] ) * RP [ {conflict_clause} ] [comment_type] |
   {check_constraint} |
   FOREIGN KEY LP {column_name} ( COMMA {column_name} ) * RP {foreign_key_clause}
 ) {

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -128,9 +128,9 @@ overrides ::= type_name
   | literal_value
 
 column_constraint ::= [ CONSTRAINT {identifier} ] (
-  PRIMARY KEY [ ASC | DESC ] {conflict_clause} |
-  [ NOT ] NULL {conflict_clause} |
-  UNIQUE {conflict_clause} |
+  PRIMARY KEY [ ASC | DESC ] [ {conflict_clause} ] |
+  [ NOT ] NULL [ {conflict_clause} ] |
+  UNIQUE [ {conflict_clause} ] |
   {check_constraint} |
   generated_clause |
   default_constraint |
@@ -185,7 +185,7 @@ bind_parameter ::= DEFAULT | ( '?' | ':' {identifier} ) {
   override = true
 }
 table_constraint ::= [ CONSTRAINT {identifier} ] (
-  ( PRIMARY KEY | UNIQUE ) [{index_name}] LP {indexed_column} [ LP {signed_number} RP ] ( COMMA {indexed_column} [ LP {signed_number} RP ] ) * RP {conflict_clause} [comment_type] |
+  ( PRIMARY KEY | UNIQUE ) [{index_name}] LP {indexed_column} [ LP {signed_number} RP ] ( COMMA {indexed_column} [ LP {signed_number} RP ] ) * RP [ {conflict_clause} ] [comment_type] |
   {check_constraint} |
   FOREIGN KEY LP {column_name} ( COMMA {column_name} ) * RP {foreign_key_clause}
 ) {
@@ -481,7 +481,7 @@ frame_spec ::= ( 'RANGE' | 'ROWS' | 'GROUPS' )
   pin = 1
 }
 
-boolean_not_expression ::= NOT (boolean_literal | {column_name})
+boolean_not_expression ::= NOT ( {function_expr} | boolean_literal | {column_name} )
 
 boolean_literal ::= TRUE | FALSE
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ ktlint = "1.3.1"
 agp = "8.9.0"
 compileSdk = "35"
 minSdk = "21"
-sqlPsi = "0.4.9"
+sqlPsi = "0.5.0"
 testContainers = "1.20.6"
 moshi = "1.15.2"
 
@@ -65,8 +65,8 @@ intellij-utilEx = { module = "com.jetbrains.intellij.platform:util-ex", version.
 intellij-utilUi = { module = "com.jetbrains.intellij.platform:util-ui", version.ref = "idea" }
 intellij-util = { module = "com.jetbrains.intellij.platform:util", version.ref = "idea" }
 
-sqlPsi = { module = "com.alecstrong.sql.psi:core", version.ref = "sqlPsi" }
-sqlPsiEnvironment = { module = "com.alecstrong.sql.psi:environment", version.ref = "sqlPsi" }
+sqlPsi = { module = "app.cash.sql-psi:core", version.ref = "sqlPsi" }
+sqlPsiEnvironment = { module = "app.cash.sql-psi:environment", version.ref = "sqlPsi" }
 robolectric = { module = "org.robolectric:robolectric", version = "4.14.1" }
 rxJava2 = { module = "io.reactivex.rxjava2:rxjava", version = "2.2.21" }
 rxJava3 = { module = "io.reactivex.rxjava3:rxjava", version = "3.1.10" }

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/TreeUtil.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/TreeUtil.kt
@@ -46,7 +46,6 @@ import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiDirectory
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiNamedElement
-import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.tree.IElementType
 import com.intellij.psi.tree.TokenSet
 import com.intellij.psi.util.PsiTreeUtil
@@ -168,8 +167,8 @@ private fun PsiElement.rangesToReplace(): List<Pair<IntRange, String>> {
     )
   } else if (this is SqlModuleArgument && moduleArgumentDef?.columnDef != null && (parent as SqlCreateVirtualTableStmt).moduleName?.text?.lowercase() == "fts5") {
     val columnDef = moduleArgumentDef!!.columnDef!!
-    // If there is a space at the end of the constraints, preserve it.
-    val lengthModifier = if (columnDef.columnConstraintList.isNotEmpty() && columnDef.columnConstraintList.last()?.lastChild?.prevSibling is PsiWhiteSpace) 1 else 0
+    // If there is a space at the end of the column constraint "TEXT NOT NULL ", preserve it as this means it could have a "TEXT NOT NULL UNINDEXED" constraint
+    val lengthModifier = if (columnDef.columnConstraintList.isNotEmpty() && columnDef.columnConstraintList.last().text.endsWith(" ")) 1 else 0
     listOf(
       Pair(
         first = (columnDef.columnName.node.startOffset + columnDef.columnName.node.textLength) until


### PR DESCRIPTION
Fixes https://github.com/sqldelight/sql-psi/issues/665

Changes also work with sql-psi `0.4.9` 

Releasing the current master branch and taking the updated dependency in SqlDelight will cause some breaking errors that need to be fixed either in sql-psi and/or sqldelight

{conflict_clause} is now not optional https://github.com/sqldelight/sql-psi/pull/624/files
and breaks grammar - Could be reverted in sql-psi or this can be fixed in SqlDelight by updating the grammars here https://github.com/search?q=repo%3Asqldelight%2Fsqldelight%20conflict_clause&type=code adding [ {conflict_clause} ]

NOT function expr fails ansi fixture test in Postgresql caused by https://github.com/sqldelight/sql-psi/pull/639 - will look into - seems that https://github.com/sqldelight/sqldelight/blame/544d94275a1df7d4b23ee6b53b4ca7a7da7c7040/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf#L484 changing to boolean_not_expression ::= NOT ( {function_expr} | boolean_literal | {column_name} ) does the trick

Test failures in app.cash.sqldelight.core.util.TreeUtilTest rawSqlText  and app.cash.sqldelight.core.QueriesTypeTest - column name is changed erroneously - There is a trailing node that causes the lengthModifier to be 1 instead of 0 https://github.com/sqldelight/sqldelight/blob/544d94275a1df7d4b23ee6b53b4ca7a7da7c7040/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/TreeUtil.kt#L172 - easy to remove the lengthModifier in sqldelight code as tests then pass

The above fixes need to be actioned on sqldelight

Other than the above issues - locally sql-psi 0.5.0 dependency passes tests