### PR TITLE
Add PostgreSql 16 SqlJson expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- [PostgreSQL Dialect] Add predicate to check whether Sql expression can be parsed as JSON (#5843 by [Griffio][griffio])
+- [PostgreSQL Dialect] Add predicate to check whether SQL expression can be parsed as JSON (#5843 by [Griffio][griffio])
 - [PostgreSQL Dialect] Add limited support for PostgreSql Comment On statement (#5808 by [Griffio][griffio])
 - [MySQL Dialect] Add support for index visibility options (#5785 by [Oren Kislev][orenkislev-faire])
 - [PostgreSql Dialect] Add support for TSQUERY data type (#5779 by [Griffio][griffio])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- [PostgreSQL Dialect] Add predicate to check whether Sql expression can be parsed as JSON (#5843 by [Griffio][griffio])
 - [PostgreSQL Dialect] Add limited support for PostgreSql Comment On statement (#5808 by [Griffio][griffio])
 - [MySQL Dialect] Add support for index visibility options (#5785 by [Oren Kislev][orenkislev-faire])
 - [PostgreSql Dialect] Add support for TSQUERY data type (#5779 by [Griffio][griffio])

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
@@ -224,6 +224,8 @@ open class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : Ty
       }
     }
     "unnest" -> unNestType(exprList[0].postgreSqlType())
+    "pg_input_is_valid" -> IntermediateType(BOOLEAN)
+
     else -> null
   }
 

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -503,7 +503,7 @@ compound_select_stmt ::= [ {with_clause} ] {select_stmt}  ( {compound_operator} 
   override = true
 }
 
-extension_expr ::= overlaps_operator_expression | range_operator_expression | extract_temporal_expression | double_colon_cast_operator_expression | contains_operator_expression | at_time_zone_operator_expression | regex_match_operator_expression | match_operator_expression | json_function_stmt | array_agg_stmt| string_agg_stmt | json_expression | boolean_not_expression | window_function_expr {
+extension_expr ::= is_json_expression | overlaps_operator_expression | range_operator_expression | extract_temporal_expression | double_colon_cast_operator_expression | contains_operator_expression | at_time_zone_operator_expression | regex_match_operator_expression | match_operator_expression | json_function_stmt | array_agg_stmt| string_agg_stmt | json_expression | boolean_not_expression | window_function_expr {
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlExtensionExprImpl"
   implements = "com.alecstrong.sql.psi.core.psi.SqlExtensionExpr"
   override = true
@@ -549,6 +549,8 @@ frame_spec ::= ( 'RANGE' | 'ROWS' | 'GROUPS' )
 boolean_not_expression ::= NOT ( {function_expr} | boolean_literal | {column_name} )
 
 boolean_literal ::= TRUE | FALSE
+
+is_json_expression ::= 'JSON' [ 'VALUE' | 'SCALAR' | 'ARRAY' | 'OBJECT' ] [ ( 'WITH' | 'WITHOUT' ) 'UNIQUE' [ 'KEYS' ] ]
 
 json_expression ::= {column_expr} ( jsona_binary_operator | jsonb_binary_operator | jsonb_boolean_operator ) <<expr '-1'>> {
   mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.JsonExpressionMixin"

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/is_json_expressions/Test.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/is_json_expressions/Test.s
@@ -1,0 +1,22 @@
+CREATE TABLE myTable(
+    data TEXT NOT NULL,
+    js_1 JSON CHECK (js_1 -> 'scores' IS NOT NULL AND js_1 -> 'scores' IS JSON ARRAY),
+    js_2 JSON CHECK ((js_2 -> 'scores'::TEXT) IS NOT NULL AND (js_2 -> 'scores'::TEXT) IS JSON ARRAY),
+    js_3 JSON CHECK ((js_3 -> 'scores' IS JSON ARRAY) IS TRUE),
+    js_4 JSON CHECK (pg_input_is_valid(js_4 ->> 'factor', 'double precision'))
+);
+
+SELECT data,
+  data IS NULL,
+  data IS NOT NULL,
+  data IS JSON,
+  data IS NOT JSON "json?",
+  data IS JSON VALUE "value?",
+  data IS JSON SCALAR "scalar?",
+  data IS JSON OBJECT "object?",
+  data IS NOT JSON OBJECT "object?",
+  data IS JSON ARRAY "array?",
+  data IS JSON ARRAY WITH UNIQUE KEYS "array with unq key?",
+  data IS JSON ARRAY WITHOUT UNIQUE KEYS "array without unq key?"
+FROM myTable
+WHERE data IS NOT NULL;

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Json.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Json.sq
@@ -10,6 +10,14 @@ CREATE TABLE TestJson(
   datad TEXT[]
 );
 
+CREATE TABLE TestJsonCheck(
+    data TEXT NOT NULL,
+    js_1 JSON CHECK (js_1 -> 'scores' IS NOT NULL AND js_1 -> 'scores' IS JSON ARRAY),
+    js_2 JSON CHECK ((js_2 -> 'scores'::TEXT) IS NOT NULL AND (js_2 -> 'scores'::TEXT) IS JSON ARRAY),
+    js_3 JSON CHECK ((js_3 -> 'scores' IS JSON ARRAY) IS TRUE),
+    js_4 JSON CHECK (pg_input_is_valid(js_4 ->> 'factor', 'double precision'))
+);
+
 insert:
 INSERT INTO TestJson(data, datab) VALUES(
   json_build_object(:key, :value),
@@ -72,3 +80,23 @@ WHERE tjf.id = ?;
 
 selectJsonAgg:
 SELECT json_agg(TestJsonFunc) FROM TestJsonFunc;
+
+insertTestJsonCheck:
+INSERT INTO TestJsonCheck (data, js_1, js_2, js_3, js_4)
+VALUES ('{"scores": [1,2,3]}', '{"scores": [1,2,3]}', '{"scores": [1,2,3]}', '{"scores": [1,2,3]}', '{"scores": [1,2,3]}');
+
+selectJsonChecks:
+SELECT
+  data IS NULL "null?",
+  data IS NOT NULL "not null?",
+  data IS JSON "json?",
+  data IS JSON VALUE "value?",
+  data IS NOT JSON "not json?",
+  data IS JSON SCALAR "scalar?",
+  data IS JSON OBJECT "object?",
+  data IS NOT JSON OBJECT "not object?",
+  data IS JSON ARRAY "array?",
+  data IS JSON ARRAY WITH UNIQUE KEYS "array with unq key?",
+  data IS JSON ARRAY WITHOUT UNIQUE KEYS "array without unq key?"
+FROM TestJsonCheck
+WHERE data IS NOT NULL;

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
@@ -1217,4 +1217,22 @@ class PostgreSqlTest {
       assertThat(first().name).isEqualTo("Donut Hut")
     }
   }
+
+  @Test
+  fun testJsonChecks() {
+    database.jsonQueries.insertTestJsonCheck()
+    with(database.jsonQueries.selectJsonChecks().executeAsList()) {
+      assertThat(first().null_).isFalse()
+      assertThat(first().not_null_).isTrue()
+      assertThat(first().json_).isTrue()
+      assertThat(first().value_).isTrue()
+      assertThat(first().not_json_).isFalse()
+      assertThat(first().scalar_).isFalse()
+      assertThat(first().object_).isTrue()
+      assertThat(first().not_object_).isFalse()
+      assertThat(first().array_).isFalse()
+      assertThat(first().array_with_unq_key_).isFalse()
+      assertThat(first().array_without_unq_key_).isFalse()
+    }
+  }
 }


### PR DESCRIPTION
SqlJson functions for PostgreSql 16 

https://www.postgresql.org/docs/current/functions-json.html#FUNCTIONS-SQLJSON-MISC

```
expression IS [ NOT ] JSON [ { VALUE | SCALAR | ARRAY | OBJECT } ] [ { WITH | WITHOUT } UNIQUE [ KEYS ] ]
```

```
pg_input_is_valid ( string text, type text ) → boolean
```

Test if expression can be parsed as JSON, possibly of a specified type. If SCALAR or ARRAY or OBJECT is specified, the test is whether or not the JSON is of that particular type. If WITH UNIQUE KEYS is specified, then any object in the expression is also tested to see if it has duplicate keys.

Useful for check constraints to validate json 

```sql
CREATE TABLE TestJsonCheck(
    js_1 JSON CHECK (js_1 -> 'scores' IS NOT NULL AND js_1 -> 'scores' IS JSON ARRAY),
    js_2 JSON CHECK ((js_2 -> 'scores'::TEXT) IS NOT NULL AND (js_2 -> 'scores'::TEXT) IS JSON ARRAY),
    js_3 JSON CHECK ((js_3 -> 'scores' IS JSON ARRAY) IS TRUE),
    js_4 JSON CHECK (pg_input_is_valid(js_4 ->> 'factor', 'double precision'))
);
```

```sql
SELECT
    data IS JSON AS "is_json?",
    data IS JSON SCALAR AS "is_scalar?",
    data IS JSON ARRAY AS "is_array?",
    data IS JSON OBJECT AS "is_object?",
    data IS NOT JSON AS "not_json?",
    data IS JSON WITHOUT UNIQUE KEYS AS "without_unique_keys?"
FROM test_json;
```

```sql
SELECT *
FROM Recipes
WHERE (recipe -> 'ingredients') IS JSON ARRAY;
```
---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
