### PR TITLE
Gradle 9 upgrade - fix deprecated dependencyProject 

### DIFF
--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightDatabase.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightDatabase.kt
@@ -117,7 +117,7 @@ abstract class SqlDelightDatabase @Inject constructor(
   }
 
   @Suppress("unused") // Public API used in gradle files.
-  fun dependency(delegatedProject: DelegatingProjectDependency) = dependency(delegatedProject.dependencyProject)
+  fun dependency(delegatedProject: DelegatingProjectDependency) = dependency(project.project(delegatedProject.path))
 
   @Suppress("unused") // Public API used in gradle files.
   fun dependency(dependencyProject: Project) {


### PR DESCRIPTION
Fixes #5793

Allows SqlDelight to compile with Gradle 9 - I am still looking to see if larger changes are required  

Fix deprecated dependencyProject
see https://docs.gradle.org/current/userguide/upgrading_version_8.html#deprecate_get_dependency_project

Allows SqlDelight to compile with Gradle 9 milestone https://github.com/JakeWharton/prerelease-testing/blob/190f8f55bee66f6fa95700d7be5049ae8ee696e0/gradle/wrapper/gradle-wrapper.properties#L4C67-L4C72

Note:  Have tested published snapshot locally and consumed user project with Gradle 9 mileston

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
