### PR TITLE
Fix Throwable from CopyAsSqliteAction

### DIFF
--- a/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/actions/CopyAsSqliteAction.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/actions/CopyAsSqliteAction.kt
@@ -19,6 +19,7 @@ import app.cash.sqldelight.core.lang.SqlDelightFile
 import app.cash.sqldelight.core.lang.SqlDelightFileType
 import app.cash.sqldelight.core.lang.util.rawSqlText
 import com.alecstrong.sql.psi.core.psi.SqlStmt
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.LangDataKeys
@@ -37,6 +38,10 @@ class CopyAsSqliteAction : AnAction() {
     e.presentation.isVisible =
       e.getData(PlatformDataKeys.VIRTUAL_FILE)?.extension == SqlDelightFileType.defaultExtension &&
       e.sqlElementAtCaret() != null
+  }
+
+  override fun getActionUpdateThread(): ActionUpdateThread {
+    return ActionUpdateThread.BGT
   }
 
   private fun AnActionEvent.sqlElementAtCaret(): SqlStmt? {


### PR DESCRIPTION
#5462 

Use ActionUpdateThread.BGT mode instead of the ActionUpdateThread.EDT mode that causes a rule use to be reported with a Throwable 🤕 ⚾ 

Recommended in docs - com.intellij.openapi.actionSystem.ActionUpdateThread

```
The update session is run on a background thread.
 * That is why {@link #BGT} the preferred value for all actions:
```

The source of the Throwable is `com.intellij.openapi.actionSystem.impl.PreCachedDataContext#reportValueProvidedByRulesUsage`:

If the rule use is enabled then a Throwable is created for reporting

```java
private static void reportValueProvidedByRulesUsage(@NotNull String dataId, boolean error) {
    if (!Registry.is("actionSystem.update.actions.warn.dataRules.on.edt")) return;
    if (EDT.isCurrentThreadEdt() && SlowOperations.isInSection(SlowOperations.ACTION_UPDATE) &&
        ActionUpdater.currentInEDTOperationName() != null && !SlowOperations.isAlwaysAllowed()) {
      String message = "'" + dataId + "' is requested on EDT by " + ActionUpdater.currentInEDTOperationName() + ". See ActionUpdateThread javadoc.";
      if (!Strings.areSameInstance(message, ourEDTWarnsInterner.intern(message))) return;
      Throwable th = error ? new Throwable(message) : null;
      AppExecutorUtil.getAppExecutorService().execute(() -> {
        if (error) {
          LOG.error(th);
        }
        else {
          LOG.warn(message);
        }
      });
    }
  }
```

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
