### PR TITLE
Add PostgreSql system columns as synthetic columns

### DIFF
--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -127,6 +127,7 @@ overrides ::= type_name
   | extension_stmt
   | create_index_stmt
   | create_view_stmt
+  | create_table_stmt
   | select_stmt
   | ordering_term
   | binary_like_operator
@@ -223,6 +224,15 @@ create_index_stmt ::= CREATE [ UNIQUE ] INDEX [ 'CONCURRENTLY' ] [ IF NOT EXISTS
 
 create_view_stmt ::= CREATE [ OR REPLACE ] [ TEMP | TEMPORARY ] [ RECURSIVE ] VIEW [ {database_name} DOT ] {view_name} [ LP {column_alias} ( COMMA {column_alias} ) * RP ] AS {compound_select_stmt} [ WITH [ 'CASCADED' | 'LOCAL' ] CHECK 'OPTION' ] {
   mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.CreateOrReplaceViewMixin"
+  override = true
+  pin = 6
+}
+
+create_table_stmt ::= CREATE [ TEMP | TEMPORARY ] TABLE [ IF NOT EXISTS ] [ {database_name} DOT ] {table_name} ( LP {column_def} ( COMMA {column_def} ) * ( COMMA {table_constraint} ) * RP [ {table_options} ] | AS {compound_select_stmt} ) {
+  mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.CreateTableMixin"
+  implements = "com.alecstrong.sql.psi.core.psi.TableElement"
+  elementTypeClass = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.CreateTableElementType"
+  stubClass = "com.alecstrong.sql.psi.core.psi.SchemaContributorStub"
   override = true
   pin = 6
 }

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/CreateTableMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/CreateTableMixin.kt
@@ -1,0 +1,57 @@
+package app.cash.sqldelight.dialects.postgresql.grammar.mixins
+
+import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlCreateTableStmt
+import com.alecstrong.sql.psi.core.SqlSchemaContributorElementType
+import com.alecstrong.sql.psi.core.psi.QueryElement.QueryColumn
+import com.alecstrong.sql.psi.core.psi.QueryElement.QueryResult
+import com.alecstrong.sql.psi.core.psi.QueryElement.SynthesizedColumn
+import com.alecstrong.sql.psi.core.psi.SchemaContributorStub
+import com.alecstrong.sql.psi.core.psi.SqlTypes
+import com.alecstrong.sql.psi.core.psi.TableElement
+import com.alecstrong.sql.psi.core.psi.impl.SqlCreateTableStmtImpl
+import com.intellij.lang.ASTNode
+import com.intellij.psi.PsiElement
+import com.intellij.psi.stubs.IStubElementType
+
+internal abstract class CreateTableMixin :
+  SqlCreateTableStmtImpl,
+  PostgreSqlCreateTableStmt {
+  constructor(node: ASTNode) : super(node)
+  constructor(stub: SchemaContributorStub, stubType: IStubElementType<*, *>) : super(stub, stubType)
+
+  override fun queryAvailable(child: PsiElement): List<QueryResult> {
+    val containsWithoutId = tableOptions
+      ?.tableOptionList
+      ?.any {
+        (it.node.findChildByType(SqlTypes.WITHOUT) != null)
+      } ?: false
+    val synthesizedColumns = if (!containsWithoutId) {
+      val columnNames = columnDefList.mapNotNull { it.columnName.name }
+      listOf(
+        SynthesizedColumn(
+          table = this,
+          acceptableValues = listOf("tableoid", "xmin", "cmin", "xmax", "cmax", "ctid").filter { it !in columnNames },
+        ),
+      )
+    } else {
+      emptyList()
+    }
+    return listOf(
+      QueryResult(
+        table = tableName,
+        columns = columnDefList.map { it.columnName }.asColumns(),
+        synthesizedColumns = synthesizedColumns,
+      ),
+    )
+  }
+}
+
+private fun List<PsiElement>.asColumns() = map { QueryColumn(it) }
+
+// this is temporary until open visibility on com.alecstrong.sql.psi.core.psi.mixins.CreateTableElementType
+internal class CreateTableElementType(
+  name: String,
+) : SqlSchemaContributorElementType<TableElement>(name, TableElement::class.java) {
+  override fun nameType() = SqlTypes.TABLE_NAME
+  override fun createPsi(stub: SchemaContributorStub) = SqlCreateTableStmtImpl(stub, this)
+}

--- a/dialects/postgresql/src/test/kotlin/app/cash/sqldelight/dialects/postgres/PostgreSqlFixturesTest.kt
+++ b/dialects/postgresql/src/test/kotlin/app/cash/sqldelight/dialects/postgres/PostgreSqlFixturesTest.kt
@@ -45,6 +45,7 @@ class PostgreSqlFixturesTest(name: String, fixtureRoot: File) : FixturesTest(nam
       "trigger-migration",
       "trigger-new-in-expression",
       "update-view-with-trigger",
+      "rowid-orderby",
     )
 
     @Suppress("unused")

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/select-system-columns/Test.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/select-system-columns/Test.s
@@ -1,0 +1,6 @@
+CREATE TABLE T (
+    id INTEGER PRIMARY KEY
+);
+
+SELECT id, tableoid, xmin, cmin, xmax, cmax, ctid
+FROM T;


### PR DESCRIPTION
PostgreSql System Columns

https://www.postgresql.org/docs/current/ddl-system-columns.html#DDL-SYSTEM-COLUMNS

System columns can be useful for getting internal Postgres values for use in queries   

* Adds columns to CreateTableMixin - a copy of existing class with synthetic columns changed for PostgreSql
 `tableoid , xmin , cmin , xmax , cmax , ctid`
* Removes Sqlite synthetic system columns that are not relevant to PostgreSql
* Add fixture test
   remove sqlite fixture test that is not relevant

TODO
  Fix sql-psi CreateTableMixin visibility https://github.com/sqldelight/sql-psi/blob/70e48c3da577a3da2ac0b50e410e36b84879a623/core/src/main/kotlin/com/alecstrong/sql/psi/core/psi/mixins/CreateTableMixin.kt#L267
  Maybe add types to the synthetic columns as defaults to `TEXT` if useful

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
