### PR TITLE
Minor tweaks about ShadowJar configurations

### DIFF
--- a/sqldelight-compiler/environment/build.gradle
+++ b/sqldelight-compiler/environment/build.gradle
@@ -1,3 +1,5 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
 plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.shadow)
@@ -63,9 +65,11 @@ tasks.named("jar") {
   enabled = false
 }
 
-tasks.named("shadowJar") {
-  archiveClassifier.set("")
+tasks.named('shadowJar', ShadowJar) {
+  archiveClassifier = ''
   configurations = [project.configurations.shadow]
+  duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+  failOnDuplicateEntries = true
 
   /**
    Before minimizing
@@ -81,32 +85,32 @@ tasks.named("shadowJar") {
   */
   minimize {
     // Needed for MockProject and MockModule.
-    exclude(dependency(libs.intellij.testFramework.get()))
+    exclude(dependency(libs.intellij.testFramework))
 
     // Needed for general utils like PsiTreeUtil.
-    exclude(dependency(libs.intellij.util.get()))
+    exclude(dependency(libs.intellij.util))
 
     // Base intellij platform.
-    exclude(dependency(libs.intellij.core.get()))
-    exclude(dependency(libs.intellij.coreImpl.get()))
+    exclude(dependency(libs.intellij.core))
+    exclude(dependency(libs.intellij.coreImpl))
 
     // Base required language support.
-    exclude(dependency(libs.intellij.lang.get()))
-    exclude(dependency(libs.intellij.langImpl.get()))
+    exclude(dependency(libs.intellij.lang))
+    exclude(dependency(libs.intellij.langImpl))
 
     // Base required analysis support, like resolve references.
-    exclude(dependency(libs.intellij.analysis.get()))
-    exclude(dependency(libs.intellij.analysisImpl.get()))
+    exclude(dependency(libs.intellij.analysis))
+    exclude(dependency(libs.intellij.analysisImpl))
 
     // Needed for resolving files and the file index.
-    exclude(dependency(libs.intellij.projectModel.get()))
-    exclude(dependency(libs.intellij.projectModelImpl.get()))
+    exclude(dependency(libs.intellij.projectModel))
+    exclude(dependency(libs.intellij.projectModelImpl))
 
     // Don't minimize coroutines support.
-    exclude(dependency(libs.intellij.utilEx.get()))
+    exclude(dependency(libs.intellij.utilEx))
 
     // Needed for Icon support.
-    exclude(dependency(libs.intellij.utilUi.get()))
+    exclude(dependency(libs.intellij.utilUi))
   }
 
   include '*.jar'

--- a/sqlite-migrations/environment/build.gradle
+++ b/sqlite-migrations/environment/build.gradle
@@ -1,3 +1,5 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
 plugins {
   alias(libs.plugins.kotlin.jvm)
   alias(libs.plugins.shadow)
@@ -18,9 +20,11 @@ tasks.named("jar", Jar) {
   enabled = false
 }
 
-tasks.named("shadowJar") {
-  archiveClassifier.set("")
+tasks.named('shadowJar', ShadowJar) {
+  archiveClassifier = ''
   configurations = [project.configurations.shadow]
+  duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+  failOnDuplicateEntries = true
 }
 
 configurations {


### PR DESCRIPTION
- Declares `duplicatesStrategy` and `failOnDuplicateEntries` as I suggested in the Shadow 9 changelog.
- It is possible to pass version catalog accessors for `dependency` in Shadow 9.

```
OLD: migrations-environment-2.2.0-SNAPSHOT.jar.old
NEW: migrations-environment-2.2.0-SNAPSHOT.jar.new

 JAR   │ old      │ new      │ diff
───────┼──────────┼──────────┼──────
 class │  2.2 MiB │  2.2 MiB │  0 B
 other │ 24.5 MiB │ 24.5 MiB │  0 B
───────┼──────────┼──────────┼──────
 total │ 26.7 MiB │ 26.7 MiB │  0 B

 CLASSES │ old  │ new  │ diff
─────────┼──────┼──────┼───────────
 classes │  742 │  742 │ 0 (+0 -0)
 methods │ 7641 │ 7641 │ 0 (+0 -0)
  fields │ 2343 │ 2343 │ 0 (+0 -0)
```

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
