### PR TITLE
Fix async result type for transaction blocks returning Long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@
 
 ### Fixed
 
-- [SQLite Dialect] Fix Sqlite 3.18 missing functions (#5759 by by [Griffio][griffio])
+- [Compiler] Fix async result type for transaction blocks returning Long (#5836 by [Griffio][griffio])
+- [SQLite Dialect] Fix Sqlite 3.18 missing functions (#5759 by [Griffio][griffio])
 
 
 ## [2.1.0] - 2025-05-16

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/ExecuteQueryGenerator.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/ExecuteQueryGenerator.kt
@@ -2,8 +2,10 @@ package app.cash.sqldelight.core.compiler
 
 import app.cash.sqldelight.core.capitalize
 import app.cash.sqldelight.core.compiler.model.NamedExecute
+import app.cash.sqldelight.core.lang.ASYNC_RESULT_TYPE
 import app.cash.sqldelight.core.lang.QUERY_RESULT_TYPE
 import app.cash.sqldelight.core.lang.argumentType
+import app.cash.sqldelight.core.psi.SqlDelightStmtClojureStmtList
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FunSpec
@@ -38,7 +40,11 @@ open class ExecuteQueryGenerator(
         },
       )
       .apply {
-        val type = if (generateAsync) LONG else QUERY_RESULT_TYPE.parameterizedBy(LONG)
+        val type = when {
+          generateAsync && query.statement is SqlDelightStmtClojureStmtList -> ASYNC_RESULT_TYPE.parameterizedBy(LONG)
+          generateAsync -> LONG
+          else -> QUERY_RESULT_TYPE.parameterizedBy(LONG)
+        }
         returns(type, CodeBlock.of("The number of rows updated."))
       }
   }

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/async/AsyncSelectQueryTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/async/AsyncSelectQueryTypeTest.kt
@@ -186,7 +186,7 @@ class AsyncSelectQueryTypeTest {
       |/**
       | * @return The number of rows updated.
       | */
-      |public suspend fun insertTwice(`value`: kotlin.Long): kotlin.Long = app.cash.sqldelight.db.QueryResult.AsyncValue {
+      |public suspend fun insertTwice(`value`: kotlin.Long): app.cash.sqldelight.db.QueryResult.AsyncValue<kotlin.Long> = app.cash.sqldelight.db.QueryResult.AsyncValue {
       |  transactionWithResult {
       |    driver.execute(${query.idForIndex(0).withUnderscores}, ""${'"'}
       |        |INSERT INTO data (value)

--- a/sqldelight-gradle-plugin/src/test/integration-mysql-async/src/main/sqldelight/app/cash/sqldelight/mysql/integration/async/Dog.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-mysql-async/src/main/sqldelight/app/cash/sqldelight/mysql/integration/async/Dog.sq
@@ -16,6 +16,15 @@ VALUES (?, ?, DEFAULT, ?);
 SELECT * FROM dog;
 }
 
+insertTerrierDog {
+INSERT INTO dog
+VALUES ('Jack', 'Terrier', 0, 3);
+}
+
+deleteTerrierDogs {
+DELETE FROM dog WHERE breed = 'Terrier';
+}
+
 selectDogs:
 SELECT *
 FROM dog;
@@ -25,3 +34,4 @@ SELECT *
 FROM dog
 WHERE breed = ?
   AND name IN ?;
+

--- a/sqldelight-gradle-plugin/src/test/integration-mysql-async/src/test/kotlin/app/cash/sqldelight/mysql/integration/async/MySqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-mysql-async/src/test/kotlin/app/cash/sqldelight/mysql/integration/async/MySqlTest.kt
@@ -94,4 +94,12 @@ class MySqlTest {
         )
     }
   }
+
+  @Test
+  fun useExecutableBlockReturnsCount() = runTest { database ->
+    with(database) {
+      assertThat(dogQueries.insertTerrierDog().await()).isEqualTo(1L)
+      assertThat(dogQueries.deleteTerrierDogs().await()).isEqualTo(1L)
+    }
+  }
 }

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql-async/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/async/Dog.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql-async/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/async/Dog.sq
@@ -22,3 +22,12 @@ insertAndReturn:
 INSERT INTO dog
 VALUES (?, ?, DEFAULT, ?)
 RETURNING *;
+
+insertTerrierDog {
+INSERT INTO dog
+VALUES ('Jack', 'Terrier', 0, 3);
+}
+
+deleteTerrierDogs {
+DELETE FROM dog WHERE breed = 'Terrier';
+}

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql-async/src/test/kotlin/app/cash/sqldelight/postgresql/integration/async/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql-async/src/test/kotlin/app/cash/sqldelight/postgresql/integration/async/PostgreSqlTest.kt
@@ -196,4 +196,12 @@ class PostgreSqlTest {
       } catch (e: OptimisticLockException) { }
     }
   }
+
+  @Test
+  fun useExecutableBlockReturnsCount() = runTest { database ->
+    with(database) {
+      assertThat(dogQueries.insertTerrierDog().await()).isEqualTo(1L)
+      assertThat(dogQueries.deleteTerrierDogs().await()).isEqualTo(1L)
+    }
+  }
 }


### PR DESCRIPTION
Fixes #5753 

Fixed -  Return `QueryResult.AsyncValue<Long>` for async transaction blocks
Fixed - `grouped statements same parameter` Test fixture code isn't valid because return type was `kotlin.Long`
Added - tests that actually compile generated code as there are no async Sqlite driver runtime tests
  (e.g adding MySql, PostgreSql async integration tests will catch any compilation problems)

Note:
The issue occurred since executable statements in a transaction block were changed to return the underlying driver result value - returning a count value for executable statements in a transaction block may not be that useful as only the last statement value is used.

The work-around was If the last statement was a `SELECT` then the compiler produced an ExecutableResult avoiding the issue.

---

- [X] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
