### PR TITLE
Use DependencyHandler for modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## UNRELEASED
 
-Nothing yet!
+- [Gradle Plugin] Add support for version catalogs when adding modules (#5755 by [Michael Rittmeister][DRSchlaubi])
 
 ## [2.1.0] - 2025-05-16
 
@@ -1152,3 +1152,4 @@ Initial release.
   [drewd]: https://github.com/drewd
   [orenkislev-faire]: https://github.com/orenkislev-faire
   [janbina]: https://github.com/janbina
+  [DRSchlaubi]: https://github.com/DRSchlaubi

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightDatabase.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightDatabase.kt
@@ -12,12 +12,16 @@ import java.io.File
 import javax.inject.Inject
 import org.gradle.api.GradleException
 import org.gradle.api.Project
+import org.gradle.api.artifacts.ExternalModuleDependencyBundle
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.catalog.DelegatingProjectDependency
+import org.gradle.api.internal.provider.ProviderInternal
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderConvertible
+import org.gradle.internal.Cast
 
 @SqlDelightDsl
 abstract class SqlDelightDatabase @Inject constructor(
@@ -57,7 +61,7 @@ abstract class SqlDelightDatabase @Inject constructor(
   internal var addedDialect: Boolean = false
 
   fun module(module: Any) {
-    configuration.dependencies.add(project.dependencies.create(module))
+    project.dependencies.add(configuration.name, module)
   }
 
   fun dialect(dialect: Any) {

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightDatabase.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightDatabase.kt
@@ -12,16 +12,12 @@ import java.io.File
 import javax.inject.Inject
 import org.gradle.api.GradleException
 import org.gradle.api.Project
-import org.gradle.api.artifacts.ExternalModuleDependencyBundle
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.catalog.DelegatingProjectDependency
-import org.gradle.api.internal.provider.ProviderInternal
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
-import org.gradle.api.provider.ProviderConvertible
-import org.gradle.internal.Cast
 
 @SqlDelightDsl
 abstract class SqlDelightDatabase @Inject constructor(

--- a/sqldelight-gradle-plugin/src/test/integration-sqlite-json-version-catalogs/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-sqlite-json-version-catalogs/build.gradle
@@ -1,0 +1,21 @@
+plugins {
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.sqldelight)
+}
+
+sqldelight {
+  databases {
+    QueryWrapper {
+      packageName = "app.cash.sqldelight.integration"
+      dialect(libs.sqldelight.sqlite.dialect)
+      module(libs.sqldelight.module.json)
+    }
+  }
+}
+
+dependencies {
+  implementation libs.sqliteJdbc
+  implementation "app.cash.sqldelight:sqlite-driver:${app.cash.sqldelight.VersionKt.VERSION}"
+  implementation libs.truth
+  implementation libs.moshi
+}

--- a/sqldelight-gradle-plugin/src/test/integration-sqlite-json-version-catalogs/settings.gradle
+++ b/sqldelight-gradle-plugin/src/test/integration-sqlite-json-version-catalogs/settings.gradle
@@ -1,0 +1,18 @@
+pluginManagement {
+  includeBuild("../build-logic-tests")
+}
+
+plugins {
+  id("sqldelightTests")
+}
+
+def sqldelightVersion = providers.gradleProperty("sqldelightVersion").get().toString()
+
+dependencyResolutionManagement {
+  versionCatalogs {
+    named("libs") {
+      library("sqldelight-module-json", "app.cash.sqldelight", "sqlite-json-module").version(sqldelightVersion)
+      library("sqldelight-sqlite-dialect", "app.cash.sqldelight", "sqlite-3-18-dialect").version(sqldelightVersion)
+    }
+  }
+}

--- a/sqldelight-gradle-plugin/src/test/integration-sqlite-json-version-catalogs/src/main/sqldelight/app/cash/sqldelight/integration/JsonTable.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-sqlite-json-version-catalogs/src/main/sqldelight/app/cash/sqldelight/integration/JsonTable.sq
@@ -1,0 +1,21 @@
+CREATE TABLE user(
+  name TEXT NOT NULL PRIMARY KEY,
+  phone TEXT
+);
+
+insertUser:
+INSERT INTO user
+VALUES (?, ?);
+
+byAreaCode:
+SELECT DISTINCT user.name
+  FROM user, json_each(user.phone) AS user_phone
+ WHERE user_phone.value LIKE :areaCode || '-%';
+
+byAreaCode2:
+SELECT name FROM user WHERE phone LIKE :areaCode || '-%'
+UNION
+SELECT user.name
+  FROM user, json_each(user.phone)
+ WHERE json_valid(user.phone)
+   AND json_each.value LIKE :areaCode || '-%';

--- a/sqldelight-gradle-plugin/src/test/integration-sqlite-json-version-catalogs/src/test/java/app/cash/sqldelight/integration/IntegrationTests.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-sqlite-json-version-catalogs/src/test/java/app/cash/sqldelight/integration/IntegrationTests.kt
@@ -1,0 +1,53 @@
+package app.cash.sqldelight.integration
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver.Companion.IN_MEMORY
+import com.google.common.truth.Truth.assertThat
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+import com.squareup.moshi.adapter
+import org.junit.Before
+import org.junit.Test
+
+class IntegrationTests {
+  private val moshi = Moshi.Builder().build()
+
+  private lateinit var queryWrapper: QueryWrapper
+  private lateinit var jsonQueries: JsonTableQueries
+
+  @Before fun before() {
+    val database = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+    QueryWrapper.Schema.create(database)
+
+    queryWrapper = QueryWrapper(database)
+    jsonQueries = queryWrapper.jsonTableQueries
+  }
+
+  @Test fun jsonArray() {
+    with(jsonQueries) {
+      insertUser("user1", jsonPhones("704-555-5555", "705-555-5555"))
+      insertUser("user2", jsonPhones("604-555-5555", "605-555-5555"))
+      assertThat(byAreaCode(areaCode = "704").executeAsList()).containsExactly(
+        "user1",
+      )
+    }
+  }
+
+  @Test fun jsonArrayOrLiteral() {
+    with(jsonQueries) {
+      insertUser("user1", jsonPhones("704-555-5555", "705-555-5555"))
+      insertUser("user2", jsonPhones("604-555-5555", "605-555-5555"))
+      insertUser("user3", "704-666-6666")
+      assertThat(byAreaCode2(areaCode = "704").executeAsList()).containsExactly(
+        "user1",
+        "user3",
+      )
+    }
+  }
+
+  private fun jsonPhones(vararg phoneNumbers: String): String {
+    val adapter =
+      moshi.adapter<List<String>>(Types.newParameterizedType(List::class.java, String::class.java))
+    return adapter.toJson(phoneNumbers.toList())
+  }
+}

--- a/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/integrations/IntegrationTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/integrations/IntegrationTest.kt
@@ -41,6 +41,15 @@ class IntegrationTest {
     assertThat(result.output).contains("BUILD SUCCESSFUL")
   }
 
+  @Test fun integrationTestsSqliteJsonModuleWithVersionCatalogs() {
+    val runner = GradleRunner.create()
+      .withCommonConfiguration(File("src/test/integration-sqlite-json-version-catalogs"))
+      .withArguments("clean", "check", "--stacktrace")
+
+    val result = runner.build()
+    assertThat(result.output).contains("BUILD SUCCESSFUL")
+  }
+
   @Test fun migrationCallbackIntegrationTests() {
     val runner = GradleRunner.create()
       .withCommonConfiguration(File("src/test/integration-migration-callbacks"))


### PR DESCRIPTION
This PR changes the logic for adding a dependency on a module, this has the advantage that it can accept version catalogs, wich the current logic can't

the dialect function already calls the same function

Fixes #5282 