### PR TITLE
Update PostgreSqlTypeResolver.kt - change arrayIntermediateType visibility to public

### DIFF
--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
@@ -411,7 +411,7 @@ open class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : Ty
       PostgreSqlType.TIME,
     )
 
-    private fun arrayIntermediateType(type: IntermediateType): IntermediateType {
+    fun arrayIntermediateType(type: IntermediateType): IntermediateType {
       return IntermediateType(
         ArrayDialectType(type),
       )


### PR DESCRIPTION
Allow `arrayIntermediateType` to be accessed by PostgreSql Modules
Arrays can be returned in new functions
e.g https://github.com/griffio/sqldelight-pgroonga-module-app
---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
