### PR TITLE
Simplify generated code by using constructor references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Changed
 
 - In-development snapshots are now published to the Central Portal Snapshots repository at https://central.sonatype.com/repository/maven-snapshots/.
+- Simplified default generated queries by using constructor references (#???? by [Jon Poulton][jonapoul])
 
 ### Fixed
 
@@ -1167,3 +1168,4 @@ Initial release.
   [orenkislev-faire]: https://github.com/orenkislev-faire
   [janbina]: https://github.com/janbina
   [DRSchlaubi]: https://github.com/DRSchlaubi
+  [jonapoul]: https://github.com/jonapoul

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Changed
 
 - In-development snapshots are now published to the Central Portal Snapshots repository at https://central.sonatype.com/repository/maven-snapshots/.
-- Simplified default generated queries by using constructor references (#???? by [Jon Poulton][jonapoul])
+- Simplified default generated queries by using constructor references (#5814 by [Jon Poulton][jonapoul])
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Changed
 
 - In-development snapshots are now published to the Central Portal Snapshots repository at https://central.sonatype.com/repository/maven-snapshots/.
-- Simplified default generated queries by using constructor references (#5814 by [Jon Poulton][jonapoul])
+- [Compiler] Simplified default generated queries using constructor references (#5814 by [Jon Poulton][jonapoul])
 
 ### Fixed
 

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/GroupQueries.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/GroupQueries.kt
@@ -24,10 +24,5 @@ public class GroupQueries(
     )
   }
 
-  public fun selectFromTable2(): Query<SelectFromTable2> = selectFromTable2 { something, nice ->
-    SelectFromTable2(
-      something,
-      nice
-    )
-  }
+  public fun selectFromTable2(): Query<SelectFromTable2> = selectFromTable2(::SelectFromTable2)
 }

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/PlayerQueries.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/PlayerQueries.kt
@@ -43,14 +43,7 @@ public class PlayerQueries(
     number: Long,
     team: Team.Name?,
     shoots: Shoots,
-  ): ExecutableQuery<Player> = insertAndReturn(name, number, team, shoots) { name_, number_, team_, shoots_ ->
-    Player(
-      name_,
-      number_,
-      team_,
-      shoots_
-    )
-  }
+  ): ExecutableQuery<Player> = insertAndReturn(name, number, team, shoots, ::Player)
 
   public fun <T : Any> allPlayers(mapper: (
     name: Player.Name,
@@ -69,14 +62,7 @@ public class PlayerQueries(
     )
   }
 
-  public fun allPlayers(): Query<Player> = allPlayers { name, number, team, shoots ->
-    Player(
-      name,
-      number,
-      team,
-      shoots
-    )
-  }
+  public fun allPlayers(): Query<Player> = allPlayers(::Player)
 
   public fun <T : Any> playersForTeam(team: Team.Name?, mapper: (
     name: Player.Name,
@@ -92,14 +78,7 @@ public class PlayerQueries(
     )
   }
 
-  public fun playersForTeam(team: Team.Name?): Query<Player> = playersForTeam(team) { name, number, team_, shoots ->
-    Player(
-      name,
-      number,
-      team_,
-      shoots
-    )
-  }
+  public fun playersForTeam(team: Team.Name?): Query<Player> = playersForTeam(team, ::Player)
 
   public fun <T : Any> playersForNumbers(number: Collection<Long>, mapper: (
     name: Player.Name,
@@ -115,14 +94,7 @@ public class PlayerQueries(
     )
   }
 
-  public fun playersForNumbers(number: Collection<Long>): Query<Player> = playersForNumbers(number) { name, number_, team, shoots ->
-    Player(
-      name,
-      number_,
-      team,
-      shoots
-    )
-  }
+  public fun playersForNumbers(number: Collection<Long>): Query<Player> = playersForNumbers(number, ::Player)
 
   public fun <T : Any> selectNull(mapper: (expr: Void?) -> T): ExecutableQuery<T> = Query(106_890_351, driver, "Player.sq", "selectNull", "SELECT NULL") { cursor ->
     mapper(
@@ -130,11 +102,7 @@ public class PlayerQueries(
     )
   }
 
-  public fun selectNull(): ExecutableQuery<SelectNull> = selectNull { expr ->
-    SelectNull(
-      expr
-    )
-  }
+  public fun selectNull(): ExecutableQuery<SelectNull> = selectNull(::SelectNull)
 
   public fun <T : Any> selectStuff(mapper: (expr: Long, expr_: Long) -> T): ExecutableQuery<T> = Query(-976_770_036, driver, "Player.sq", "selectStuff", "SELECT 1, 2") { cursor ->
     mapper(
@@ -143,12 +111,7 @@ public class PlayerQueries(
     )
   }
 
-  public fun selectStuff(): ExecutableQuery<SelectStuff> = selectStuff { expr, expr_ ->
-    SelectStuff(
-      expr,
-      expr_
-    )
-  }
+  public fun selectStuff(): ExecutableQuery<SelectStuff> = selectStuff(::SelectStuff)
 
   public fun <T : Any> greaterThanNumberAndName(
     number: Long,
@@ -168,14 +131,7 @@ public class PlayerQueries(
     )
   }
 
-  public fun greaterThanNumberAndName(number: Long, name: Player.Name): Query<Player> = greaterThanNumberAndName(number, name) { name_, number_, team, shoots ->
-    Player(
-      name_,
-      number_,
-      team,
-      shoots
-    )
-  }
+  public fun greaterThanNumberAndName(number: Long, name: Player.Name): Query<Player> = greaterThanNumberAndName(number, name, ::Player)
 
   /**
    * @return The number of rows updated.

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/TeamQueries.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/TeamQueries.kt
@@ -23,12 +23,7 @@ public class TeamQueries(
     )
   }
 
-  public fun teamForCoach(coach: String): Query<TeamForCoach> = teamForCoach(coach) { name, captain ->
-    TeamForCoach(
-      name,
-      captain
-    )
-  }
+  public fun teamForCoach(coach: String): Query<TeamForCoach> = teamForCoach(coach, ::TeamForCoach)
 
   public fun <T : Any> forInnerType(inner_type: Shoots.Type?, mapper: (
     name: Team.Name,
@@ -44,14 +39,7 @@ public class TeamQueries(
     )
   }
 
-  public fun forInnerType(inner_type: Shoots.Type?): Query<Team> = forInnerType(inner_type) { name, captain, inner_type_, coach ->
-    Team(
-      name,
-      captain,
-      inner_type_,
-      coach
-    )
-  }
+  public fun forInnerType(inner_type: Shoots.Type?): Query<Team> = forInnerType(inner_type, ::Team)
 
   public fun <T : Any> selectStuff(mapper: (expr: Long, expr_: Long) -> T): ExecutableQuery<T> = Query(397_134_288, driver, "Team.sq", "selectStuff", "SELECT 1, 2") { cursor ->
     mapper(
@@ -60,12 +48,7 @@ public class TeamQueries(
     )
   }
 
-  public fun selectStuff(): ExecutableQuery<SelectStuff> = selectStuff { expr, expr_ ->
-    SelectStuff(
-      expr,
-      expr_
-    )
-  }
+  public fun selectStuff(): ExecutableQuery<SelectStuff> = selectStuff(::SelectStuff)
 
   private inner class TeamForCoachQuery<out T : Any>(
     public val coach: String,

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/SelectQueryGenerator.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/SelectQueryGenerator.kt
@@ -65,12 +65,8 @@ class SelectQueryGenerator(
     val parametersAndTypes = query.parameters.map { argNameAllocator.newName(it.name, it) to it.argumentType() }
 
     val params = parametersAndTypes.map { (name, _) -> CodeBlock.of(name) }
-    val queryCall = if (params.isEmpty()) {
-      CodeBlock.of("%L(::%T)", query.name, query.interfaceType)
-    } else {
-      val ctorCall = CodeBlock.of("::%T", query.interfaceType)
-      (params + ctorCall).joinToCode(", ", "${query.name}(", ")")
-    }
+    val ctorCall = CodeBlock.of("::%T", query.interfaceType)
+    val queryCall = (params + ctorCall).joinToCode(", ", "${query.name}(", ")")
 
     return defaultResultTypeFunctionInterface(parametersAndTypes)
       .addStatement("return %L", queryCall)

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/SelectQueryGenerator.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/SelectQueryGenerator.kt
@@ -64,43 +64,16 @@ class SelectQueryGenerator(
     val argNameAllocator = NameAllocator()
     val parametersAndTypes = query.parameters.map { argNameAllocator.newName(it.name, it) to it.argumentType() }
 
-    val function = defaultResultTypeFunctionInterface(parametersAndTypes)
-    val params = parametersAndTypes.map { (name) -> CodeBlock.of(name) }
-
-    val columnArgs = query.resultColumns.map { argument ->
-      argNameAllocator.newName(argument.name, argument)
+    val params = parametersAndTypes.map { (name, _) -> CodeBlock.of(name) }
+    val queryCall = if (params.isEmpty()) {
+      CodeBlock.of("%L(::%T)", query.name, query.interfaceType)
+    } else {
+      val ctorCall = CodeBlock.of("::%T", query.interfaceType)
+      (params + ctorCall).joinToCode(", ", "${query.name}(", ")")
     }
 
-    val lamdaParams = columnArgs.joinToString(separator = ", ")
-    val ctorParams = columnArgs.joinToString(separator = ",\n", postfix = "\n")
-
-    val trailingLambda = CodeBlock.builder()
-      .add(CodeBlock.of("·{ $lamdaParams ->\n"))
-      .indent()
-      .add("%T(\n", query.interfaceType)
-      .indent()
-      .add(ctorParams)
-      .unindent()
-      .add(")\n")
-      .unindent()
-      .add("}")
-      .build()
-
-    return function
-      .addStatement(
-        "return %L",
-        CodeBlock
-          .builder()
-          .add(
-            if (params.isEmpty()) {
-              CodeBlock.of(query.name)
-            } else {
-              params.joinToCode(", ", "${query.name}(", ")")
-            },
-          )
-          .add(trailingLambda)
-          .build(),
-      )
+    return defaultResultTypeFunctionInterface(parametersAndTypes)
+      .addStatement("return %L", queryCall)
       .build()
   }
 

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/Constants.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/Constants.kt
@@ -4,7 +4,6 @@ import app.cash.sqldelight.core.capitalize
 import app.cash.sqldelight.core.decapitalize
 import com.intellij.openapi.vfs.VirtualFile
 import com.squareup.kotlinpoet.ClassName
-import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 
 internal val CURSOR_TYPE = ClassName("app.cash.sqldelight.db", "SqlCursor")
 internal const val CURSOR_NAME = "cursor"
@@ -22,18 +21,13 @@ internal val AFTER_VERSION_TYPE = ClassName("app.cash.sqldelight.db", "AfterVers
 
 internal val PREPARED_STATEMENT_TYPE = ClassName("app.cash.sqldelight.db", "SqlPreparedStatement")
 
-internal const val CUSTOM_DATABASE_NAME = "database"
-
 internal const val ADAPTER_NAME = "Adapter"
 
 internal val QUERY_TYPE = ClassName("app.cash.sqldelight", "Query")
 internal val EXECUTABLE_QUERY_TYPE = ClassName("app.cash.sqldelight", "ExecutableQuery")
 internal val QUERY_LISTENER_TYPE = QUERY_TYPE.nestedClass("Listener")
-internal val QUERY_LISTENER_LIST_TYPE = ClassName("kotlin.collections", "MutableList")
-  .parameterizedBy(QUERY_LISTENER_TYPE)
 
 internal const val MAPPER_NAME = "mapper"
-internal const val EXECUTE_BLOCK_NAME = "block"
 
 internal const val EXECUTE_METHOD = "execute"
 

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/QueriesTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/QueriesTypeTest.kt
@@ -145,12 +145,7 @@ class QueriesTypeTest {
       |    )
       |  }
       |
-      |  public fun selectForId(id: Long): Query<Data_> = selectForId(id) { id_, value_ ->
-      |    Data_(
-      |      id_,
-      |      value_
-      |    )
-      |  }
+      |  public fun selectForId(id: Long): Query<Data_> = selectForId(id, ::Data_)
       |
       |  public fun <T : Any> selectAllValues(mapper: (id: Long, value_: List?) -> T): Query<T> {
       |    check(setOf(dataAdapter.value_Adapter, otherAdapter.value_Adapter).size == 1) { "Adapter types are expected to be identical." }
@@ -166,12 +161,7 @@ class QueriesTypeTest {
       |    }
       |  }
       |
-      |  public fun selectAllValues(): Query<SelectAllValues> = selectAllValues { id, value_ ->
-      |    SelectAllValues(
-      |      id,
-      |      value_
-      |    )
-      |  }
+      |  public fun selectAllValues(): Query<SelectAllValues> = selectAllValues(::SelectAllValues)
       |
       |  /**
       |   * @return The number of rows updated.
@@ -506,12 +496,7 @@ class QueriesTypeTest {
       |    )
       |  }
       |
-      |  public fun selectForId(id: Long): Query<SelectForId> = selectForId(id) { id_, value_ ->
-      |    SelectForId(
-      |      id_,
-      |      value_
-      |    )
-      |  }
+      |  public fun selectForId(id: Long): Query<SelectForId> = selectForId(id, ::SelectForId)
       |
       |  /**
       |   * @return The number of rows updated.
@@ -662,12 +647,7 @@ class QueriesTypeTest {
       |    )
       |  }
       |
-      |  public fun selectOffsets(search: String): Query<SelectOffsets> = selectOffsets(search) { id, offsets ->
-      |    SelectOffsets(
-      |      id,
-      |      offsets
-      |    )
-      |  }
+      |  public fun selectOffsets(search: String): Query<SelectOffsets> = selectOffsets(search, ::SelectOffsets)
       |
       |  /**
       |   * @return The number of rows updated.
@@ -803,14 +783,7 @@ class QueriesTypeTest {
       |    )
       |  }
       |
-      |  public fun forSoupToken(soup_token: String): Query<SoupView> = forSoupToken(soup_token) { token, soup_token_, soup_broth, soup_name ->
-      |    SoupView(
-      |      token,
-      |      soup_token_,
-      |      soup_broth,
-      |      soup_name
-      |    )
-      |  }
+      |  public fun forSoupToken(soup_token: String): Query<SoupView> = forSoupToken(soup_token, ::SoupView)
       |
       |  public fun <T : Any> maxSoupBroth(mapper: (MAX: ChickenSoupBase.Broth?) -> T): Query<T> = Query(-1_892_940_684, arrayOf("soupBase", "soup"), driver, "MyView.sq", "maxSoupBroth", ""${'"'}
       |  |SELECT MAX(soup_broth)
@@ -821,11 +794,7 @@ class QueriesTypeTest {
       |    )
       |  }
       |
-      |  public fun maxSoupBroth(): Query<MaxSoupBroth> = maxSoupBroth { MAX ->
-      |    MaxSoupBroth(
-      |      MAX
-      |    )
-      |  }
+      |  public fun maxSoupBroth(): Query<MaxSoupBroth> = maxSoupBroth(::MaxSoupBroth)
       |
       |  private inner class ForSoupTokenQuery<out T : Any>(
       |    public val soup_token: String,

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/async/AsyncQueriesTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/async/AsyncQueriesTypeTest.kt
@@ -146,12 +146,7 @@ class AsyncQueriesTypeTest {
       |    )
       |  }
       |
-      |  public fun selectForId(id: Long): Query<Data_> = selectForId(id) { id_, value_ ->
-      |    Data_(
-      |      id_,
-      |      value_
-      |    )
-      |  }
+      |  public fun selectForId(id: Long): Query<Data_> = selectForId(id, ::Data_)
       |
       |  public fun <T : Any> selectAllValues(mapper: (id: Long, value_: List?) -> T): Query<T> {
       |    check(setOf(dataAdapter.value_Adapter, otherAdapter.value_Adapter).size == 1) { "Adapter types are expected to be identical." }
@@ -167,12 +162,7 @@ class AsyncQueriesTypeTest {
       |    }
       |  }
       |
-      |  public fun selectAllValues(): Query<SelectAllValues> = selectAllValues { id, value_ ->
-      |    SelectAllValues(
-      |      id,
-      |      value_
-      |    )
-      |  }
+      |  public fun selectAllValues(): Query<SelectAllValues> = selectAllValues(::SelectAllValues)
       |
       |  /**
       |   * @return The number of rows updated.

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/ExpressionTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/ExpressionTest.kt
@@ -7,6 +7,7 @@ import app.cash.sqldelight.core.TestDialect.POSTGRESQL
 import app.cash.sqldelight.core.compiler.SelectQueryGenerator
 import app.cash.sqldelight.core.dialects.blobType
 import app.cash.sqldelight.core.dialects.textType
+import app.cash.sqldelight.core.test.fileContents
 import app.cash.sqldelight.dialects.sqlite_3_18.SqliteDialect
 import app.cash.sqldelight.test.util.FixtureCompiler
 import com.google.common.truth.Truth.assertThat
@@ -47,15 +48,15 @@ class ExpressionTest {
     )
 
     val generator = SelectQueryGenerator(file.namedQueries.first())
-    assertThat(generator.defaultResultTypeFunction().toString()).isEqualTo(
+    assertThat(generator.defaultResultTypeFunction().fileContents()).isEqualTo(
       """
-      |public fun testQuery(SecondId: kotlin.Long, value_: kotlin.String): app.cash.sqldelight.Query<com.example.Test> = testQuery(SecondId, value_) { TestId, TestText, SecondId_ ->
-      |  com.example.Test(
-      |    TestId,
-      |    TestText,
-      |    SecondId_
-      |  )
-      |}
+      |package com.example
+      |
+      |import app.cash.sqldelight.Query
+      |import kotlin.Long
+      |import kotlin.String
+      |
+      |public fun testQuery(SecondId: Long, value_: String): Query<Test> = testQuery(SecondId, value_, ::Test)
       |
       """.trimMargin(),
     )

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/InterfaceGeneration.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/InterfaceGeneration.kt
@@ -870,13 +870,7 @@ class InterfaceGeneration {
       |    )
       |  }
       |
-      |  public fun selectSongsByAlbumId(album_id: Long?): Query<Song> = selectSongsByAlbumId(album_id) { title, track_number, album_id_ ->
-      |    Song(
-      |      title,
-      |      track_number,
-      |      album_id_
-      |    )
-      |  }
+      |  public fun selectSongsByAlbumId(album_id: Long?): Query<Song> = selectSongsByAlbumId(album_id, ::Song)
       |
       |  private inner class SelectSongsByAlbumIdQuery<out T : Any>(
       |    public val album_id: Long?,
@@ -1080,12 +1074,7 @@ class InterfaceGeneration {
       |    )
       |  }
       |
-      |  public fun recursiveQuery(id: Long): Query<RecursiveQuery> = recursiveQuery(id) { id_, parent_id ->
-      |    RecursiveQuery(
-      |      id_,
-      |      parent_id
-      |    )
-      |  }
+      |  public fun recursiveQuery(id: Long): Query<RecursiveQuery> = recursiveQuery(id, ::RecursiveQuery)
       |
       |  private inner class RecursiveQueryQuery<out T : Any>(
       |    public val id: Long,
@@ -1180,12 +1169,7 @@ class InterfaceGeneration {
       |    )
       |  }
       |
-      |  public fun selectRank(): Query<SelectRank> = selectRank { name, rank ->
-      |    SelectRank(
-      |      name,
-      |      rank
-      |    )
-      |  }
+      |  public fun selectRank(): Query<SelectRank> = selectRank(::SelectRank)
       |}
       |
       """.trimMargin(),
@@ -1311,25 +1295,7 @@ class InterfaceGeneration {
     |    )
     |  }
     |
-    |  public fun selectIsNotNull(): Query<SelectIsNotNull> = selectIsNotNull { has_bigint, has_boolean, has_byte, has_date, has_integer, has_json, has_jsob, has_num, has_smallint, has_time, has_timestamp, has_timestamptz, has_tsvector, has_uuid, has_varchar ->
-    |    SelectIsNotNull(
-    |      has_bigint,
-    |      has_boolean,
-    |      has_byte,
-    |      has_date,
-    |      has_integer,
-    |      has_json,
-    |      has_jsob,
-    |      has_num,
-    |      has_smallint,
-    |      has_time,
-    |      has_timestamp,
-    |      has_timestamptz,
-    |      has_tsvector,
-    |      has_uuid,
-    |      has_varchar
-    |    )
-    |  }
+    |  public fun selectIsNotNull(): Query<SelectIsNotNull> = selectIsNotNull(::SelectIsNotNull)
     |}
     |
       """.trimMargin(),
@@ -1529,21 +1495,7 @@ class InterfaceGeneration {
     |    )
     |  }
     |
-    |  public fun select(): Query<Select> = select { p, f, b, l, d, g, pf, pfb, gf, gfpf, dl ->
-    |    Select(
-    |      p,
-    |      f,
-    |      b,
-    |      l,
-    |      d,
-    |      g,
-    |      pf,
-    |      pfb,
-    |      gf,
-    |      gfpf,
-    |      dl
-    |    )
-    |  }
+    |  public fun select(): Query<Select> = select(::Select)
     |}
     |
       """.trimMargin(),

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/JavadocTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/JavadocTest.kt
@@ -7,6 +7,7 @@ import app.cash.sqldelight.core.compiler.SelectQueryGenerator
 import app.cash.sqldelight.core.dialects.binderCheck
 import app.cash.sqldelight.core.dialects.cursorCheck
 import app.cash.sqldelight.core.dialects.textType
+import app.cash.sqldelight.core.test.fileContents
 import app.cash.sqldelight.test.util.FixtureCompiler
 import app.cash.sqldelight.test.util.withUnderscores
 import com.google.common.truth.Truth.assertThat
@@ -36,17 +37,16 @@ class JavadocTest {
     )
 
     val selectGenerator = SelectQueryGenerator(file.namedQueries.first())
-    assertThat(selectGenerator.defaultResultTypeFunction().toString()).isEqualTo(
+    assertThat(selectGenerator.defaultResultTypeFunction().fileContents()).isEqualTo(
       """
+      |package com.example
+      |
+      |import app.cash.sqldelight.Query
+      |
       |/**
       | * Queries all values.
       | */
-      |public fun selectAll(): app.cash.sqldelight.Query<com.example.Test> = selectAll { _id, value_ ->
-      |  com.example.Test(
-      |    _id,
-      |    value_
-      |  )
-      |}
+      |public fun selectAll(): Query<Test> = selectAll(::Test)
       |
       """.trimMargin(),
     )
@@ -75,17 +75,16 @@ class JavadocTest {
     )
 
     val selectGenerator = SelectQueryGenerator(file.namedQueries.first())
-    assertThat(selectGenerator.defaultResultTypeFunction().toString()).isEqualTo(
+    assertThat(selectGenerator.defaultResultTypeFunction().fileContents()).isEqualTo(
       """
+      |package com.example
+      |
+      |import app.cash.sqldelight.Query
+      |
       |/**
       | * Queries all values.
       | */
-      |public fun selectAll(): app.cash.sqldelight.Query<com.example.Test> = selectAll { _id, value_ ->
-      |  com.example.Test(
-      |    _id,
-      |    value_
-      |  )
-      |}
+      |public fun selectAll(): Query<Test> = selectAll(::Test)
       |
       """.trimMargin(),
     )
@@ -110,20 +109,19 @@ class JavadocTest {
     )
 
     val selectGenerator = SelectQueryGenerator(file.namedQueries.first())
-    assertThat(selectGenerator.defaultResultTypeFunction().toString()).isEqualTo(
+    assertThat(selectGenerator.defaultResultTypeFunction().fileContents()).isEqualTo(
       """
+      |package com.example
+      |
+      |import app.cash.sqldelight.Query
+      |
       |/**
       | * Queries all values.
       | * Returns values as a List.
       | *
       | * @deprecated Don't use it!
       | */
-      |public fun selectAll(): app.cash.sqldelight.Query<com.example.Test> = selectAll { _id, value_ ->
-      |  com.example.Test(
-      |    _id,
-      |    value_
-      |  )
-      |}
+      |public fun selectAll(): Query<Test> = selectAll(::Test)
       |
       """.trimMargin(),
     )
@@ -148,20 +146,19 @@ class JavadocTest {
     )
 
     val selectGenerator = SelectQueryGenerator(file.namedQueries.first())
-    assertThat(selectGenerator.defaultResultTypeFunction().toString()).isEqualTo(
+    assertThat(selectGenerator.defaultResultTypeFunction().fileContents()).isEqualTo(
       """
+      |package com.example
+      |
+      |import app.cash.sqldelight.Query
+      |
       |/**
       | * Queries all values. **
       | * Returns values as a * List.
       | *
       | * ** @deprecated Don't use it!
       | */
-      |public fun selectAll(): app.cash.sqldelight.Query<com.example.Test> = selectAll { _id, value_ ->
-      |  com.example.Test(
-      |    _id,
-      |    value_
-      |  )
-      |}
+      |public fun selectAll(): Query<Test> = selectAll(::Test)
       |
       """.trimMargin(),
     )
@@ -180,16 +177,17 @@ class JavadocTest {
     )
 
     val selectGenerator = SelectQueryGenerator(file.namedQueries.first())
-    assertThat(selectGenerator.defaultResultTypeFunction().toString()).isEqualTo(
+    assertThat(selectGenerator.defaultResultTypeFunction().fileContents()).isEqualTo(
       """
+      |package com.example
+      |
+      |import app.cash.sqldelight.ExecutableQuery
+      |import kotlin.String
+      |
       |/**
       | * Queries all values.
       | */
-      |public fun selectAll(input: kotlin.String?): app.cash.sqldelight.ExecutableQuery<com.example.SelectAll> = selectAll(input) { expr ->
-      |  com.example.SelectAll(
-      |    expr
-      |  )
-      |}
+      |public fun selectAll(input: String?): ExecutableQuery<SelectAll> = selectAll(input, ::SelectAll)
       |
       """.trimMargin(),
     )
@@ -225,17 +223,16 @@ class JavadocTest {
     )
 
     val selectGenerator = SelectQueryGenerator(file.namedQueries.first())
-    assertThat(selectGenerator.defaultResultTypeFunction().toString()).isEqualTo(
+    assertThat(selectGenerator.defaultResultTypeFunction().fileContents()).isEqualTo(
       """
+      |package com.example
+      |
+      |import app.cash.sqldelight.Query
+      |
       |/**
       | * Queries all values.
       | */
-      |public fun selectAll(): app.cash.sqldelight.Query<com.example.Test> = selectAll { _id, value_ ->
-      |  com.example.Test(
-      |    _id,
-      |    value_
-      |  )
-      |}
+      |public fun selectAll(): Query<Test> = selectAll(::Test)
       |
       """.trimMargin(),
     )

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/PgInsertReturningTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/PgInsertReturningTest.kt
@@ -1,6 +1,7 @@
 package app.cash.sqldelight.core.queries
 
 import app.cash.sqldelight.core.compiler.SelectQueryGenerator
+import app.cash.sqldelight.core.test.fileContents
 import app.cash.sqldelight.dialects.postgresql.PostgreSqlDialect
 import app.cash.sqldelight.test.util.FixtureCompiler
 import com.google.common.truth.Truth.assertThat
@@ -33,14 +34,13 @@ class PgInsertReturningTest {
     val insert = file.namedQueries.first()
     val generator = SelectQueryGenerator(insert)
 
-    assertThat(generator.defaultResultTypeFunction().toString()).isEqualTo(
+    assertThat(generator.defaultResultTypeFunction().fileContents()).isEqualTo(
       """
-        |public fun insertReturn(data_: com.example.Data_): app.cash.sqldelight.ExecutableQuery<com.example.Data_> = insertReturn(data_) { id, data__ ->
-        |  com.example.Data_(
-        |    id,
-        |    data__
-        |  )
-        |}
+        |package com.example
+        |
+        |import app.cash.sqldelight.ExecutableQuery
+        |
+        |public fun insertReturn(data_: Data_): ExecutableQuery<Data_> = insertReturn(data_, ::Data_)
         |
       """.trimMargin(),
     )
@@ -79,14 +79,13 @@ class PgInsertReturningTest {
     val insert = file.namedQueries.first()
     val generator = SelectQueryGenerator(insert)
 
-    assertThat(generator.defaultResultTypeFunction().toString()).isEqualTo(
+    assertThat(generator.defaultResultTypeFunction().fileContents()).isEqualTo(
       """
-        |public fun insertReturn(data_: com.example.Data_): app.cash.sqldelight.ExecutableQuery<com.example.InsertReturn> = insertReturn(data_) { data__, id ->
-        |  com.example.InsertReturn(
-        |    data__,
-        |    id
-        |  )
-        |}
+        |package com.example
+        |
+        |import app.cash.sqldelight.ExecutableQuery
+        |
+        |public fun insertReturn(data_: Data_): ExecutableQuery<InsertReturn> = insertReturn(data_, ::InsertReturn)
         |
       """.trimMargin(),
     )

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/SelectQueryFunctionTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/SelectQueryFunctionTest.kt
@@ -3,6 +3,7 @@ package app.cash.sqldelight.core.queries
 import app.cash.sqldelight.core.TestDialect
 import app.cash.sqldelight.core.compiler.SelectQueryGenerator
 import app.cash.sqldelight.core.dialects.intType
+import app.cash.sqldelight.core.test.fileContents
 import app.cash.sqldelight.test.util.FixtureCompiler
 import app.cash.sqldelight.test.util.withUnderscores
 import com.google.common.truth.Truth.assertThat
@@ -36,14 +37,14 @@ class SelectQueryFunctionTest {
     )
 
     val generator = SelectQueryGenerator(file.namedQueries.first())
-    assertThat(generator.defaultResultTypeFunction().toString()).isEqualTo(
+    assertThat(generator.defaultResultTypeFunction().fileContents()).isEqualTo(
       """
-      |public fun selectForId(id: kotlin.Long): app.cash.sqldelight.Query<com.example.Data_> = selectForId(id) { id_, value_ ->
-      |  com.example.Data_(
-      |    id_,
-      |    value_
-      |  )
-      |}
+      |package com.example
+      |
+      |import app.cash.sqldelight.Query
+      |import kotlin.Long
+      |
+      |public fun selectForId(id: Long): Query<Data_> = selectForId(id, ::Data_)
       |
       """.trimMargin(),
     )
@@ -79,19 +80,18 @@ class SelectQueryFunctionTest {
     )
 
     val generator = SelectQueryGenerator(file.namedQueries.first())
-    assertThat(generator.defaultResultTypeFunction().toString()).isEqualTo(
+    assertThat(generator.defaultResultTypeFunction().fileContents()).isEqualTo(
       """
+      |package com.example
+      |
+      |import app.cash.sqldelight.Query
+      |import kotlin.String
+      |
       |public fun selectByChannelId(
-      |  channelId: kotlin.String,
-      |  from: com.example.LocalDateTime,
-      |  to: com.example.LocalDateTime,
-      |): app.cash.sqldelight.Query<com.example.Data_> = selectByChannelId(channelId, from, to) { channelId_, startTime, endTime ->
-      |  com.example.Data_(
-      |    channelId_,
-      |    startTime,
-      |    endTime
-      |  )
-      |}
+      |  channelId: String,
+      |  from: LocalDateTime,
+      |  to: LocalDateTime,
+      |): Query<Data_> = selectByChannelId(channelId, from, to, ::Data_)
       |
       """.trimMargin(),
     )
@@ -115,14 +115,15 @@ class SelectQueryFunctionTest {
     )
 
     val generator = SelectQueryGenerator(file.namedQueries.first())
-    assertThat(generator.defaultResultTypeFunction().toString()).isEqualTo(
+    assertThat(generator.defaultResultTypeFunction().fileContents()).isEqualTo(
       """
-      |public fun select(value_: kotlin.String, id: kotlin.Long): app.cash.sqldelight.Query<com.example.Data_> = select(value_, id) { id_, value__ ->
-      |  com.example.Data_(
-      |    id_,
-      |    value__
-      |  )
-      |}
+      |package com.example
+      |
+      |import app.cash.sqldelight.Query
+      |import kotlin.Long
+      |import kotlin.String
+      |
+      |public fun select(value_: String, id: Long): Query<Data_> = select(value_, id, ::Data_)
       |
       """.trimMargin(),
     )
@@ -346,14 +347,14 @@ class SelectQueryFunctionTest {
     )
 
     val generator = SelectQueryGenerator(file.namedQueries.first())
-    assertThat(generator.defaultResultTypeFunction().toString()).isEqualTo(
+    assertThat(generator.defaultResultTypeFunction().fileContents()).isEqualTo(
       """
-      |public fun someSelect(minimum: kotlin.Long, offset: kotlin.Long): app.cash.sqldelight.Query<com.example.Data_> = someSelect(minimum, offset) { some_column, some_column2 ->
-      |  com.example.Data_(
-      |    some_column,
-      |    some_column2
-      |  )
-      |}
+      |package com.example
+      |
+      |import app.cash.sqldelight.Query
+      |import kotlin.Long
+      |
+      |public fun someSelect(minimum: Long, offset: Long): Query<Data_> = someSelect(minimum, offset, ::Data_)
       |
       """.trimMargin(),
     )
@@ -804,15 +805,13 @@ class SelectQueryFunctionTest {
     )
 
     val generator = SelectQueryGenerator(file.namedQueries.first())
-    assertThat(generator.defaultResultTypeFunction().toString()).isEqualTo(
+    assertThat(generator.defaultResultTypeFunction().fileContents()).isEqualTo(
       """
-      |public fun selectData(): app.cash.sqldelight.Query<com.example.SelectData> = selectData { coalesce, value_, value2 ->
-      |  com.example.SelectData(
-      |    coalesce,
-      |    value_,
-      |    value2
-      |  )
-      |}
+      |package com.example
+      |
+      |import app.cash.sqldelight.Query
+      |
+      |public fun selectData(): Query<SelectData> = selectData(::SelectData)
       |
       """.trimMargin(),
     )
@@ -1425,14 +1424,13 @@ class SelectQueryFunctionTest {
     val query = file.namedQueries.first()
     val generator = SelectQueryGenerator(query)
 
-    assertThat(generator.defaultResultTypeFunction().toString()).isEqualTo(
+    assertThat(generator.defaultResultTypeFunction().fileContents()).isEqualTo(
       """
-      |public fun unioned(): app.cash.sqldelight.Query<com.example.SupView> = unioned { value1, value2 ->
-      |  com.example.SupView(
-      |    value1,
-      |    value2
-      |  )
-      |}
+      |package com.example
+      |
+      |import app.cash.sqldelight.Query
+      |
+      |public fun unioned(): Query<SupView> = unioned(::SupView)
       |
       """.trimMargin(),
     )
@@ -1465,13 +1463,13 @@ class SelectQueryFunctionTest {
     val query = file.namedQueries.first()
     val generator = SelectQueryGenerator(query)
 
-    assertThat(generator.defaultResultTypeFunction().toString()).isEqualTo(
+    assertThat(generator.defaultResultTypeFunction().fileContents()).isEqualTo(
       """
-      |public fun unioned(): app.cash.sqldelight.Query<com.example.Unioned> = unioned { value_ ->
-      |  com.example.Unioned(
-      |    value_
-      |  )
-      |}
+      |package com.example
+      |
+      |import app.cash.sqldelight.Query
+      |
+      |public fun unioned(): Query<Unioned> = unioned(::Unioned)
       |
       """.trimMargin(),
     )
@@ -1500,13 +1498,13 @@ class SelectQueryFunctionTest {
     val query = file.namedQueries.first()
     val generator = SelectQueryGenerator(query)
 
-    assertThat(generator.defaultResultTypeFunction().toString()).isEqualTo(
+    assertThat(generator.defaultResultTypeFunction().fileContents()).isEqualTo(
       """
-      |public fun unioned(): app.cash.sqldelight.Query<com.example.Sup> = unioned { value_ ->
-      |  com.example.Sup(
-      |    value_
-      |  )
-      |}
+      |package com.example
+      |
+      |import app.cash.sqldelight.Query
+      |
+      |public fun unioned(): Query<Sup> = unioned(::Sup)
       |
       """.trimMargin(),
     )
@@ -1546,14 +1544,13 @@ class SelectQueryFunctionTest {
     val query = file.namedQueries.first()
     val generator = SelectQueryGenerator(query)
 
-    assertThat(generator.defaultResultTypeFunction().toString()).isEqualTo(
+    assertThat(generator.defaultResultTypeFunction().fileContents()).isEqualTo(
       """
-      |public fun findAll(): app.cash.sqldelight.Query<com.example.TestView> = findAll { id, name ->
-      |  com.example.TestView(
-      |    id,
-      |    name
-      |  )
-      |}
+      |package com.example
+      |
+      |import app.cash.sqldelight.Query
+      |
+      |public fun findAll(): Query<TestView> = findAll(::TestView)
       |
       """.trimMargin(),
     )
@@ -1601,15 +1598,14 @@ class SelectQueryFunctionTest {
     )
 
     val generator = SelectQueryGenerator(file.namedQueries.first())
-    assertThat(generator.defaultResultTypeFunction().toString()).isEqualTo(
+    assertThat(generator.defaultResultTypeFunction().fileContents()).isEqualTo(
       """
-      |public fun select_default_with_query(value_: kotlin.String): app.cash.sqldelight.Query<com.example.Player> = select_default_with_query(value_) { id, username, email ->
-      |  com.example.Player(
-      |    id,
-      |    username,
-      |    email
-      |  )
-      |}
+      |package com.example
+      |
+      |import app.cash.sqldelight.Query
+      |import kotlin.String
+      |
+      |public fun select_default_with_query(value_: String): Query<Player> = select_default_with_query(value_, ::Player)
       |
       """.trimMargin(),
     )
@@ -1666,18 +1662,19 @@ class SelectQueryFunctionTest {
     )
 
     val generator = SelectQueryGenerator(file.namedQueries.first())
-    assertThat(generator.defaultResultTypeFunction().toString()).isEqualTo(
+    assertThat(generator.defaultResultTypeFunction().fileContents()).isEqualTo(
       """
+      |package com.example
+      |
+      |import app.cash.sqldelight.Query
+      |import kotlin.Long
+      |import kotlin.String
+      |
       |public fun findStoresForUser(
-      |  userId: kotlin.String,
-      |  value_: kotlin.Long,
-      |  value__: kotlin.Long,
-      |): app.cash.sqldelight.Query<com.example.Stores> = findStoresForUser(userId, value_, value__) { id, name ->
-      |  com.example.Stores(
-      |    id,
-      |    name
-      |  )
-      |}
+      |  userId: String,
+      |  value_: Long,
+      |  value__: Long,
+      |): Query<Stores> = findStoresForUser(userId, value_, value__, ::Stores)
       |
       """.trimMargin(),
     )
@@ -1748,13 +1745,14 @@ class SelectQueryFunctionTest {
     val query1 = file.namedQueries[0]
     var generator = SelectQueryGenerator(query1)
 
-    assertThat(generator.defaultResultTypeFunction().toString()).isEqualTo(
+    assertThat(generator.defaultResultTypeFunction().fileContents()).isEqualTo(
       """
-        |public fun test1(initialized: kotlin.Boolean?): app.cash.sqldelight.Query<com.example.Users> = test1(initialized) { initialized_ ->
-        |  com.example.Users(
-        |    initialized_
-        |  )
-        |}
+        |package com.example
+        |
+        |import app.cash.sqldelight.Query
+        |import kotlin.Boolean
+        |
+        |public fun test1(initialized: Boolean?): Query<Users> = test1(initialized, ::Users)
         |
       """.trimMargin(),
     )
@@ -1762,13 +1760,14 @@ class SelectQueryFunctionTest {
     val query2 = file.namedQueries[1]
     generator = SelectQueryGenerator(query2)
 
-    assertThat(generator.defaultResultTypeFunction().toString()).isEqualTo(
+    assertThat(generator.defaultResultTypeFunction().fileContents()).isEqualTo(
       """
-        |public fun test2(initialized: kotlin.Boolean?): app.cash.sqldelight.Query<com.example.Users> = test2(initialized) { initialized_ ->
-        |  com.example.Users(
-        |    initialized_
-        |  )
-        |}
+        |package com.example
+        |
+        |import app.cash.sqldelight.Query
+        |import kotlin.Boolean
+        |
+        |public fun test2(initialized: Boolean?): Query<Users> = test2(initialized, ::Users)
         |
       """.trimMargin(),
     )

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/async/AsyncQueryFunctionTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/async/AsyncQueryFunctionTest.kt
@@ -1,8 +1,9 @@
 package app.cash.sqldelight.core.queries.async
 
 import app.cash.sqldelight.core.compiler.SelectQueryGenerator
+import app.cash.sqldelight.core.test.fileContents
 import app.cash.sqldelight.test.util.FixtureCompiler
-import com.google.common.truth.Truth
+import com.google.common.truth.Truth.assertThat
 import com.squareup.burst.BurstJUnit4
 import org.junit.Rule
 import org.junit.Test
@@ -33,14 +34,14 @@ class AsyncQueryFunctionTest {
     )
 
     val generator = SelectQueryGenerator(file.namedQueries.first())
-    Truth.assertThat(generator.defaultResultTypeFunction().toString()).isEqualTo(
+    assertThat(generator.defaultResultTypeFunction().fileContents()).isEqualTo(
       """
-      |public fun selectForId(id: kotlin.Long): app.cash.sqldelight.Query<com.example.Data_> = selectForId(id) { id_, value_ ->
-      |  com.example.Data_(
-      |    id_,
-      |    value_
-      |  )
-      |}
+      |package com.example
+      |
+      |import app.cash.sqldelight.Query
+      |import kotlin.Long
+      |
+      |public fun selectForId(id: Long): Query<Data_> = selectForId(id, ::Data_)
       |
       """.trimMargin(),
     )

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/test/FunSpecExtensions.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/test/FunSpecExtensions.kt
@@ -1,0 +1,17 @@
+package app.cash.sqldelight.core.test
+
+import app.cash.sqldelight.core.compiler.SelectQueryGenerator
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.FunSpec
+
+/**
+ * Added to make sure imports are resolved, since we're referencing constructors in generated code and Kotlin doesn't
+ * support that when specifying the full package name inline (e.g. `::MyClass` works but `com.example::MyClass`
+ * doesn't) - which we're doing when calling [FunSpec.toString]. This should only be necessary when calling
+ * [SelectQueryGenerator.defaultResultTypeFunction], not for [SelectQueryGenerator.customResultTypeFunction].
+ */
+internal fun FunSpec.fileContents(): String = FileSpec
+  .builder("com.example", "Test")
+  .addFunction(this)
+  .build()
+  .toString()

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-add-constraint/output/com/example/DataQueries.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-add-constraint/output/com/example/DataQueries.kt
@@ -22,12 +22,7 @@ public class DataQueries(
     )
   }
 
-  public fun selectSingle(): Query<TestSingle> = selectSingle { first, second ->
-    TestSingle(
-      first,
-      second
-    )
-  }
+  public fun selectSingle(): Query<TestSingle> = selectSingle(::TestSingle)
 
   public fun <T : Any> selectCompound(mapper: (first: Int, second: String) -> T): Query<T> = Query(-19_725_220, arrayOf("TestCompound"), driver, "Data.sq", "selectCompound", """
   |SELECT TestCompound.first, TestCompound.second
@@ -40,10 +35,5 @@ public class DataQueries(
     )
   }
 
-  public fun selectCompound(): Query<TestCompound> = selectCompound { first, second ->
-    TestCompound(
-      first,
-      second
-    )
-  }
+  public fun selectCompound(): Query<TestCompound> = selectCompound(::TestCompound)
 }

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table/output/com/example/DataQueries.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table/output/com/example/DataQueries.kt
@@ -22,10 +22,5 @@ public class DataQueries(
     )
   }
 
-  public fun migrationSelect(): Query<New_test> = migrationSelect { first, second ->
-    New_test(
-      first,
-      second
-    )
-  }
+  public fun migrationSelect(): Query<New_test> = migrationSelect(::New_test)
 }

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/create-or-replace-view/output/com/example/DataQueries.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/create-or-replace-view/output/com/example/DataQueries.kt
@@ -29,11 +29,5 @@ public class DataQueries(
     )
   }
 
-  public fun select(): Query<V_test> = select { a, b, c ->
-    V_test(
-      a,
-      b,
-      c
-    )
-  }
+  public fun select(): Query<V_test> = select(::V_test)
 }

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/create-or-replace-view/output/com/example/queries/DataQueries.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/create-or-replace-view/output/com/example/queries/DataQueries.kt
@@ -29,11 +29,5 @@ public class DataQueries(
     )
   }
 
-  public fun select(): Query<V_test> = select { a, b, c ->
-    V_test(
-      a,
-      b,
-      c
-    )
-  }
+  public fun select(): Query<V_test> = select(::V_test)
 }

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/varying-query-migration-packages/output/com/example/queries/DataQueries.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/varying-query-migration-packages/output/com/example/queries/DataQueries.kt
@@ -27,12 +27,7 @@ public class DataQueries(
     )
   }
 
-  public fun migrationSelect(): Query<Test> = migrationSelect { first, second ->
-    Test(
-      first,
-      second
-    )
-  }
+  public fun migrationSelect(): Query<Test> = migrationSelect(::Test)
 
   public fun <T : Any> migrationInsert(
     first: String,
@@ -46,12 +41,7 @@ public class DataQueries(
     )
   }
 
-  public fun migrationInsert(first: String, second: Int): ExecutableQuery<Test> = migrationInsert(first, second) { first_, second_ ->
-    Test(
-      first_,
-      second_
-    )
-  }
+  public fun migrationInsert(first: String, second: Int): ExecutableQuery<Test> = migrationInsert(first, second, ::Test)
 
   public fun <T : Any> migrationDelete(first: String, mapper: (first: String, second: Int) -> T): ExecutableQuery<T> = MigrationDeleteQuery(first) { cursor ->
     check(cursor is JdbcCursor)
@@ -61,12 +51,7 @@ public class DataQueries(
     )
   }
 
-  public fun migrationDelete(first: String): ExecutableQuery<Test> = migrationDelete(first) { first_, second ->
-    Test(
-      first_,
-      second
-    )
-  }
+  public fun migrationDelete(first: String): ExecutableQuery<Test> = migrationDelete(first, ::Test)
 
   public fun <T : Any> migrationUpdate(first: String, mapper: (first: String, second: Int) -> T): ExecutableQuery<T> = MigrationUpdateQuery(first) { cursor ->
     check(cursor is JdbcCursor)
@@ -76,12 +61,7 @@ public class DataQueries(
     )
   }
 
-  public fun migrationUpdate(first: String): ExecutableQuery<Test> = migrationUpdate(first) { first_, second ->
-    Test(
-      first_,
-      second
-    )
-  }
+  public fun migrationUpdate(first: String): ExecutableQuery<Test> = migrationUpdate(first, ::Test)
 
   private inner class MigrationInsertQuery<out T : Any>(
     public val first: String,

--- a/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/WithCommonConfiguration.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/WithCommonConfiguration.kt
@@ -1,6 +1,7 @@
 package app.cash.sqldelight
 
 import java.io.File
+import java.util.Properties
 import org.gradle.testkit.runner.GradleRunner
 
 internal fun GradleRunner.withCommonConfiguration(projectRoot: File): GradleRunner {
@@ -11,5 +12,29 @@ internal fun GradleRunner.withCommonConfiguration(projectRoot: File): GradleRunn
       |
     """.trimMargin(),
   )
+  File(projectRoot, "local.properties").apply {
+    if (!exists()) writeText("sdk.dir=${androidHome()}\n")
+  }
   return withProjectDir(projectRoot).withTestKitDir(File("build/gradle-test-kit").absoluteFile)
+}
+
+private fun androidHome(): String {
+  val env = System.getenv("ANDROID_HOME")
+  if (env != null) {
+    return env.withInvariantPathSeparators()
+  }
+  val localProp = File(File(System.getProperty("user.dir")).parentFile, "local.properties")
+  if (localProp.exists()) {
+    val prop = Properties()
+    localProp.inputStream().use {
+      prop.load(it)
+    }
+    val sdkHome = prop.getProperty("sdk.dir")
+    if (sdkHome != null) {
+      return sdkHome.withInvariantPathSeparators()
+    }
+  }
+  throw IllegalStateException(
+    "Missing 'ANDROID_HOME' environment variable or local.properties with 'sdk.dir'",
+  )
 }


### PR DESCRIPTION
**No functional difference**

Made a change to the generated code from `SelectQueryGenerator` to reduce generated LoC and complexity, especially for big queries with lots of columns.

Previously we'd get two generated queries, like:
```kotlin
public fun <T : Any> getData(id: Long, mapper: (id: Long, parent_id: Long?) -> T): Query<T> = GetDataQuery(id) { cursor ->
  mapper(
    cursor.getLong(0)!!,
    cursor.getLong(1)
  )
}

public fun getData(id: Long): Query<GetData> = getData(id) { id_, parent_id ->
  GetData(
    id_,
    parent_id
  )
}
```

The first one stays as-is, but now the latter one is replaced with:

```kotlin
public fun getData(id: Long): Query<GetData> = getData(id, ::GetData)
```

Or if there are no query parameters:
```kotlin
public fun getData(): Query<GetData> = getData(::GetData)
```

Most diffs are from updating the tests - a few of which now convert generated `FunSpec` to `FileSpec` before asserting because of awkwardness referring to constructors when also needing the full classpath inline. See the comment on `fileContents()`

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
