### PR TITLE
Fix SqlDelight Plugin UI components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [Compiler] Simplified default generated queries using constructor references (#5814 by [Jon Poulton][jonapoul])
 
 ### Fixed
+- [Gradle Plugin] Fix crash when opening SqlDelight tool window to add "New Connection" (by #5906 [Griffio][griffio])
 - [IntelliJ Plugin] Avoid threading-related crash in the copy-to-sqlite gutter action (#5901 by [Griffio][griffio])
 - [IntelliJ Plugin] Fix for PostgreSql dialect when using schema statements CREATE INDEX and CREATE VIEW (#5772 by [Griffio][griffio])
 - [Compiler] Fix FTS stack overflow when referencing columns (#5896 by [Griffio][griffio])

--- a/dialects/mysql/src/main/kotlin/app/cash/sqldelight/dialects/mysql/ide/MySqlConnectionDialog.kt
+++ b/dialects/mysql/src/main/kotlin/app/cash/sqldelight/dialects/mysql/ide/MySqlConnectionDialog.kt
@@ -3,10 +3,11 @@ package app.cash.sqldelight.dialects.mysql.ide
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.openapi.ui.ValidationInfo
-import com.intellij.ui.layout.GrowPolicy.MEDIUM_TEXT
+import com.intellij.ui.dsl.builder.COLUMNS_MEDIUM
+import com.intellij.ui.dsl.builder.bindText
+import com.intellij.ui.dsl.builder.columns
+import com.intellij.ui.dsl.builder.panel
 import com.intellij.ui.layout.ValidationInfoBuilder
-import com.intellij.ui.layout.applyToComponent
-import com.intellij.ui.layout.panel
 import javax.swing.JComponent
 import javax.swing.JTextField
 
@@ -29,49 +30,31 @@ internal class MySqlConnectionDialog(
   override fun createCenterPanel(): JComponent {
     return panel {
       row("Connection Name") {
-        textField(
-          getter = { connectionKey },
-          setter = { connectionName = it },
-        ).withValidationOnApply(validateNonEmpty(CONNECTION_NAME_NON_EMPTY))
-          .growPolicy(MEDIUM_TEXT)
+        textField().bindText({ connectionKey }, { connectionName = it }).validationOnApply(validateNonEmpty(CONNECTION_NAME_NON_EMPTY))
+          .columns(COLUMNS_MEDIUM)
           .applyToComponent {
             if (connectionName != null) this.isEditable = false
           }
       }
       row("Host") {
-        textField(
-          getter = { host },
-          setter = { host = it },
-        ).withValidationOnApply(validateNonEmpty(HOST_NON_EMPTY))
-          .growPolicy(MEDIUM_TEXT)
+        textField().bindText({ host }, { host = it }).validationOnApply(validateNonEmpty(HOST_NON_EMPTY))
+          .columns(COLUMNS_MEDIUM)
       }
       row("Port") {
-        textField(
-          getter = { port },
-          setter = { port = it },
-        ).withValidationOnApply(validateNonEmpty(PORT_NON_EMPTY))
-          .growPolicy(MEDIUM_TEXT)
+        textField().bindText({ port }, { port = it }).validationOnApply(validateNonEmpty(PORT_NON_EMPTY))
+          .columns(COLUMNS_MEDIUM)
       }
       row("Database Name") {
-        textField(
-          getter = { databaseName },
-          setter = { databaseName = it },
-        )
-          .growPolicy(MEDIUM_TEXT)
+        textField().bindText({ databaseName }, { databaseName = it })
+          .columns(COLUMNS_MEDIUM)
       }
       row("Username") {
-        textField(
-          getter = { username },
-          setter = { username = it },
-        )
-          .growPolicy(MEDIUM_TEXT)
+        textField().bindText({ username }, { username = it })
+          .columns(COLUMNS_MEDIUM)
       }
       row("Password") {
-        textField(
-          getter = { password },
-          setter = { password = it },
-        )
-          .growPolicy(MEDIUM_TEXT)
+        textField().bindText({ password }, setter = { password = it })
+          .columns(COLUMNS_MEDIUM)
       }
     }
   }

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/ide/PostgresConnectionDialog.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/ide/PostgresConnectionDialog.kt
@@ -3,10 +3,11 @@ package app.cash.sqldelight.dialects.postgresql.ide
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.openapi.ui.ValidationInfo
-import com.intellij.ui.layout.GrowPolicy.MEDIUM_TEXT
+import com.intellij.ui.dsl.builder.COLUMNS_MEDIUM
+import com.intellij.ui.dsl.builder.bindText
+import com.intellij.ui.dsl.builder.columns
+import com.intellij.ui.dsl.builder.panel
 import com.intellij.ui.layout.ValidationInfoBuilder
-import com.intellij.ui.layout.applyToComponent
-import com.intellij.ui.layout.panel
 import javax.swing.JComponent
 import javax.swing.JTextField
 
@@ -29,49 +30,31 @@ internal class PostgresConnectionDialog(
   override fun createCenterPanel(): JComponent {
     return panel {
       row("Connection Name") {
-        textField(
-          getter = { connectionKey },
-          setter = { connectionName = it },
-        ).withValidationOnApply(validateNonEmpty(CONNECTION_NAME_NON_EMPTY))
-          .growPolicy(MEDIUM_TEXT)
+        textField().bindText({ connectionKey }, { connectionName = it }).validationOnApply(validateNonEmpty(CONNECTION_NAME_NON_EMPTY))
+          .columns(COLUMNS_MEDIUM)
           .applyToComponent {
             if (connectionName != null) this.isEditable = false
           }
       }
       row("Host") {
-        textField(
-          getter = { host },
-          setter = { host = it },
-        ).withValidationOnApply(validateNonEmpty(HOST_NON_EMPTY))
-          .growPolicy(MEDIUM_TEXT)
+        textField().bindText({ host }, { host = it }).validationOnApply(validateNonEmpty(HOST_NON_EMPTY))
+          .columns(COLUMNS_MEDIUM)
       }
       row("Port") {
-        textField(
-          getter = { port },
-          setter = { port = it },
-        ).withValidationOnApply(validateNonEmpty(PORT_NON_EMPTY))
-          .growPolicy(MEDIUM_TEXT)
+        textField().bindText({ port }, { port = it }).validationOnApply(validateNonEmpty(PORT_NON_EMPTY))
+          .columns(COLUMNS_MEDIUM)
       }
       row("Database Name") {
-        textField(
-          getter = { databaseName },
-          setter = { databaseName = it },
-        )
-          .growPolicy(MEDIUM_TEXT)
+        textField().bindText({ databaseName }, { databaseName = it })
+          .columns(COLUMNS_MEDIUM)
       }
       row("Username") {
-        textField(
-          getter = { username },
-          setter = { username = it },
-        )
-          .growPolicy(MEDIUM_TEXT)
+        textField().bindText({ username }, { username = it })
+          .columns(COLUMNS_MEDIUM)
       }
       row("Password") {
-        textField(
-          getter = { password },
-          setter = { password = it },
-        )
-          .growPolicy(MEDIUM_TEXT)
+        textField().bindText({ password }, { password = it })
+          .columns(COLUMNS_MEDIUM)
       }
     }
   }

--- a/dialects/sqlite-3-18/src/main/kotlin/app/cash/sqldelight/dialects/sqlite_3_18/SelectConnectionTypeDialog.kt
+++ b/dialects/sqlite-3-18/src/main/kotlin/app/cash/sqldelight/dialects/sqlite_3_18/SelectConnectionTypeDialog.kt
@@ -7,8 +7,12 @@ import com.intellij.openapi.ui.DialogWrapper
 import com.intellij.openapi.ui.ValidationInfo
 import com.intellij.ui.RecentsManager
 import com.intellij.ui.TextFieldWithHistoryWithBrowseButton
+import com.intellij.ui.components.textFieldWithHistoryWithBrowseButton
+import com.intellij.ui.dsl.builder.AlignX
+import com.intellij.ui.dsl.builder.MutableProperty
+import com.intellij.ui.dsl.builder.bindText
+import com.intellij.ui.dsl.builder.panel
 import com.intellij.ui.layout.ValidationInfoBuilder
-import com.intellij.ui.layout.panel
 import java.io.File
 import javax.swing.JComponent
 import javax.swing.JTextField
@@ -35,28 +39,29 @@ internal class SelectConnectionTypeDialog(
   override fun createCenterPanel(): JComponent {
     return panel {
       row("Connection Name") {
-        textField(
-          getter = { connectionName },
-          setter = { connectionName = it },
-        ).withValidationOnApply(validateKey())
-          .withValidationOnInput(validateKey())
+        textField().bindText({ connectionName }, { connectionName = it })
+          .validationOnApply(validateKey())
+          .validationOnInput(validateKey())
       }
       row(label = "DB File Path") {
-        textFieldWithHistoryWithBrowseButton(
-          browseDialogTitle = "Choose File",
-          getter = { filePath },
-          setter = { filePath = it },
-          fileChooserDescriptor = FileTypeDescriptor("Choose File", "db"),
-          historyProvider = { recentsManager.getRecentEntries(RECENT_DB_PATH).orEmpty() },
-          fileChosen = { vFile ->
-            vFile.path.also { path ->
-              filePath = path
-              recentsManager.registerRecentEntry(RECENT_DB_PATH, path)
-            }
-          },
-        )
-          .withValidationOnInput(validateFilePath())
-          .withValidationOnApply(validateFilePath())
+        cell(
+          textFieldWithHistoryWithBrowseButton(
+            browseDialogTitle = "Choose File",
+            project = null,
+            fileChooserDescriptor = FileTypeDescriptor("Choose File", "db"),
+            historyProvider = { recentsManager.getRecentEntries(RECENT_DB_PATH).orEmpty() },
+            fileChosen = { vFile ->
+              vFile.path.also { path ->
+                filePath = path
+                recentsManager.registerRecentEntry(RECENT_DB_PATH, path)
+              }
+            },
+          ),
+        ).align(AlignX.FILL)
+          .resizableColumn()
+          .bind({ it.text }, { button, text -> button.text = text }, MutableProperty({ filePath }, { filePath = it }))
+          .validationOnApply(validateFilePath())
+          .validationOnInput(validateFilePath())
       }
     }.also {
       validate()
@@ -66,7 +71,7 @@ internal class SelectConnectionTypeDialog(
 
 private fun validateKey(): ValidationInfoBuilder.(JTextField) -> ValidationInfo? = {
   if (it.text.isNullOrEmpty()) {
-    error("You must supply a connection key.")
+    error("You must supply a connection name.")
   } else {
     null
   }

--- a/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/run/ArgumentsInputDialogImpl.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/run/ArgumentsInputDialogImpl.kt
@@ -2,7 +2,8 @@ package app.cash.sqldelight.intellij.run
 
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogWrapper
-import com.intellij.ui.layout.panel
+import com.intellij.ui.dsl.builder.bindText
+import com.intellij.ui.dsl.builder.panel
 import javax.swing.JComponent
 
 internal interface ArgumentsInputDialog {
@@ -32,7 +33,7 @@ internal class ArgumentsInputDialogImpl(
     return panel {
       parameters.forEach { parameter ->
         row("${parameter.name}:") {
-          textField(parameter::value, {
+          textField().bindText(parameter::value, {
             _result.add(parameter.copy(value = it))
           })
         }


### PR DESCRIPTION
fixes #5899 

The Plugin UI Dialog components can't initialise in 2025.2

Long deprecated UI components have been finally removed from recent JetBrains IntelliJ Plugins and cause exceptions to be reported as some methods cannot be referenced.

For example: `package com.intellij.ui.layout`

``` kotlin
@ApiStatus.ScheduledForRemoval
  @Deprecated("Use Kotlin UI DSL Version 2")
  fun textField(getter: () -> String, setter: (String) -> Unit, columns: Int? = null) = textField(PropertyBinding(getter, setter), columns)
```


Need to migrate UI components to supported DSL - https://plugins.jetbrains.com/docs/intellij/android-studio-releases-list.html#2025

Migration to JetBrains UI DSL v2 https://plugins.jetbrains.com/docs/intellij/kotlin-ui-dsl-version-2.html#migration-from-version-1

The code changes are *not* published with the SqlDelight IDEA Plugin - they are loaded from the SqlDelight Dialect Gradle Plugin.

An updated SqlDelight Gradle Plugin, followed by closing and reopening IDEA, will demonstrate the UI components are now loading.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
