### PR TITLE
Use table aliases when expanding SELECT * statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Fixed
 
 - [SQLite Dialect] Fix Sqlite 3.18 missing functions (#5759 by by [Griffio][griffio])
+- [Compiler] Keep track of table aliases when expanding SELECT * statements (#5816 by [Jon Poulton][jonapoul])
 
 
 ## [2.1.0] - 2025-05-16

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/TreeUtil.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/TreeUtil.kt
@@ -357,6 +357,8 @@ private fun SqlResultColumn.createTableNameToAliasMapping() = PsiTreeUtil
   .toMap()
 
 private fun toMappingOrNull(alias: SqlTableAlias): Pair<String, String>? {
-  val tableName = PsiTreeUtil.getPrevSiblingOfType(alias, SqlTableName::class.java)?.name
-  return tableName?.let { it to alias.name }
+  // using "nameIdentifier.text" instead of "name" because it captures of backticks around table/alias names
+  val tableName = PsiTreeUtil.getPrevSiblingOfType(alias, SqlTableName::class.java)?.nameIdentifier?.text
+  val aliasName = alias.nameIdentifier?.text
+  return if (tableName != null && aliasName != null) tableName to aliasName else null
 }

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/util/TreeUtilTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/util/TreeUtilTest.kt
@@ -163,4 +163,21 @@ class TreeUtilTest {
       """.trimMargin(),
     )
   }
+
+  @Test fun `rawSqlText maintains aliased tables in join statement when selecting all columns`() {
+    val file = FixtureCompiler.parseSql(
+      """
+      |CREATE TABLE IF NOT EXISTS TableA(id TEXT PRIMARY KEY, value INTEGER);
+      |CREATE TABLE IF NOT EXISTS TableB(id TEXT PRIMARY KEY, value INTEGER);
+      |
+      |getMatching:
+      |  SELECT * FROM TableA a LEFT JOIN TableB b ON a.id = b.id;
+      """.trimMargin(),
+      temporaryFolder,
+    )
+
+    assertThat(file.sqlStatements().last().statement.rawSqlText()).isEqualTo(
+      "SELECT a.id, a.value, b.id, b.value FROM TableA a LEFT JOIN TableB b ON a.id = b.id",
+    )
+  }
 }

--- a/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/integrations/IntegrationTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/integrations/IntegrationTest.kt
@@ -198,4 +198,13 @@ class IntegrationTest {
     val result = runner.build()
     assertThat(result.output).contains("BUILD SUCCESSFUL")
   }
+
+  @Test fun `Generate aliased table references when selecting all columns`() {
+    val output = GradleRunner.create()
+      .withCommonConfiguration(File("src/test/select-all-joining-aliased-tables"))
+      .withArguments("clean", "test", "--stacktrace")
+      .build()
+      .output
+    assertThat(output).contains("BUILD SUCCESSFUL")
+  }
 }

--- a/sqldelight-gradle-plugin/src/test/select-all-joining-aliased-tables/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/select-all-joining-aliased-tables/build.gradle
@@ -1,0 +1,18 @@
+plugins {
+  alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.sqldelight)
+}
+
+sqldelight {
+  databases {
+    TestDatabase {
+      packageName = "app.cash.sqldelight.integration"
+    }
+  }
+}
+
+dependencies {
+  implementation libs.sqliteJdbc
+  implementation "app.cash.sqldelight:sqlite-driver:${app.cash.sqldelight.VersionKt.VERSION}"
+  implementation libs.truth
+}

--- a/sqldelight-gradle-plugin/src/test/select-all-joining-aliased-tables/settings.gradle
+++ b/sqldelight-gradle-plugin/src/test/select-all-joining-aliased-tables/settings.gradle
@@ -1,0 +1,15 @@
+pluginManagement {
+  includeBuild("../build-logic-tests")
+}
+
+plugins {
+  id("sqldelightTests")
+}
+
+rootProject.name = 'select-all-joining-aliased-tables'
+
+buildCache {
+  local {
+    directory = new File(rootDir, 'build-cache')
+  }
+}

--- a/sqldelight-gradle-plugin/src/test/select-all-joining-aliased-tables/src/main/sqldelight/app/cash/sqldelight/integration/Test.sq
+++ b/sqldelight-gradle-plugin/src/test/select-all-joining-aliased-tables/src/main/sqldelight/app/cash/sqldelight/integration/Test.sq
@@ -1,11 +1,15 @@
+-- Regular join operations
 CREATE TABLE IF NOT EXISTS TableA(id TEXT PRIMARY KEY, value INTEGER);
 CREATE TABLE IF NOT EXISTS TableB(id TEXT PRIMARY KEY, value INTEGER);
 
-insertA:
-  INSERT INTO TableA VALUES ?;
+insertA: INSERT INTO TableA VALUES ?;
+insertB: INSERT INTO TableB VALUES ?;
+getMatching: SELECT * FROM TableA a LEFT JOIN TableB b ON a.id = b.id;
 
-insertB:
-  INSERT INTO TableB VALUES ?;
+-- Checking that backticks are handled properly on table names and aliases
+CREATE TABLE `player`(id INTEGER NOT NULL PRIMARY KEY, name TEXT NOT NULL, team_id INTEGER NOT NULL);
+CREATE TABLE `team`(id INTEGER NOT NULL PRIMARY KEY, name TEXT NOT NULL);
 
-getMatching:
-  SELECT * FROM TableA a LEFT JOIN TableB b ON a.id = b.id;
+insertPlayer: INSERT INTO `player` VALUES ?;
+insertTeam: INSERT INTO `team` VALUES ?;
+matchPlayerToTeam: SELECT * FROM `player` `p` JOIN `team` ON `p`.team_id = `team`.id;

--- a/sqldelight-gradle-plugin/src/test/select-all-joining-aliased-tables/src/main/sqldelight/app/cash/sqldelight/integration/Test.sq
+++ b/sqldelight-gradle-plugin/src/test/select-all-joining-aliased-tables/src/main/sqldelight/app/cash/sqldelight/integration/Test.sq
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS TableA(id TEXT PRIMARY KEY, value INTEGER);
+CREATE TABLE IF NOT EXISTS TableB(id TEXT PRIMARY KEY, value INTEGER);
+
+insertA:
+  INSERT INTO TableA VALUES ?;
+
+insertB:
+  INSERT INTO TableB VALUES ?;
+
+getMatching:
+  SELECT * FROM TableA a LEFT JOIN TableB b ON a.id = b.id;

--- a/sqldelight-gradle-plugin/src/test/select-all-joining-aliased-tables/src/test/java/app/cash/sqldelight/integration/IntegrationTests.kt
+++ b/sqldelight-gradle-plugin/src/test/select-all-joining-aliased-tables/src/test/java/app/cash/sqldelight/integration/IntegrationTests.kt
@@ -1,0 +1,35 @@
+package app.cash.sqldelight.integration
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class IntegrationTests {
+  @Test fun `running left join with named tables generates a valid select statement`() {
+    val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+    TestDatabase.Schema.create(driver)
+    val db = TestDatabase(driver)
+
+    with(db.testQueries) {
+      transaction {
+        insertA(TableA("1", 123L))
+        insertA(TableA("2", 456L))
+        insertA(TableA("3", 789L))
+        insertA(TableA("4", 1234L))
+
+        insertB(TableB("1", 2345L))
+        insertB(TableB("3", 6789L))
+        insertB(TableB("5", 123456L))
+      }
+    }
+
+    val expected = listOf(
+      GetMatching(id = "1", value_ = 123L, id_ = "1", value__ = 2345L),
+      GetMatching(id = "2", value_ = 456L, id_ = null, value__ = null),
+      GetMatching(id = "3", value_ = 789L, id_ = "3", value__ = 6789L),
+      GetMatching(id = "4", value_ = 1234L, id_ = null, value__ = null),
+    )
+    val actual = db.testQueries.getMatching().executeAsList()
+    assertThat(actual).isEqualTo(expected)
+  }
+}

--- a/sqldelight-gradle-plugin/src/test/select-all-joining-aliased-tables/src/test/java/app/cash/sqldelight/integration/IntegrationTests.kt
+++ b/sqldelight-gradle-plugin/src/test/select-all-joining-aliased-tables/src/test/java/app/cash/sqldelight/integration/IntegrationTests.kt
@@ -32,4 +32,35 @@ class IntegrationTests {
     val actual = db.testQueries.getMatching().executeAsList()
     assertThat(actual).isEqualTo(expected)
   }
+
+  @Test fun `running named tables surrounded by backticks generates a valid select statement`() {
+    val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+    TestDatabase.Schema.create(driver)
+    val db = TestDatabase(driver)
+
+    with(db.testQueries) {
+      transaction {
+        insertPlayer(Player(1L, "Andrey Arshavin", 101L))
+        insertPlayer(Player(2L, "Barry Bannan", 102L))
+        insertPlayer(Player(3L, "Christian Chivu", 103L))
+        insertPlayer(Player(4L, "Didier Drogba", 104L))
+        insertPlayer(Player(5L, "Emmanuel Eboué", 101L))
+
+        insertTeam(Team(101L, "Arsenal"))
+        insertTeam(Team(102L, "Aston Villa"))
+        insertTeam(Team(103L, "Inter"))
+        insertTeam(Team(104L, "Chelsea"))
+      }
+    }
+
+    val expected = listOf(
+      MatchPlayerToTeam(1L, "Andrey Arshavin", 101L, 101L, "Arsenal"),
+      MatchPlayerToTeam(2L, "Barry Bannan", 102L, 102L, "Aston Villa"),
+      MatchPlayerToTeam(3L, "Christian Chivu", 103L, 103L, "Inter"),
+      MatchPlayerToTeam(4L, "Didier Drogba", 104L, 104L, "Chelsea"),
+      MatchPlayerToTeam(5L, "Emmanuel Eboué", 101L, 101L, "Arsenal"),
+    )
+    val actual = db.testQueries.matchPlayerToTeam().executeAsList()
+    assertThat(actual).isEqualTo(expected)
+  }
 }


### PR DESCRIPTION
Fixed an issue that I ran into where I had a statement like below:
```sql
CREATE TABLE IF NOT EXISTS TableA(id TEXT PRIMARY KEY, value INTEGER);
CREATE TABLE IF NOT EXISTS TableB(id TEXT PRIMARY KEY, value INTEGER);

getMatching:
  SELECT * FROM TableA a LEFT JOIN TableB b ON a.id = b.id;
```
But the generated code for the statement looked like:
```kotlin
public fun <T : Any> getMatching(mapper: (
  id: String,
  value_: Long?,
  id_: String?,
  value__: Long?,
) -> T): Query<T> = Query(-953_075_072, arrayOf("TableA", "TableB"), driver, "Test.sq",
    "getMatching", """
|SELECT TableA.id, TableA.value, TableB.id, TableB.value
|  FROM TableA a
|  LEFT JOIN TableB b
|  ON a.id = b.id
""".trimMargin()) { cursor ->
  mapper(
    cursor.getString(0)!!,
    cursor.getLong(1),
    cursor.getString(2),
    cursor.getLong(3)
  )
}
```
but the select statement isn't using the named aliases, so we get a runtime error:
```
[SQLITE_ERROR] SQL error or missing database (no such column: TableA.id)
```

But now it tracks the aliases as expected:
```diff
-|SELECT TableA.id, TableA.value, TableB.id, TableB.value
+|SELECT a.id, a.value, b.id, b.value
```

Resolves https://github.com/sqldelight/sqldelight/issues/5762

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
