### PR TITLE
Add basic Ltree support for Postgresql

### DIFF
--- a/.github/workflows/PR-skip.yml
+++ b/.github/workflows/PR-skip.yml
@@ -4,6 +4,7 @@
 name: Test
 
 on:
+  workflow_dispatch:
   pull_request:
     # Ensure paths match paths-ignore in PR.yml
     paths:

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -1,6 +1,7 @@
 name: Test
 
 on:
+  workflow_dispatch:
   pull_request:
     # Ensure paths-ignore match paths in PR-skip.yml
     paths-ignore:

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -506,7 +506,7 @@ compound_select_stmt ::= [ {with_clause} ] {select_stmt}  ( {compound_operator} 
   override = true
 }
 
-extension_expr ::= overlaps_operator_expression | range_operator_expression | extract_temporal_expression | double_colon_cast_operator_expression | contains_operator_expression | at_time_zone_operator_expression | regex_match_operator_expression | match_operator_expression | json_function_stmt | array_agg_stmt| string_agg_stmt | json_expression | boolean_not_expression | window_function_expr {
+extension_expr ::= overlaps_operator_expression | range_operator_expression | extract_temporal_expression | double_colon_cast_operator_expression | contains_operator_expression | at_time_zone_operator_expression | regex_match_operator_expression | match_operator_expression | json_function_stmt | array_agg_stmt| string_agg_stmt | json_expression | ltree_expression | ltree_function_stmt | boolean_not_expression | window_function_expr {
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlExtensionExprImpl"
   implements = "com.alecstrong.sql.psi.core.psi.SqlExtensionExpr"
   override = true
@@ -566,7 +566,7 @@ ltree_expression ::= {column_expr} ( ltree_binary_operator | ltree_boolean_opera
 jsona_binary_operator ::= '->' | '->>' | '#>' | '#>>'
 jsonb_binary_operator ::= '#-'
 jsonb_boolean_operator ::= '@?' | '??|' | '??&' | '??'
-ltree_binary_operator ::= '?@>' | '?<@' | '?@' | '?~' | '||'
+ltree_binary_operator ::= '?@>' | '?<@' | '?@' | '?~'
 ltree_boolean_operator ::= '<@' | '@>' | '@' | '~' | '^<@' | '^@>' | '^@' | '^~' | '?'
 contains_operator ::= '@>' | '<@'
 match_operator ::= '@@'

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -558,10 +558,16 @@ json_expression ::= {column_expr} ( jsona_binary_operator | jsonb_binary_operato
   pin = 2
 }
 
+ltree_expression ::= {column_expr} ( ltree_binary_operator | ltree_boolean_operator ) <<expr '-1'>> {
+  mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.LtreeExpressionMixin"
+  pin = 2
+}
+
 jsona_binary_operator ::= '->' | '->>' | '#>' | '#>>'
 jsonb_binary_operator ::= '#-'
 jsonb_boolean_operator ::= '@?' | '??|' | '??&' | '??'
-ltree_operators ::= '<@' | '@>' | '@' | '~' | '^<@' | '^@>' | '^@' | '^~' | '||' | '?'
+ltree_binary_operator ::= '?@>' | '?<@' | '?@' | '?~' | '||'
+ltree_boolean_operator ::= '<@' | '@>' | '@' | '~' | '^<@' | '^@>' | '^@' | '^~' | '?'
 contains_operator ::= '@>' | '<@'
 match_operator ::= '@@'
 overlaps_operator ::= '&&'
@@ -585,11 +591,6 @@ overlaps_operator_expression ::= ( {bind_expr} | {literal_expr} | {cast_expr} | 
 
 range_operator_expression ::= ( {bind_expr} | {literal_expr} | {cast_expr} | {function_expr} | {column_expr} ) range_boolean_operator <<expr '-1'>> {
   mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.RangeOperatorExpressionMixin"
-  pin = 2
-}
-
-ltree_operator_expression ::= ( {bind_expr} | {literal_expr} | {cast_expr} | {function_expr} | {column_expr} ) ltree_operators <<expr '-1'>> {
-  mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.LtreeOperatorExpressionMixin"
   pin = 2
 }
 

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -176,6 +176,7 @@ type_name ::= (
   boolean_data_type |
   json_data_type |
   blob_data_type |
+  ltree_data_type |
   tsvector_data_type |
   tsquery_data_type |
   tstzrange |
@@ -266,6 +267,8 @@ json_data_type ::= 'JSON' | 'JSONB'
 blob_data_type ::= 'BYTEA'
 
 tsvector_data_type ::= 'TSVECTOR'
+
+ltree_data_type ::= 'LTREE'
 
 tsquery_data_type ::= 'TSQUERY'
 
@@ -558,6 +561,7 @@ json_expression ::= {column_expr} ( jsona_binary_operator | jsonb_binary_operato
 jsona_binary_operator ::= '->' | '->>' | '#>' | '#>>'
 jsonb_binary_operator ::= '#-'
 jsonb_boolean_operator ::= '@?' | '??|' | '??&' | '??'
+ltree_operators ::= '<@' | '@>' | '@' | '~' | '^<@' | '^@>' | '^@' | '^~' | '||' | '?'
 contains_operator ::= '@>' | '<@'
 match_operator ::= '@@'
 overlaps_operator ::= '&&'
@@ -581,6 +585,11 @@ overlaps_operator_expression ::= ( {bind_expr} | {literal_expr} | {cast_expr} | 
 
 range_operator_expression ::= ( {bind_expr} | {literal_expr} | {cast_expr} | {function_expr} | {column_expr} ) range_boolean_operator <<expr '-1'>> {
   mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.RangeOperatorExpressionMixin"
+  pin = 2
+}
+
+ltree_operator_expression ::= ( {bind_expr} | {literal_expr} | {cast_expr} | {function_expr} | {column_expr} ) ltree_operators <<expr '-1'>> {
+  mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.LtreeOperatorExpressionMixin"
   pin = 2
 }
 
@@ -675,6 +684,8 @@ truncate_option_identity ::= ( 'RESTART' | 'CONTINUE' ) 'IDENTITY'
 truncate_option_cascade ::=  'CASCADE' | 'RESTRICT'
 
 json_function_stmt ::= ( 'row_to_json' | 'json_agg' | 'to_json' | 'to_jsonb' ) LP ( {table_alias} | {table_name} ) RP
+
+ltree_function_stmt ::= ( 'subltree' | 'subpath' | 'nlevel' | 'index' | 'text2ltree' | 'ltree2text' | 'lca') LP ( {table_alias} | {table_name} ) RP
 
 string_agg_stmt ::= 'string_agg' LP [ ALL | DISTINCT ] <<expr '-1'>> COMMA string_literal [ ORDER BY {ordering_term} ( COMMA {ordering_term} ) * ] RP
 [ 'FILTER' LP WHERE <<expr '-1'>> RP ] {

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/ContainsOperatorExpressionMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/ContainsOperatorExpressionMixin.kt
@@ -30,8 +30,9 @@ internal abstract class ContainsOperatorExpressionMixin(node: ASTNode) :
         columnType == "TSMULTIRANGE" ||
         columnType == "TSTZMULTIRANGE" ||
         columnType.endsWith("[]") -> super.annotate(annotationHolder)
+      columnType == "LTREE" -> annotationHolder.createErrorAnnotation(firstChild.firstChild, "Left side of ltree expression must be a ltree column.")
       columnType == "JSON" -> annotationHolder.createErrorAnnotation(firstChild.firstChild, "Left side of jsonb expression must be a jsonb column.")
-      else -> annotationHolder.createErrorAnnotation(firstChild.firstChild, "expression must be ARRAY, JSONB, TSVECTOR, TSRANGE, TSTZRANGE, TSMULTIRANGE, TSTZMULTIRANGE.")
+      else -> annotationHolder.createErrorAnnotation(firstChild.firstChild, "expression must be ARRAY, JSONB, LTREE, TSVECTOR, TSRANGE, TSTZRANGE, TSMULTIRANGE, TSTZMULTIRANGE.")
     }
     super.annotate(annotationHolder)
   }

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/ContainsOperatorExpressionMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/ContainsOperatorExpressionMixin.kt
@@ -10,7 +10,7 @@ import com.alecstrong.sql.psi.core.psi.SqlExpr
 import com.intellij.lang.ASTNode
 
 /**
- * The "@> <@" contain operators is used by Array, TsVector, Jsonb (not Json), TsRange, TsTzRange, TsMultiRange, TsTzMultiRange
+ * The "@> <@" contain operators is used by Array, TsVector, Ltree, Jsonb (not Json), TsRange, TsTzRange, TsMultiRange, TsTzMultiRange
  * The type annotation is performed here for these types
  * For other json operators see JsonExpressionMixin
  */
@@ -23,6 +23,7 @@ internal abstract class ContainsOperatorExpressionMixin(node: ASTNode) :
     val columnType = ((firstChild.firstChild.reference?.resolve() as? SqlColumnName)?.parent as? SqlColumnDef)?.columnType?.typeName?.text
     when {
       columnType == null ||
+        columnType == "LTREE" ||
         columnType == "JSONB" ||
         columnType == "TSVECTOR" ||
         columnType == "TSRANGE" ||
@@ -30,7 +31,6 @@ internal abstract class ContainsOperatorExpressionMixin(node: ASTNode) :
         columnType == "TSMULTIRANGE" ||
         columnType == "TSTZMULTIRANGE" ||
         columnType.endsWith("[]") -> super.annotate(annotationHolder)
-      columnType == "LTREE" -> annotationHolder.createErrorAnnotation(firstChild.firstChild, "Left side of ltree expression must be a ltree column.")
       columnType == "JSON" -> annotationHolder.createErrorAnnotation(firstChild.firstChild, "Left side of jsonb expression must be a jsonb column.")
       else -> annotationHolder.createErrorAnnotation(firstChild.firstChild, "expression must be ARRAY, JSONB, LTREE, TSVECTOR, TSRANGE, TSTZRANGE, TSMULTIRANGE, TSTZMULTIRANGE.")
     }

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/LtreeExpressionMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/LtreeExpressionMixin.kt
@@ -1,0 +1,30 @@
+package app.cash.sqldelight.dialects.postgresql.grammar.mixins
+
+import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlJsonExpression
+import com.alecstrong.sql.psi.core.SqlAnnotationHolder
+import com.alecstrong.sql.psi.core.psi.SqlBinaryExpr
+import com.alecstrong.sql.psi.core.psi.SqlColumnDef
+import com.alecstrong.sql.psi.core.psi.SqlColumnName
+import com.alecstrong.sql.psi.core.psi.SqlCompositeElementImpl
+import com.alecstrong.sql.psi.core.psi.SqlExpr
+import com.intellij.lang.ASTNode
+
+internal abstract class LtreeExpressionMixin(node: ASTNode) :
+  SqlCompositeElementImpl(node),
+  SqlBinaryExpr,
+  PostgreSqlJsonExpression {
+  override fun annotate(annotationHolder: SqlAnnotationHolder) {
+    val columnType = ((firstChild.firstChild.reference?.resolve() as? SqlColumnName)?.parent as? SqlColumnDef)?.columnType?.typeName?.text
+    if (columnType == null || columnType !in arrayOf("LTREE")) {
+      annotationHolder.createErrorAnnotation(firstChild.firstChild, "Left side of json expression must be a ltree column.")
+    }
+    if ((jsonbBinaryOperator != null || jsonbBooleanOperator != null) && columnType != "LTREE") {
+      annotationHolder.createErrorAnnotation(firstChild.firstChild, "Left side of jsonb expression must be a ltree column.")
+    }
+    super.annotate(annotationHolder)
+  }
+
+  override fun getExprList(): List<SqlExpr> {
+    return children.filterIsInstance<SqlExpr>()
+  }
+}

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/LtreeOperatorExpressionMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/LtreeOperatorExpressionMixin.kt
@@ -1,7 +1,6 @@
 package app.cash.sqldelight.dialects.postgresql.grammar.mixins
 
-import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlJsonExpression
-import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlLtreeExpression
+import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlRangeOperatorExpression
 import com.alecstrong.sql.psi.core.SqlAnnotationHolder
 import com.alecstrong.sql.psi.core.psi.SqlBinaryExpr
 import com.alecstrong.sql.psi.core.psi.SqlColumnDef
@@ -9,23 +8,22 @@ import com.alecstrong.sql.psi.core.psi.SqlColumnName
 import com.alecstrong.sql.psi.core.psi.SqlCompositeElementImpl
 import com.alecstrong.sql.psi.core.psi.SqlExpr
 import com.intellij.lang.ASTNode
-import kotlinx.coroutines.NonCancellable.children
 
-internal abstract class LtreeExpressionMixin(node: ASTNode) :
+/**
+ * Operators '<@' | '@>' | '@' | '~' | '^<@' | '^@>' | '^@' | '^~' | '||' | '?' for Ltree
+ */
+internal abstract class LtreeOperatorExpressionMixin(node: ASTNode) :
   SqlCompositeElementImpl(node),
-  SqlBinaryExpr,
-  PostgreSqlLtreeExpression {
+  SqlBinaryExpr {
+
   override fun annotate(annotationHolder: SqlAnnotationHolder) {
     val columnType = ((firstChild.firstChild.reference?.resolve() as? SqlColumnName)?.parent as? SqlColumnDef)?.columnType?.typeName?.text
-    if (columnType == null || columnType !in arrayOf("LTREE")) {
-      annotationHolder.createErrorAnnotation(firstChild.firstChild, "Left side of ltree expression must be a ltree column.")
-    }
-    if ((ltreeBooleanOperator != null || ltreeBinaryOperator != null) && columnType != "LTREE") {
-      annotationHolder.createErrorAnnotation(firstChild.firstChild, "Left side of ltree expression must be a ltree column.")
+    when (columnType) {
+      null, "LTREE" -> super.annotate(annotationHolder)
+      else -> annotationHolder.createErrorAnnotation(firstChild.firstChild, "expression must be LTREE")
     }
     super.annotate(annotationHolder)
   }
-
   override fun getExprList(): List<SqlExpr> {
     return children.filterIsInstance<SqlExpr>()
   }

--- a/dialects/postgresql/src/test/kotlin/app/cash/sqldelight/dialects/postgres/PostgreSqlFixturesTest.kt
+++ b/dialects/postgresql/src/test/kotlin/app/cash/sqldelight/dialects/postgres/PostgreSqlFixturesTest.kt
@@ -19,7 +19,7 @@ class PostgreSqlFixturesTest(name: String, fixtureRoot: File) : FixturesTest(nam
     "CREATE VIEW IF NOT EXISTS" to "CREATE OR REPLACE VIEW",
     "id TEXT GENERATED ALWAYS AS (2) UNIQUE NOT NULL" to "id TEXT GENERATED ALWAYS AS (2) STORED UNIQUE NOT NULL",
     "'(', ')', ',', '.', <binary like operator real>, BETWEEN or IN expected, got ','"
-      to "'#-', '&&', '(', ')', ',', '.', '::', <binary like operator real>, <contains operator real>, <jsona binary operator real>, <jsonb boolean operator real>, <range boolean operator real>, <regex match operator real>, '@@', AT, BETWEEN or IN expected, got ','",
+      to "'#-', '&&', '(', ')', ',', '.', '::', <binary like operator real>, <contains operator real>, <jsona binary operator real>, <jsonb boolean operator real>, <ltree binary operator real>, <ltree boolean operator real>, <range boolean operator real>, <regex match operator real>, '@@', AT, BETWEEN or IN expected, got ','",
   )
 
   override fun setupDialect() {

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/ltree/Test.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/ltree/Test.s
@@ -1,0 +1,24 @@
+CREATE TABLE myTable(
+    path LTREE NOT NULL
+);
+
+SELECT path FROM myTable
+WHERE path @> 'a.b.c';
+
+SELECT path FROM myTable
+WHERE path @> 'a.*.c';
+
+SELECT path FROM myTable
+WHERE path @> 'a.*.d';
+
+SELECT path FROM myTable
+WHERE path @> '*';
+
+SELECT path FROM myTable
+WHERE path <@ 'a.b.c';
+
+SELECT path FROM myTable
+WHERE path <@ 'a.b';
+
+SELECT path FROM myTable
+WHERE path <@ 'a.*.c';

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/ltree/Test.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/ltree/Test.s
@@ -6,19 +6,10 @@ SELECT path FROM myTable
 WHERE path @> 'a.b.c';
 
 SELECT path FROM myTable
-WHERE path @> 'a.*.c';
-
-SELECT path FROM myTable
-WHERE path @> 'a.*.d';
-
-SELECT path FROM myTable
-WHERE path @> '*';
-
-SELECT path FROM myTable
 WHERE path <@ 'a.b.c';
 
 SELECT path FROM myTable
-WHERE path <@ 'a.b';
+WHERE path @ 'a.*.c';
 
 SELECT path FROM myTable
-WHERE path <@ 'a.*.c';
+WHERE path ? 'a.*.c';

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/ts-ranges/Test.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/ts-ranges/Test.s
@@ -54,6 +54,6 @@ SELECT tstzmultirange(tstzrange('2010-01-01 14:30:00', '2010-01-01 15:30:00', '[
 FROM Ranges
 WHERE tst_2 && tstzrange('2010-01-01 14:30:00', '2010-01-01 15:30:00', '[]');
 
---error[col 7]: expression must be ARRAY, JSONB, TSVECTOR, TSRANGE, TSTZRANGE, TSMULTIRANGE, TSTZMULTIRANGE.
+--error[col 7]: expression must be ARRAY, JSONB, LTREE, TSVECTOR, TSRANGE, TSTZRANGE, TSMULTIRANGE, TSTZMULTIRANGE.
 SELECT id @> ts_1
 FROM Ranges;


### PR DESCRIPTION
Added basic support for ltree postgresql extension.

```sql
CREATE TABLE myTable(
    path LTREE NOT NULL
);

SELECT path FROM myTable
WHERE path @> 'a.b.c';

SELECT path FROM myTable
WHERE path <@ 'a.b.c';

SELECT path FROM myTable
WHERE path @ 'a.*.c';

SELECT path FROM myTable
WHERE path ? 'a.*.c';
```

There are a few operators that are not support due to conflicting mixin expressions that I was unsure of how to navigate. These include `~` and `||` operators.