### PR TITLE
Add option to execute code before a migration

### DIFF
--- a/drivers/android-driver/src/main/java/app/cash/sqldelight/driver/android/AndroidSqliteDriver.kt
+++ b/drivers/android-driver/src/main/java/app/cash/sqldelight/driver/android/AndroidSqliteDriver.kt
@@ -16,7 +16,7 @@ import androidx.sqlite.db.SupportSQLiteStatement
 import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
 import app.cash.sqldelight.Query
 import app.cash.sqldelight.Transacter
-import app.cash.sqldelight.db.AfterVersion
+import app.cash.sqldelight.db.MigrationCallback
 import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlCursor
 import app.cash.sqldelight.db.SqlDriver
@@ -198,7 +198,7 @@ class AndroidSqliteDriver private constructor(
 
   open class Callback(
     private val schema: SqlSchema<QueryResult.Value<Unit>>,
-    private vararg val callbacks: AfterVersion,
+    private vararg val callbacks: MigrationCallback,
   ) : SupportSQLiteOpenHelper.Callback(
     if (schema.version > Int.MAX_VALUE) error("Schema version is larger than Int.MAX_VALUE: ${schema.version}.") else schema.version.toInt(),
   ) {

--- a/drivers/driver-test/src/commonMain/kotlin/com/squareup/sqldelight/driver/test/DriverTest.kt
+++ b/drivers/driver-test/src/commonMain/kotlin/com/squareup/sqldelight/driver/test/DriverTest.kt
@@ -2,7 +2,7 @@ package com.squareup.sqldelight.driver.test
 
 import app.cash.sqldelight.Transacter
 import app.cash.sqldelight.TransacterImpl
-import app.cash.sqldelight.db.AfterVersion
+import app.cash.sqldelight.db.MigrationCallback
 import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlCursor
 import app.cash.sqldelight.db.SqlDriver
@@ -54,7 +54,7 @@ abstract class DriverTest {
       driver: SqlDriver,
       oldVersion: Long,
       newVersion: Long,
-      vararg callbacks: AfterVersion,
+      vararg callbacks: MigrationCallback,
     ) = QueryResult.Unit
   }
   private var transacter = AtomicReference<Transacter?>(null)

--- a/drivers/driver-test/src/commonMain/kotlin/com/squareup/sqldelight/driver/test/EphemeralTest.kt
+++ b/drivers/driver-test/src/commonMain/kotlin/com/squareup/sqldelight/driver/test/EphemeralTest.kt
@@ -1,7 +1,7 @@
 package com.squareup.sqldelight.driver.test
 
 import app.cash.sqldelight.Query
-import app.cash.sqldelight.db.AfterVersion
+import app.cash.sqldelight.db.MigrationCallback
 import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlCursor
 import app.cash.sqldelight.db.SqlDriver
@@ -44,7 +44,7 @@ abstract class EphemeralTest {
       driver: SqlDriver,
       oldVersion: Long,
       newVersion: Long,
-      vararg callbacks: AfterVersion,
+      vararg callbacks: MigrationCallback,
     ): QueryResult.Value<Unit> {
       // No-op.
       return QueryResult.Unit

--- a/drivers/driver-test/src/commonMain/kotlin/com/squareup/sqldelight/driver/test/QueryTest.kt
+++ b/drivers/driver-test/src/commonMain/kotlin/com/squareup/sqldelight/driver/test/QueryTest.kt
@@ -1,7 +1,7 @@
 package com.squareup.sqldelight.driver.test
 
 import app.cash.sqldelight.Query
-import app.cash.sqldelight.db.AfterVersion
+import app.cash.sqldelight.db.MigrationCallback
 import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlCursor
 import app.cash.sqldelight.db.SqlDriver
@@ -49,7 +49,7 @@ abstract class QueryTest {
           driver: SqlDriver,
           oldVersion: Long,
           newVersion: Long,
-          vararg callbacks: AfterVersion,
+          vararg callbacks: MigrationCallback,
         ): QueryResult.Value<Unit> {
           // No-op.
           return QueryResult.Unit

--- a/drivers/driver-test/src/commonMain/kotlin/com/squareup/sqldelight/driver/test/TransacterTest.kt
+++ b/drivers/driver-test/src/commonMain/kotlin/com/squareup/sqldelight/driver/test/TransacterTest.kt
@@ -1,7 +1,7 @@
 package com.squareup.sqldelight.driver.test
 
 import app.cash.sqldelight.TransacterImpl
-import app.cash.sqldelight.db.AfterVersion
+import app.cash.sqldelight.db.MigrationCallback
 import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.db.SqlSchema
@@ -27,7 +27,7 @@ abstract class TransacterTest {
           driver: SqlDriver,
           oldVersion: Long,
           newVersion: Long,
-          vararg callbacks: AfterVersion,
+          vararg callbacks: MigrationCallback,
         ): QueryResult.Value<Unit> = QueryResult.Unit
       },
     )

--- a/drivers/native-driver/src/nativeMain/kotlin/app/cash/sqldelight/driver/native/NativeSqlDatabase.kt
+++ b/drivers/native-driver/src/nativeMain/kotlin/app/cash/sqldelight/driver/native/NativeSqlDatabase.kt
@@ -2,8 +2,8 @@ package app.cash.sqldelight.driver.native
 
 import app.cash.sqldelight.Query
 import app.cash.sqldelight.Transacter
-import app.cash.sqldelight.db.AfterVersion
 import app.cash.sqldelight.db.Closeable
+import app.cash.sqldelight.db.MigrationCallback
 import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlCursor
 import app.cash.sqldelight.db.SqlDriver
@@ -118,7 +118,7 @@ class NativeSqliteDriver(
     name: String,
     maxReaderConnections: Int = 1,
     onConfiguration: (DatabaseConfiguration) -> DatabaseConfiguration = { it },
-    vararg callbacks: AfterVersion,
+    vararg callbacks: MigrationCallback,
   ) : this(
     configuration = DatabaseConfiguration(
       name = name,

--- a/drivers/native-driver/src/nativeTest/kotlin/com/squareup/sqldelight/drivers/native/LazyDriverBaseTest.kt
+++ b/drivers/native-driver/src/nativeTest/kotlin/com/squareup/sqldelight/drivers/native/LazyDriverBaseTest.kt
@@ -1,7 +1,7 @@
 package com.squareup.sqldelight.drivers.native
 
 import app.cash.sqldelight.TransacterImpl
-import app.cash.sqldelight.db.AfterVersion
+import app.cash.sqldelight.db.MigrationCallback
 import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.db.SqlSchema
@@ -70,7 +70,7 @@ abstract class LazyDriverBaseTest {
         driver: SqlDriver,
         oldVersion: Long,
         newVersion: Long,
-        vararg callbacks: AfterVersion,
+        vararg callbacks: MigrationCallback,
       ) = QueryResult.Unit
     }
   }

--- a/drivers/native-driver/src/nativeTest/kotlin/com/squareup/sqldelight/drivers/native/NativeDriverConcurrencyTest.kt
+++ b/drivers/native-driver/src/nativeTest/kotlin/com/squareup/sqldelight/drivers/native/NativeDriverConcurrencyTest.kt
@@ -1,7 +1,7 @@
 package com.squareup.sqldelight.drivers.native
 
 import app.cash.sqldelight.Query
-import app.cash.sqldelight.db.AfterVersion
+import app.cash.sqldelight.db.MigrationCallback
 import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlCursor
 import app.cash.sqldelight.db.SqlDriver
@@ -56,7 +56,7 @@ class NativeDriverConcurrencyTest {
           driver: SqlDriver,
           oldVersion: Long,
           newVersion: Long,
-          vararg callbacks: AfterVersion,
+          vararg callbacks: MigrationCallback,
         ): QueryResult.Value<Unit> {
           // No-op.
           return QueryResult.Unit

--- a/drivers/native-driver/src/nativeTest/kotlin/com/squareup/sqldelight/drivers/native/connectionpool/BaseConcurrencyTest.kt
+++ b/drivers/native-driver/src/nativeTest/kotlin/com/squareup/sqldelight/drivers/native/connectionpool/BaseConcurrencyTest.kt
@@ -1,6 +1,6 @@
 package com.squareup.sqldelight.drivers.native.connectionpool
 
-import app.cash.sqldelight.db.AfterVersion
+import app.cash.sqldelight.db.MigrationCallback
 import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.db.SqlSchema
@@ -138,7 +138,7 @@ abstract class BaseConcurrencyTest {
           driver: SqlDriver,
           oldVersion: Long,
           newVersion: Long,
-          vararg callbacks: AfterVersion,
+          vararg callbacks: MigrationCallback,
         ) = QueryResult.Unit
       },
       dbType,

--- a/drivers/sqlite-driver/src/main/kotlin/app/cash/sqldelight/driver/jdbc/sqlite/JdbcSqliteSchema.kt
+++ b/drivers/sqlite-driver/src/main/kotlin/app/cash/sqldelight/driver/jdbc/sqlite/JdbcSqliteSchema.kt
@@ -1,7 +1,7 @@
 package app.cash.sqldelight.driver.jdbc.sqlite
 
 import app.cash.sqldelight.TransacterImpl
-import app.cash.sqldelight.db.AfterVersion
+import app.cash.sqldelight.db.MigrationCallback
 import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlCursor
 import app.cash.sqldelight.db.SqlSchema
@@ -11,7 +11,7 @@ import java.util.Properties
  * Constructs [JdbcSqliteDriver] and creates or migrates [schema] from current PRAGMA `user_version`.
  * After that updates PRAGMA `user_version` to migrated [schema] version.
  * Each of the [callbacks] are executed during the migration whenever the upgrade to the version specified by
- * [AfterVersion.afterVersion] has been completed.
+ * [MigrationCallback.version] is being completed.
  *
  * @see JdbcSqliteDriver
  * @see SqlSchema.create
@@ -22,7 +22,7 @@ fun JdbcSqliteDriver(
   properties: Properties = Properties(),
   schema: SqlSchema<QueryResult.Value<Unit>>,
   migrateEmptySchema: Boolean = false,
-  vararg callbacks: AfterVersion,
+  vararg callbacks: MigrationCallback,
 ): JdbcSqliteDriver {
   val driver = JdbcSqliteDriver(url, properties)
   val transacter = object : TransacterImpl(driver) {}

--- a/drivers/web-worker-driver/src/jsTest/kotlin/app/cash/sqldelight/drivers/worker/WebWorkerDriverTest.kt
+++ b/drivers/web-worker-driver/src/jsTest/kotlin/app/cash/sqldelight/drivers/worker/WebWorkerDriverTest.kt
@@ -3,7 +3,7 @@ package app.cash.sqldelight.drivers.worker
 import app.cash.sqldelight.async.coroutines.await
 import app.cash.sqldelight.async.coroutines.awaitCreate
 import app.cash.sqldelight.async.coroutines.awaitQuery
-import app.cash.sqldelight.db.AfterVersion
+import app.cash.sqldelight.db.MigrationCallback
 import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.QueryResult.AsyncValue
 import app.cash.sqldelight.db.SqlCursor
@@ -59,7 +59,7 @@ class WebWorkerDriverTest {
       driver: SqlDriver,
       oldVersion: Long,
       newVersion: Long,
-      vararg callbacks: AfterVersion,
+      vararg callbacks: MigrationCallback,
     ) = QueryResult.AsyncValue {}
   }
 

--- a/drivers/web-worker-driver/src/jsTest/kotlin/app/cash/sqldelight/drivers/worker/WebWorkerTransacterTest.kt
+++ b/drivers/web-worker-driver/src/jsTest/kotlin/app/cash/sqldelight/drivers/worker/WebWorkerTransacterTest.kt
@@ -3,7 +3,7 @@ package app.cash.sqldelight.drivers.worker
 import app.cash.sqldelight.SuspendingTransacter
 import app.cash.sqldelight.SuspendingTransacterImpl
 import app.cash.sqldelight.async.coroutines.awaitCreate
-import app.cash.sqldelight.db.AfterVersion
+import app.cash.sqldelight.db.MigrationCallback
 import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.db.SqlSchema
@@ -23,7 +23,7 @@ class WebWorkerTransacterTest {
       driver: SqlDriver,
       oldVersion: Long,
       newVersion: Long,
-      vararg callbacks: AfterVersion,
+      vararg callbacks: MigrationCallback,
     ): QueryResult.Value<Unit> = QueryResult.Unit
   }
 

--- a/extensions/androidx-paging3/src/nativeTest/kotlin/app/cash/sqldelight/paging3/ProvideDbDriver.kt
+++ b/extensions/androidx-paging3/src/nativeTest/kotlin/app/cash/sqldelight/paging3/ProvideDbDriver.kt
@@ -15,7 +15,7 @@
  */
 package app.cash.sqldelight.paging3
 
-import app.cash.sqldelight.db.AfterVersion
+import app.cash.sqldelight.db.MigrationCallback
 import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.db.SqlSchema
@@ -29,7 +29,7 @@ private fun defaultSchema(): SqlSchema<QueryResult.Value<Unit>> {
       driver: SqlDriver,
       oldVersion: Long,
       newVersion: Long,
-      vararg callbacks: AfterVersion,
+      vararg callbacks: MigrationCallback,
     ) = QueryResult.Unit
   }
 }

--- a/extensions/async-extensions/src/concurrentMain/kotlin/app/cash/sqldelight/async/coroutines/Synchronous.kt
+++ b/extensions/async-extensions/src/concurrentMain/kotlin/app/cash/sqldelight/async/coroutines/Synchronous.kt
@@ -1,6 +1,6 @@
 package app.cash.sqldelight.async.coroutines
 
-import app.cash.sqldelight.db.AfterVersion
+import app.cash.sqldelight.db.MigrationCallback
 import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.db.SqlSchema
@@ -19,7 +19,7 @@ fun SqlSchema<QueryResult.AsyncValue<Unit>>.synchronous() = object : SqlSchema<Q
     driver: SqlDriver,
     oldVersion: Long,
     newVersion: Long,
-    vararg callbacks: AfterVersion,
+    vararg callbacks: MigrationCallback,
   ) = QueryResult.Value(
     runBlocking { this@synchronous.migrate(driver, oldVersion, newVersion, *callbacks).await() },
   )

--- a/extensions/coroutines-extensions/src/testableNativeTest/kotlin/app/cash/sqldelight/coroutines/TestDriver.kt
+++ b/extensions/coroutines-extensions/src/testableNativeTest/kotlin/app/cash/sqldelight/coroutines/TestDriver.kt
@@ -16,7 +16,7 @@
 
 package app.cash.sqldelight.coroutines
 
-import app.cash.sqldelight.db.AfterVersion
+import app.cash.sqldelight.db.MigrationCallback
 import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.db.SqlSchema
@@ -31,7 +31,7 @@ private fun defaultSchema(): SqlSchema<QueryResult.Value<Unit>> {
       driver: SqlDriver,
       oldVersion: Long,
       newVersion: Long,
-      vararg callbacks: AfterVersion,
+      vararg callbacks: MigrationCallback,
     ) = QueryResult.Unit
   }
 }

--- a/runtime/api/runtime.api
+++ b/runtime/api/runtime.api
@@ -113,14 +113,37 @@ public abstract interface class app/cash/sqldelight/TransactionWithoutReturn : a
 	public abstract fun transaction (Lkotlin/jvm/functions/Function1;)V
 }
 
-public final class app/cash/sqldelight/db/AfterVersion {
+public final class app/cash/sqldelight/db/AfterVersion : app/cash/sqldelight/db/MigrationCallback {
 	public fun <init> (JLkotlin/jvm/functions/Function1;)V
+	public fun afterMigration (Lapp/cash/sqldelight/db/SqlDriver;)V
+	public fun beforeMigration (Lapp/cash/sqldelight/db/SqlDriver;)V
 	public final fun getAfterVersion ()J
 	public final fun getBlock ()Lkotlin/jvm/functions/Function1;
+	public fun getVersion ()J
+}
+
+public final class app/cash/sqldelight/db/BeforeVersion : app/cash/sqldelight/db/MigrationCallback {
+	public fun <init> (JLkotlin/jvm/functions/Function1;)V
+	public fun afterMigration (Lapp/cash/sqldelight/db/SqlDriver;)V
+	public fun beforeMigration (Lapp/cash/sqldelight/db/SqlDriver;)V
+	public final fun getBeforeVersion ()J
+	public final fun getBlock ()Lkotlin/jvm/functions/Function1;
+	public fun getVersion ()J
 }
 
 public final class app/cash/sqldelight/db/CloseableKt {
 	public static final fun use (Ljava/io/Closeable;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+}
+
+public abstract interface class app/cash/sqldelight/db/MigrationCallback {
+	public abstract fun afterMigration (Lapp/cash/sqldelight/db/SqlDriver;)V
+	public abstract fun beforeMigration (Lapp/cash/sqldelight/db/SqlDriver;)V
+	public abstract fun getVersion ()J
+}
+
+public final class app/cash/sqldelight/db/MigrationCallback$DefaultImpls {
+	public static fun afterMigration (Lapp/cash/sqldelight/db/MigrationCallback;Lapp/cash/sqldelight/db/SqlDriver;)V
+	public static fun beforeMigration (Lapp/cash/sqldelight/db/MigrationCallback;Lapp/cash/sqldelight/db/SqlDriver;)V
 }
 
 public final class app/cash/sqldelight/db/OptimisticLockException : java/lang/IllegalStateException {
@@ -210,7 +233,7 @@ public abstract interface class app/cash/sqldelight/db/SqlPreparedStatement {
 public abstract interface class app/cash/sqldelight/db/SqlSchema {
 	public abstract fun create (Lapp/cash/sqldelight/db/SqlDriver;)Lapp/cash/sqldelight/db/QueryResult;
 	public abstract fun getVersion ()J
-	public abstract fun migrate (Lapp/cash/sqldelight/db/SqlDriver;JJ[Lapp/cash/sqldelight/db/AfterVersion;)Lapp/cash/sqldelight/db/QueryResult;
+	public abstract fun migrate (Lapp/cash/sqldelight/db/SqlDriver;JJ[Lapp/cash/sqldelight/db/MigrationCallback;)Lapp/cash/sqldelight/db/QueryResult;
 }
 
 public final class app/cash/sqldelight/logs/LogSqliteDriver : app/cash/sqldelight/db/SqlDriver {

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/testmodule/TestDatabaseImpl.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/testmodule/TestDatabaseImpl.kt
@@ -1,7 +1,7 @@
 package com.example.testmodule
 
 import app.cash.sqldelight.TransacterImpl
-import app.cash.sqldelight.db.AfterVersion
+import app.cash.sqldelight.db.MigrationCallback
 import app.cash.sqldelight.db.QueryResult
 import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.db.SqlSchema
@@ -79,7 +79,7 @@ private class TestDatabaseImpl(
       driver: SqlDriver,
       oldVersion: Long,
       newVersion: Long,
-      vararg callbacks: AfterVersion,
+      vararg callbacks: MigrationCallback,
     ): QueryResult.Value<Unit> = QueryResult.Unit
   }
 }

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/Constants.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/Constants.kt
@@ -18,7 +18,7 @@ internal val VALUE_RESULT_TYPE = QUERY_RESULT_TYPE.nestedClass("Value")
 internal val ASYNC_RESULT_TYPE = QUERY_RESULT_TYPE.nestedClass("AsyncValue")
 internal val UNIT_RESULT_TYPE = QUERY_RESULT_TYPE.nestedClass("Unit")
 
-internal val AFTER_VERSION_TYPE = ClassName("app.cash.sqldelight.db", "AfterVersion")
+internal val MIGRATION_CALLBACK_TYPE = ClassName("app.cash.sqldelight.db", "MigrationCallback")
 
 internal val PREPARED_STATEMENT_TYPE = ClassName("app.cash.sqldelight.db", "SqlPreparedStatement")
 

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/QueriesTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/QueriesTypeTest.kt
@@ -54,7 +54,7 @@ class QueriesTypeTest {
       |package com.example.testmodule
       |
       |import app.cash.sqldelight.TransacterImpl
-      |import app.cash.sqldelight.db.AfterVersion
+      |import app.cash.sqldelight.db.MigrationCallback
       |import app.cash.sqldelight.db.QueryResult
       |import app.cash.sqldelight.db.SqlDriver
       |import app.cash.sqldelight.db.SqlSchema
@@ -107,7 +107,7 @@ class QueriesTypeTest {
       |      driver: SqlDriver,
       |      oldVersion: Long,
       |      newVersion: Long,
-      |      vararg callbacks: AfterVersion,
+      |      vararg callbacks: MigrationCallback,
       |    ): QueryResult.Value<Unit> = QueryResult.Unit
       |  }
       |}
@@ -245,7 +245,7 @@ class QueriesTypeTest {
       |package com.example.testmodule
       |
       |import app.cash.sqldelight.TransacterImpl
-      |import app.cash.sqldelight.db.AfterVersion
+      |import app.cash.sqldelight.db.MigrationCallback
       |import app.cash.sqldelight.db.QueryResult
       |import app.cash.sqldelight.db.SqlDriver
       |import app.cash.sqldelight.db.SqlSchema
@@ -287,7 +287,7 @@ class QueriesTypeTest {
       |      driver: SqlDriver,
       |      oldVersion: Long,
       |      newVersion: Long,
-      |      vararg callbacks: AfterVersion,
+      |      vararg callbacks: MigrationCallback,
       |    ): QueryResult.Value<Unit> = QueryResult.Unit
       |  }
       |}
@@ -347,7 +347,7 @@ class QueriesTypeTest {
       |package com.example.testmodule
       |
       |import app.cash.sqldelight.TransacterImpl
-      |import app.cash.sqldelight.db.AfterVersion
+      |import app.cash.sqldelight.db.MigrationCallback
       |import app.cash.sqldelight.db.QueryResult
       |import app.cash.sqldelight.db.SqlDriver
       |import app.cash.sqldelight.db.SqlSchema
@@ -384,7 +384,7 @@ class QueriesTypeTest {
       |      driver: SqlDriver,
       |      oldVersion: Long,
       |      newVersion: Long,
-      |      vararg callbacks: AfterVersion,
+      |      vararg callbacks: MigrationCallback,
       |    ): QueryResult.Value<Unit> = QueryResult.Unit
       |  }
       |}
@@ -425,7 +425,7 @@ class QueriesTypeTest {
       |package com.example.testmodule
       |
       |import app.cash.sqldelight.TransacterImpl
-      |import app.cash.sqldelight.db.AfterVersion
+      |import app.cash.sqldelight.db.MigrationCallback
       |import app.cash.sqldelight.db.QueryResult
       |import app.cash.sqldelight.db.SqlDriver
       |import app.cash.sqldelight.db.SqlSchema
@@ -467,7 +467,7 @@ class QueriesTypeTest {
       |      driver: SqlDriver,
       |      oldVersion: Long,
       |      newVersion: Long,
-      |      vararg callbacks: AfterVersion,
+      |      vararg callbacks: MigrationCallback,
       |    ): QueryResult.Value<Unit> = QueryResult.Unit
       |  }
       |}
@@ -584,7 +584,7 @@ class QueriesTypeTest {
       |package com.example.testmodule
       |
       |import app.cash.sqldelight.TransacterImpl
-      |import app.cash.sqldelight.db.AfterVersion
+      |import app.cash.sqldelight.db.MigrationCallback
       |import app.cash.sqldelight.db.QueryResult
       |import app.cash.sqldelight.db.SqlDriver
       |import app.cash.sqldelight.db.SqlSchema
@@ -624,7 +624,7 @@ class QueriesTypeTest {
       |      driver: SqlDriver,
       |      oldVersion: Long,
       |      newVersion: Long,
-      |      vararg callbacks: AfterVersion,
+      |      vararg callbacks: MigrationCallback,
       |    ): QueryResult.Value<Unit> = QueryResult.Unit
       |  }
       |}

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/QueryWrapperTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/QueryWrapperTest.kt
@@ -36,7 +36,7 @@ class QueryWrapperTest {
       |package com.example.testmodule
       |
       |import app.cash.sqldelight.TransacterImpl
-      |import app.cash.sqldelight.db.AfterVersion
+      |import app.cash.sqldelight.db.MigrationCallback
       |import app.cash.sqldelight.db.QueryResult
       |import app.cash.sqldelight.db.SqlDriver
       |import app.cash.sqldelight.db.SqlSchema
@@ -77,7 +77,7 @@ class QueryWrapperTest {
       |      driver: SqlDriver,
       |      oldVersion: Long,
       |      newVersion: Long,
-      |      vararg callbacks: AfterVersion,
+      |      vararg callbacks: MigrationCallback,
       |    ): QueryResult.Value<Unit> = QueryResult.Unit
       |  }
       |}
@@ -117,7 +117,7 @@ class QueryWrapperTest {
         |package com.example.testmodule
         |
         |import app.cash.sqldelight.TransacterImpl
-        |import app.cash.sqldelight.db.AfterVersion
+        |import app.cash.sqldelight.db.MigrationCallback
         |import app.cash.sqldelight.db.QueryResult
         |import app.cash.sqldelight.db.SqlDriver
         |import app.cash.sqldelight.db.SqlSchema
@@ -170,7 +170,7 @@ class QueryWrapperTest {
         |      driver: SqlDriver,
         |      oldVersion: Long,
         |      newVersion: Long,
-        |      vararg callbacks: AfterVersion,
+        |      vararg callbacks: MigrationCallback,
         |    ): QueryResult.Value<Unit> = QueryResult.Unit
         |  }
         |}
@@ -204,7 +204,7 @@ class QueryWrapperTest {
         |package com.example.testmodule
         |
         |import app.cash.sqldelight.TransacterImpl
-        |import app.cash.sqldelight.db.AfterVersion
+        |import app.cash.sqldelight.db.MigrationCallback
         |import app.cash.sqldelight.db.QueryResult
         |import app.cash.sqldelight.db.SqlDriver
         |import app.cash.sqldelight.db.SqlSchema
@@ -245,7 +245,7 @@ class QueryWrapperTest {
         |      driver: SqlDriver,
         |      oldVersion: Long,
         |      newVersion: Long,
-        |      vararg callbacks: AfterVersion,
+        |      vararg callbacks: MigrationCallback,
         |    ): QueryResult.Value<Unit> = QueryResult.Unit
         |  }
         |}
@@ -299,7 +299,7 @@ class QueryWrapperTest {
         |package com.example.testmodule
         |
         |import app.cash.sqldelight.TransacterImpl
-        |import app.cash.sqldelight.db.AfterVersion
+        |import app.cash.sqldelight.db.MigrationCallback
         |import app.cash.sqldelight.db.QueryResult
         |import app.cash.sqldelight.db.SqlDriver
         |import app.cash.sqldelight.db.SqlSchema
@@ -342,7 +342,7 @@ class QueryWrapperTest {
         |      driver: SqlDriver,
         |      oldVersion: Long,
         |      newVersion: Long,
-        |      vararg callbacks: AfterVersion,
+        |      vararg callbacks: MigrationCallback,
         |    ): QueryResult.Value<Unit> = QueryResult.Unit
         |  }
         |}
@@ -386,7 +386,7 @@ class QueryWrapperTest {
         |package com.example.testmodule
         |
         |import app.cash.sqldelight.TransacterImpl
-        |import app.cash.sqldelight.db.AfterVersion
+        |import app.cash.sqldelight.db.MigrationCallback
         |import app.cash.sqldelight.db.QueryResult
         |import app.cash.sqldelight.db.SqlDriver
         |import app.cash.sqldelight.db.SqlSchema
@@ -440,7 +440,7 @@ class QueryWrapperTest {
         |      driver: SqlDriver,
         |      oldVersion: Long,
         |      newVersion: Long,
-        |      vararg callbacks: AfterVersion,
+        |      vararg callbacks: MigrationCallback,
         |    ): QueryResult.Value<Unit> = QueryResult.Unit
         |  }
         |}
@@ -471,7 +471,7 @@ class QueryWrapperTest {
         |package com.example.testmodule
         |
         |import app.cash.sqldelight.TransacterImpl
-        |import app.cash.sqldelight.db.AfterVersion
+        |import app.cash.sqldelight.db.MigrationCallback
         |import app.cash.sqldelight.db.QueryResult
         |import app.cash.sqldelight.db.SqlDriver
         |import app.cash.sqldelight.db.SqlSchema
@@ -511,7 +511,7 @@ class QueryWrapperTest {
         |      driver: SqlDriver,
         |      oldVersion: Long,
         |      newVersion: Long,
-        |      vararg callbacks: AfterVersion,
+        |      vararg callbacks: MigrationCallback,
         |    ): QueryResult.Value<Unit> = QueryResult.Unit
         |  }
         |}
@@ -547,7 +547,7 @@ class QueryWrapperTest {
         |package com.example.testmodule
         |
         |import app.cash.sqldelight.TransacterImpl
-        |import app.cash.sqldelight.db.AfterVersion
+        |import app.cash.sqldelight.db.MigrationCallback
         |import app.cash.sqldelight.db.QueryResult
         |import app.cash.sqldelight.db.SqlDriver
         |import app.cash.sqldelight.db.SqlSchema
@@ -591,7 +591,7 @@ class QueryWrapperTest {
         |      driver: SqlDriver,
         |      oldVersion: Long,
         |      newVersion: Long,
-        |      vararg callbacks: AfterVersion,
+        |      vararg callbacks: MigrationCallback,
         |    ): QueryResult.Value<Unit> = QueryResult.Unit
         |  }
         |}
@@ -627,7 +627,7 @@ class QueryWrapperTest {
         |package com.example.testmodule
         |
         |import app.cash.sqldelight.TransacterImpl
-        |import app.cash.sqldelight.db.AfterVersion
+        |import app.cash.sqldelight.db.MigrationCallback
         |import app.cash.sqldelight.db.QueryResult
         |import app.cash.sqldelight.db.SqlDriver
         |import app.cash.sqldelight.db.SqlSchema
@@ -670,7 +670,7 @@ class QueryWrapperTest {
         |      driver: SqlDriver,
         |      oldVersion: Long,
         |      newVersion: Long,
-        |      vararg callbacks: AfterVersion,
+        |      vararg callbacks: MigrationCallback,
         |    ): QueryResult.Value<Unit> = QueryResult.Unit
         |  }
         |}
@@ -723,7 +723,7 @@ class QueryWrapperTest {
         |package com.example.testmodule
         |
         |import app.cash.sqldelight.TransacterImpl
-        |import app.cash.sqldelight.db.AfterVersion
+        |import app.cash.sqldelight.db.MigrationCallback
         |import app.cash.sqldelight.db.QueryResult
         |import app.cash.sqldelight.db.SqlDriver
         |import app.cash.sqldelight.db.SqlSchema
@@ -782,16 +782,17 @@ class QueryWrapperTest {
         |      driver: SqlDriver,
         |      oldVersion: Long,
         |      newVersion: Long,
-        |      vararg callbacks: AfterVersion,
+        |      vararg callbacks: MigrationCallback,
         |    ): QueryResult.Value<Unit> {
         |      var lastVersion = oldVersion
         |
-        |      callbacks.filter { it.afterVersion in oldVersion until newVersion }
-        |      .sortedBy { it.afterVersion }
+        |      callbacks.filter { it.version in oldVersion until newVersion }
+        |      .sortedBy { it.version }
         |      .forEach { callback ->
-        |        migrateInternal(driver, oldVersion = lastVersion, newVersion = callback.afterVersion + 1)
-        |        callback.block(driver)
-        |        lastVersion = callback.afterVersion + 1
+        |        callback.beforeMigration(driver)
+        |        migrateInternal(driver, oldVersion = lastVersion, newVersion = callback.version + 1)
+        |        callback.afterMigration(driver)
+        |        lastVersion = callback.version + 1
         |      }
         |
         |      if (lastVersion < newVersion) {
@@ -839,7 +840,7 @@ class QueryWrapperTest {
         |package com.example.testmodule
         |
         |import app.cash.sqldelight.TransacterImpl
-        |import app.cash.sqldelight.db.AfterVersion
+        |import app.cash.sqldelight.db.MigrationCallback
         |import app.cash.sqldelight.db.QueryResult
         |import app.cash.sqldelight.db.SqlDriver
         |import app.cash.sqldelight.db.SqlSchema
@@ -895,16 +896,17 @@ class QueryWrapperTest {
         |      driver: SqlDriver,
         |      oldVersion: Long,
         |      newVersion: Long,
-        |      vararg callbacks: AfterVersion,
+        |      vararg callbacks: MigrationCallback,
         |    ): QueryResult.Value<Unit> {
         |      var lastVersion = oldVersion
         |
-        |      callbacks.filter { it.afterVersion in oldVersion until newVersion }
-        |      .sortedBy { it.afterVersion }
+        |      callbacks.filter { it.version in oldVersion until newVersion }
+        |      .sortedBy { it.version }
         |      .forEach { callback ->
-        |        migrateInternal(driver, oldVersion = lastVersion, newVersion = callback.afterVersion + 1)
-        |        callback.block(driver)
-        |        lastVersion = callback.afterVersion + 1
+        |        callback.beforeMigration(driver)
+        |        migrateInternal(driver, oldVersion = lastVersion, newVersion = callback.version + 1)
+        |        callback.afterMigration(driver)
+        |        lastVersion = callback.version + 1
         |      }
         |
         |      if (lastVersion < newVersion) {
@@ -953,7 +955,7 @@ class QueryWrapperTest {
         |package com.example.testmodule
         |
         |import app.cash.sqldelight.TransacterImpl
-        |import app.cash.sqldelight.db.AfterVersion
+        |import app.cash.sqldelight.db.MigrationCallback
         |import app.cash.sqldelight.db.QueryResult
         |import app.cash.sqldelight.db.SqlDriver
         |import app.cash.sqldelight.db.SqlSchema
@@ -1013,7 +1015,7 @@ class QueryWrapperTest {
         |      driver: SqlDriver,
         |      oldVersion: Long,
         |      newVersion: Long,
-        |      vararg callbacks: AfterVersion,
+        |      vararg callbacks: MigrationCallback,
         |    ): QueryResult.Value<Unit> = QueryResult.Unit
         |  }
         |}

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/async/AsyncQueriesTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/async/AsyncQueriesTypeTest.kt
@@ -55,7 +55,7 @@ class AsyncQueriesTypeTest {
       |package com.example.testmodule
       |
       |import app.cash.sqldelight.SuspendingTransacterImpl
-      |import app.cash.sqldelight.db.AfterVersion
+      |import app.cash.sqldelight.db.MigrationCallback
       |import app.cash.sqldelight.db.QueryResult
       |import app.cash.sqldelight.db.SqlDriver
       |import app.cash.sqldelight.db.SqlSchema
@@ -107,7 +107,7 @@ class AsyncQueriesTypeTest {
       |      driver: SqlDriver,
       |      oldVersion: Long,
       |      newVersion: Long,
-      |      vararg callbacks: AfterVersion,
+      |      vararg callbacks: MigrationCallback,
       |    ): QueryResult.AsyncValue<Unit> = QueryResult.AsyncValue {
       |    }
       |  }

--- a/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/tests/MigrationTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/tests/MigrationTest.kt
@@ -318,16 +318,17 @@ class MigrationTest {
       |      driver: SqlDriver,
       |      oldVersion: Long,
       |      newVersion: Long,
-      |      vararg callbacks: AfterVersion,
+      |      vararg callbacks: MigrationCallback,
       |    ): QueryResult.Value<Unit> {
       |      var lastVersion = oldVersion
       |
-      |      callbacks.filter { it.afterVersion in oldVersion until newVersion }
-      |      .sortedBy { it.afterVersion }
+      |      callbacks.filter { it.version in oldVersion until newVersion }
+      |      .sortedBy { it.version }
       |      .forEach { callback ->
-      |        migrateInternal(driver, oldVersion = lastVersion, newVersion = callback.afterVersion + 1)
-      |        callback.block(driver)
-      |        lastVersion = callback.afterVersion + 1
+      |        callback.beforeMigration(driver)
+      |        migrateInternal(driver, oldVersion = lastVersion, newVersion = callback.version + 1)
+      |        callback.afterMigration(driver)
+      |        lastVersion = callback.version + 1
       |      }
       |
       |      if (lastVersion < newVersion) {


### PR DESCRIPTION
Adds a new interface `MigrationCallback` which replaces `AfterVersion` as the callback vararg type for migrations. It is defined as follows:
```
interface MigrationCallback {
  val version: Long
  fun beforeMigration(driver: SqlDriver) {}
  fun afterMigration(driver: SqlDriver) {}
}
```

`AfterVersion` is updated to implement this interface, and remains fully backwards compatible. In addition a matching class `BeforeVersion` is added for ease of use.