### PR TITLE
Add limited support for PostgreSql Comment On statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- [PostgreSQL Dialect] Add limited support for PostgreSql Comment On statement (#5808 by [Griffio][griffio])
 - [MySQL Dialect] Add support for index visibility options (#5785 by [Oren Kislev][orenkislev-faire])
 - [Gradle Plugin] Add support for version catalogs when adding modules (#5755 by [Michael Rittmeister][DRSchlaubi])
 

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -90,6 +90,7 @@
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.SELECT"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.SET"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.STRING"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.TABLE"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.TEMP"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.TEMPORARY"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.TO"
@@ -602,7 +603,7 @@ at_time_zone_operator_expression ::= ( {literal_expr} | {cast_expr} | {function_
 }
 
 extension_stmt ::= create_sequence_stmt | copy_stdin | truncate_stmt | set_stmt | drop_sequence_stmt |
- alter_sequence_stmt | create_extension_stmt | drop_extension_stmt | alter_extension_stmt {
+ alter_sequence_stmt | create_extension_stmt | drop_extension_stmt | alter_extension_stmt | comment_on_extension_stmt {
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlExtensionStmtImpl"
   implements = "com.alecstrong.sql.psi.core.psi.SqlExtensionStmt"
   override = true
@@ -706,5 +707,10 @@ extract_temporal_field ::= 'century' | 'day' | 'decade' | 'dow' | 'doy' | 'epoch
 
 extract_temporal_expression ::= 'EXTRACT' LP extract_temporal_field FROM <<expr '-1'>> RP {
   mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.ExtractTemporalExpressionMixin"
+  pin = 2
+}
+
+comment_on_extension_stmt ::= 'COMMENT' ON ( COLUMN {column_expr} | TABLE {table_name} | VIEW {view_name} ) IS ( NULL | string_literal )  {
+  mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.CommentOnMixin"
   pin = 2
 }

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/CommentOnMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/CommentOnMixin.kt
@@ -1,0 +1,18 @@
+package app.cash.sqldelight.dialects.postgresql.grammar.mixins
+
+import com.alecstrong.sql.psi.core.psi.QueryElement
+import com.alecstrong.sql.psi.core.psi.SqlCompositeElementImpl
+import com.intellij.lang.ASTNode
+import com.intellij.psi.PsiElement
+/**
+ * Comment On Table, View and Column.
+ * Currently limited to table queries - other schema elements like Indices are not queryable outside sql-psi.
+ */
+internal abstract class CommentOnMixin(
+  node: ASTNode,
+) : SqlCompositeElementImpl(node) {
+
+  override fun queryAvailable(child: PsiElement): Collection<QueryElement.QueryResult> {
+    return tablesAvailable(child).map { it.query }
+  }
+}

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/comment-on/Test.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/comment-on/Test.s
@@ -1,0 +1,19 @@
+CREATE TABLE SomeTable (
+  id INTEGER PRIMARY KEY,
+  txt TEXT NOT NULL
+);
+
+CREATE VIEW VSomeTable AS
+SELECT * FROM SomeTable;
+
+COMMENT ON TABLE SomeTable IS 'Stores text for every row';
+COMMENT ON VIEW VSomeTable IS 'A View for every row';
+COMMENT ON COLUMN SomeTable.id IS 'Integer Primary Key column';
+COMMENT ON TABLE SomeTable IS NULL;
+
+--error[col 17]: No table found with name Xyz
+COMMENT ON TABLE Xyz IS NULL;
+--error[col 16]:  No table found with name VXyz
+COMMENT ON VIEW VXyz IS NULL;
+--error[col 28]: No column found with name x
+COMMENT ON COLUMN SomeTable.x IS NULL;

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql-migrations/src/main/sqldelight/migrations/app/cash/sqldelight/postgresql/integration/V1__Product.sqm
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql-migrations/src/main/sqldelight/migrations/app/cash/sqldelight/postgresql/integration/V1__Product.sqm
@@ -3,3 +3,6 @@ CREATE TABLE Products
     id                   SERIAL PRIMARY KEY,
     sku                  VARCHAR(255) NOT NULL
 );
+
+COMMENT ON TABLE Products IS 'Store the sku rows by id';
+COMMENT ON COLUMN Products.sku IS 'The sku is not a unique identifier';

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql-migrations/src/main/sqldelight/migrations/app/cash/sqldelight/postgresql/integration/V2__Product_alter.sqm
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql-migrations/src/main/sqldelight/migrations/app/cash/sqldelight/postgresql/integration/V2__Product_alter.sqm
@@ -1,1 +1,2 @@
 ALTER TABLE Products ADD COLUMN requires_dpi BOOLEAN DEFAULT FALSE;
+COMMENT ON COLUMN Products.requires_dpi IS 'requires_dpi is false by default';

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql-migrations/src/main/sqldelight/migrations/app/cash/sqldelight/postgresql/integration/V3__Product_alter.sqm
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql-migrations/src/main/sqldelight/migrations/app/cash/sqldelight/postgresql/integration/V3__Product_alter.sqm
@@ -1,1 +1,2 @@
 ALTER TABLE Products RENAME COLUMN requires_dpi TO requiresDpi;
+COMMENT ON COLUMN Products.requiresDpi IS 'requiresDpi is false by default';


### PR DESCRIPTION
Fixes #5806 

* Adds limited support for PostgreSql https://www.postgresql.org/docs/current/sql-comment.html - tables, views and columns only
  * This is due to SqlDelight dialects currently not having access to internal sql-psi schema like indexes  

* Adds fixture test
* Adds integration migration test


Note: See also https://github.com/sqldelight/sqldelight/issues/4998

---

- [X] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
