### PR TITLE
Fix 5758 3.18 functions missing

### DIFF
--- a/dialects/sqlite-3-25/src/main/kotlin/app/cash/sqldelight/dialects/sqlite_3_25/SqliteTypeResolver.kt
+++ b/dialects/sqlite-3-25/src/main/kotlin/app/cash/sqldelight/dialects/sqlite_3_25/SqliteTypeResolver.kt
@@ -21,7 +21,7 @@ open class SqliteTypeResolver(private val parentResolver: TypeResolver) : Sqlite
   }
 
   override fun functionType(functionExpr: SqlFunctionExpr): IntermediateType? {
-    return functionExpr.sqliteFunctionType() ?: parentResolver.functionType(functionExpr)
+    return functionExpr.sqliteFunctionType() ?: super.functionType(functionExpr)
   }
 
   private fun SqlFunctionExpr.sqliteFunctionType() = when (functionName.text.lowercase()) {

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/ExpressionTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/ExpressionTest.kt
@@ -7,6 +7,7 @@ import app.cash.sqldelight.core.TestDialect.POSTGRESQL
 import app.cash.sqldelight.core.compiler.SelectQueryGenerator
 import app.cash.sqldelight.core.dialects.blobType
 import app.cash.sqldelight.core.dialects.textType
+import app.cash.sqldelight.dialects.sqlite_3_18.SqliteDialect
 import app.cash.sqldelight.test.util.FixtureCompiler
 import com.google.common.truth.Truth.assertThat
 import com.squareup.burst.BurstJUnit4
@@ -925,5 +926,19 @@ class ExpressionTest {
 
     val query = file.namedQueries.first()
     assertThat(query.resultColumns[0].javaType).isEqualTo(INT.copy(nullable = true))
+  }
+
+  @Test fun `for each sqlite dialect inherited functions are callable`(dialect: TestDialect) {
+    assumeTrue(dialect.dialect is SqliteDialect) // any sqlite dialect
+    val file = FixtureCompiler.compileSql(
+      """
+    functions:
+       SELECT changes(), last_insert_rowid(), sqlite_version();
+      """.trimMargin(),
+      tempFolder,
+      overrideDialect = dialect.dialect,
+    )
+
+    assertThat(file.errors).isEmpty()
   }
 }


### PR DESCRIPTION
fixes #5758

Adds call super to resolve inherited functions from 3.18
Adds suitable test to prevent regressions from any future Sqlite dialects

Tested local snapshot with change

Fixture tests don't fail when functions are not resolved in queries - it returns null - only the FunctionExprMixin annotates errors 