### PR TITLE
Add PostgreSql CREATE ENUM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## UNRELEASED
 
 ### Added
+- [PostgreSQL Dialect] Add support for Postgres Enums (#5935 by [Griffio][griffio])
 - [PostgreSQL Dialect] Add limited support for Postgres Triggers (#5932 by [Griffio][griffio])
 - [PostgreSQL Dialect] Add predicate to check whether SQL expression can be parsed as JSON (#5843 by [Griffio][griffio])
 - [PostgreSQL Dialect] Add limited support for PostgreSql Comment On statement (#5808 by [Griffio][griffio])

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlType.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlType.kt
@@ -29,6 +29,7 @@ enum class PostgreSqlType(override val javaType: TypeName) : DialectType {
   TSTZMULTIRANGE(STRING),
   XML(STRING),
   TSQUERY(STRING),
+  ENUM(STRING),
   ;
 
   override fun prepareStatementBinder(columnIndex: CodeBlock, value: CodeBlock): CodeBlock {
@@ -43,7 +44,7 @@ enum class PostgreSqlType(override val javaType: TypeName) : DialectType {
       )
 
       NUMERIC -> CodeBlock.of("bindBigDecimal(%L, %L)\n", columnIndex, value)
-      INTERVAL, JSON, TSVECTOR, TSTZRANGE, TSRANGE, TSMULTIRANGE, TSTZMULTIRANGE, TSQUERY -> CodeBlock.of(
+      ENUM, INTERVAL, JSON, TSVECTOR, TSTZRANGE, TSRANGE, TSMULTIRANGE, TSTZMULTIRANGE, TSQUERY -> CodeBlock.of(
         "bindObject(%L, %L, %M)\n",
         columnIndex,
         value,
@@ -66,7 +67,7 @@ enum class PostgreSqlType(override val javaType: TypeName) : DialectType {
         BIG_INT -> "$cursorName.getLong($columnIndex)"
         DATE, TIME, TIMESTAMP, TIMESTAMP_TIMEZONE, UUID -> "$cursorName.getObject<%T>($columnIndex)"
         NUMERIC -> "$cursorName.getBigDecimal($columnIndex)"
-        INTERVAL, JSON, TSVECTOR, TSTZRANGE, TSRANGE, TSMULTIRANGE, TSTZMULTIRANGE, XML, TSQUERY -> "$cursorName.getString($columnIndex)"
+        ENUM, INTERVAL, JSON, TSVECTOR, TSTZRANGE, TSRANGE, TSMULTIRANGE, TSTZMULTIRANGE, XML, TSQUERY -> "$cursorName.getString($columnIndex)"
       },
       javaType,
     )

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -106,6 +106,7 @@
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.UNIQUE"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.UPDATE"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.USING"
+    "static com.alecstrong.sql.psi.core.psi.SqlTypes.VALUE"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.VALUES"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.WHEN"
     "static com.alecstrong.sql.psi.core.psi.SqlTypes.VIEW"
@@ -193,7 +194,8 @@ type_name ::= (
   tsrange |
   tsmultirange |
   tstzmultirange |
-  xml_data_type
+  xml_data_type |
+  enum_data_type
 ) [ '[]' ] {
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlTypeNameImpl"
   implements = "com.alecstrong.sql.psi.core.psi.SqlTypeName"
@@ -302,6 +304,8 @@ tstzrange ::= 'TSTZRANGE'
 tsmultirange ::= 'TSMULTIRANGE'
 
 tstzmultirange ::= 'TSTZMULTIRANGE'
+
+enum_data_type ::= {identifier}
 
 with_clause_auxiliary_stmt ::= {compound_select_stmt} | delete_stmt_limited | insert_stmt | update_stmt_limited {
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlWithClauseAuxiliaryStmtImpl"
@@ -625,7 +629,7 @@ at_time_zone_operator_expression ::= ( {literal_expr} | {cast_expr} | {function_
   pin = 2
 }
 
-extension_stmt ::= drop_function_stmt | create_function_stmt | create_sequence_stmt | copy_stdin | truncate_stmt | set_stmt | drop_sequence_stmt |
+extension_stmt ::= create_enum_type_stmt| drop_type_stmt | alter_type_stmt | drop_function_stmt | create_function_stmt | create_sequence_stmt | copy_stdin | truncate_stmt | set_stmt | drop_sequence_stmt |
  alter_sequence_stmt | create_extension_stmt | drop_extension_stmt | alter_extension_stmt | comment_on_extension_stmt {
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlExtensionStmtImpl"
   implements = "com.alecstrong.sql.psi.core.psi.SqlExtensionStmt"
@@ -788,3 +792,23 @@ drop_function_stmt ::= DROP 'FUNCTION' [ IF EXISTS ] {function_expr} [ CASCADE |
   mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.DropFunctionMixin"
   implements = "com.alecstrong.sql.psi.core.psi.SchemaContributor
 }
+
+enum_type_label ::= string_literal
+type_identifier ::= {identifier}
+
+create_enum_type_stmt ::= CREATE 'TYPE' type_identifier AS 'ENUM' LP enum_type_label (COMMA enum_type_label) * RP {
+  mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.CreateEnumTypeMixin"
+}
+
+drop_type_stmt ::= DROP 'TYPE' [ IF EXISTS ] type_identifier [ CASCADE | 'RESTRICT' ] {
+  mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.DropEnumTypeMixin"
+}
+alter_type_add_enum_value ::= ALTER 'TYPE' type_identifier ADD VALUE [ IF NOT EXISTS ] enum_type_label [ ( BEFORE | AFTER ) enum_type_label ]
+alter_type_rename_enum_value ::= ALTER 'TYPE' type_identifier RENAME VALUE enum_type_label TO enum_type_label
+alter_type_rename ::= ALTER 'TYPE' type_identifier RENAME TO type_identifier
+alter_type_stmt ::= alter_type_add_enum_value | alter_type_rename_enum_value | alter_type_rename
+
+
+
+
+

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/CreateEnumTypeMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/CreateEnumTypeMixin.kt
@@ -2,10 +2,27 @@ package app.cash.sqldelight.dialects.postgresql.grammar.mixins
 
 import app.cash.sqldelight.dialect.api.PreCreateTableInitialization
 import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlCreateEnumTypeStmt
+import com.alecstrong.sql.psi.core.psi.Schema
+import com.alecstrong.sql.psi.core.psi.SchemaContributor
 import com.alecstrong.sql.psi.core.psi.SqlCompositeElementImpl
 import com.intellij.lang.ASTNode
 
+/**
+ * Usage `CREATE TYPE ABC AS ENUM ('a', 'b', 'c')`
+ * Note: `IF NOT EXISTS` or `REPLACE` is not supported by PostgreSQL and means that `CREATE TYPE ...` is not idempotent.
+ * PreCreateTableInitialization is used to ensure that `create type` is ordered before `create table` when using `.sq` files.
+ * SchemaContributor is used to compile the `create type` in the `schema.create` code block.
+ */
 internal abstract class CreateEnumTypeMixin(node: ASTNode) :
   SqlCompositeElementImpl(node),
   PostgreSqlCreateEnumTypeStmt,
-  PreCreateTableInitialization
+  PreCreateTableInitialization,
+  SchemaContributor {
+
+  override fun modifySchema(schema: Schema) {
+  }
+
+  override fun name(): String {
+    return typeIdentifier.text
+  }
+}

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/CreateEnumTypeMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/CreateEnumTypeMixin.kt
@@ -1,0 +1,11 @@
+package app.cash.sqldelight.dialects.postgresql.grammar.mixins
+
+import app.cash.sqldelight.dialect.api.PreCreateTableInitialization
+import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlCreateEnumTypeStmt
+import com.alecstrong.sql.psi.core.psi.SqlCompositeElementImpl
+import com.intellij.lang.ASTNode
+
+internal abstract class CreateEnumTypeMixin(node: ASTNode) :
+  SqlCompositeElementImpl(node),
+  PostgreSqlCreateEnumTypeStmt,
+  PreCreateTableInitialization

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/DropEnumTypeMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/DropEnumTypeMixin.kt
@@ -1,11 +1,26 @@
 package app.cash.sqldelight.dialects.postgresql.grammar.mixins
 
-import app.cash.sqldelight.dialect.api.PreCreateTableInitialization
 import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlDropTypeStmt
+import com.alecstrong.sql.psi.core.psi.Schema
+import com.alecstrong.sql.psi.core.psi.SchemaContributor
 import com.alecstrong.sql.psi.core.psi.SqlCompositeElementImpl
 import com.intellij.lang.ASTNode
 
+/**
+ * Usage `DROP TYPE [IF EXISTS] ABC CASCADE | RESTRICT`
+ * Here, unlike PostgreSql, only a single type can be dropped per statement to keep a single typeIdentifier name.
+ * PreCreateTableInitialization is not used as it likely depends on tables using the enum type.
+ * SchemaContributor is used to include the `drop type` in the `schema.create` code block.
+ */
 internal abstract class DropEnumTypeMixin(node: ASTNode) :
   SqlCompositeElementImpl(node),
   PostgreSqlDropTypeStmt,
-  PreCreateTableInitialization
+  SchemaContributor {
+
+  override fun modifySchema(schema: Schema) {
+  }
+
+  override fun name(): String {
+    return typeIdentifier.text
+  }
+}

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/DropEnumTypeMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/DropEnumTypeMixin.kt
@@ -1,0 +1,11 @@
+package app.cash.sqldelight.dialects.postgresql.grammar.mixins
+
+import app.cash.sqldelight.dialect.api.PreCreateTableInitialization
+import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlDropTypeStmt
+import com.alecstrong.sql.psi.core.psi.SqlCompositeElementImpl
+import com.intellij.lang.ASTNode
+
+internal abstract class DropEnumTypeMixin(node: ASTNode) :
+  SqlCompositeElementImpl(node),
+  PostgreSqlDropTypeStmt,
+  PreCreateTableInitialization

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/create-enum/Sample.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/create-enum/Sample.s
@@ -1,0 +1,19 @@
+CREATE TYPE BUG_STATUS AS ENUM ('new', 'open', 'closed');
+
+CREATE TYPE COLORS AS ENUM ('red', 'green', 'purple');
+
+ALTER TYPE COLORS RENAME VALUE 'purple' TO 'mauve';
+
+ALTER TYPE COLORS ADD VALUE 'orange' AFTER 'red';
+
+DROP TYPE BUG_STATUS;
+
+DROP TYPE IF EXISTS COLORS CASCADE;
+
+CREATE TYPE ABC AS ENUM ('a', 'b', 'c');
+
+CREATE TABLE X  (
+   t1 ABC,
+   t2 ABC NOT NULL
+);
+

--- a/sqldelight-compiler/dialect/src/main/kotlin/app/cash/sqldelight/dialect/api/PreCreateTableInitialization.kt
+++ b/sqldelight-compiler/dialect/src/main/kotlin/app/cash/sqldelight/dialect/api/PreCreateTableInitialization.kt
@@ -1,0 +1,10 @@
+package app.cash.sqldelight.dialect.api
+
+import com.intellij.psi.PsiElement
+
+/**
+ * A Dialect implements this interface on statement Mixin classes that must be executed before `CREATE TABLE` statements
+ * in `.sq` files and where a schema is not derived from `.sqm` files.
+ * Only used in `app.cash.sqldelight.core.lang.util.TreeUtilKt.forInitializationStatements` for use by `Schema.create`
+ */
+interface PreCreateTableInitialization : PsiElement

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/TreeUtil.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/TreeUtil.kt
@@ -23,6 +23,7 @@ import app.cash.sqldelight.core.lang.psi.ColumnTypeMixin
 import app.cash.sqldelight.core.lang.psi.InsertStmtValuesMixin
 import app.cash.sqldelight.dialect.api.ExposableType
 import app.cash.sqldelight.dialect.api.IntermediateType
+import app.cash.sqldelight.dialect.api.PreCreateTableInitialization
 import app.cash.sqldelight.dialect.api.PrimitiveType
 import app.cash.sqldelight.dialect.api.PrimitiveType.INTEGER
 import app.cash.sqldelight.dialect.api.PrimitiveType.TEXT
@@ -36,6 +37,7 @@ import com.alecstrong.sql.psi.core.psi.SqlCreateTableStmt
 import com.alecstrong.sql.psi.core.psi.SqlCreateViewStmt
 import com.alecstrong.sql.psi.core.psi.SqlCreateVirtualTableStmt
 import com.alecstrong.sql.psi.core.psi.SqlExpr
+import com.alecstrong.sql.psi.core.psi.SqlExtensionStmt
 import com.alecstrong.sql.psi.core.psi.SqlModuleArgument
 import com.alecstrong.sql.psi.core.psi.SqlModuleColumnDef
 import com.alecstrong.sql.psi.core.psi.SqlPragmaName
@@ -256,28 +258,40 @@ fun PsiElement.rawSqlText(
 val PsiElement.range: IntRange
   get() = node.startOffset until (node.startOffset + node.textLength)
 
+fun SqlExtensionStmt.hasPreCreateTableInitialization(): Boolean {
+  return PsiTreeUtil.getChildOfType(
+    this,
+    PreCreateTableInitialization::class.java,
+  ) != null
+}
+
 fun Collection<SqlDelightQueriesFile>.forInitializationStatements(
   allowReferenceCycles: Boolean,
   body: (sqlText: String) -> Unit,
 ) {
   val views = ArrayList<SqlCreateViewStmt>()
+  val preTables = ArrayList<PsiElement>()
   val tables = ArrayList<SqlCreateTableStmt>()
   val creators = ArrayList<PsiElement>()
-  val miscellanious = ArrayList<PsiElement>()
+  val miscellaneous = ArrayList<PsiElement>()
 
   forEach { file ->
     file.sqlStatements()
       .filter { (label, _) -> label.name == null }
       .forEach { (_, sqlStatement) ->
         when {
+          sqlStatement.extensionStmt != null &&
+            sqlStatement.extensionStmt!!.hasPreCreateTableInitialization() -> preTables.add(sqlStatement.extensionStmt!!)
           sqlStatement.createTableStmt != null -> tables.add(sqlStatement.createTableStmt!!)
           sqlStatement.createViewStmt != null -> views.add(sqlStatement.createViewStmt!!)
           sqlStatement.createTriggerStmt != null -> creators.add(sqlStatement.createTriggerStmt!!)
           sqlStatement.createIndexStmt != null -> creators.add(sqlStatement.createIndexStmt!!)
-          else -> miscellanious.add(sqlStatement)
+          else -> miscellaneous.add(sqlStatement)
         }
       }
   }
+
+  preTables.forEach { body(it.rawSqlText()) }
 
   when (allowReferenceCycles) {
     // If we allow cycles, don't attempt to order the table creation statements. The dialect
@@ -294,7 +308,7 @@ fun Collection<SqlDelightQueriesFile>.forInitializationStatements(
   )
 
   creators.forEach { body(it.rawSqlText()) }
-  miscellanious.forEach { body(it.rawSqlText()) }
+  miscellaneous.forEach { body(it.rawSqlText()) }
 }
 
 private fun ArrayList<SqlCreateTableStmt>.buildGraph(): Graph<SqlCreateTableStmt, DefaultEdge> {

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Enums.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Enums.sq
@@ -1,0 +1,30 @@
+CREATE TYPE PRIORITY AS ENUM('low','medium','high');
+
+CREATE TABLE Requests(
+    id INT PRIMARY KEY,
+    title TEXT NOT NULL,
+    priority PRIORITY NOT NULL
+);
+
+insert:
+INSERT INTO Requests(id, title, priority) VALUES (?, ?, ?) RETURNING *;
+
+select:
+SELECT *
+FROM Requests
+ORDER BY priority;
+
+selectByPriority:
+SELECT *
+FROM Requests
+WHERE priority = ?
+ORDER BY priority;
+
+selectMinPriority:
+SELECT * FROM Requests
+WHERE priority = (SELECT MIN(priority) FROM Requests);
+
+selectEnumValues:
+SELECT enum_range(NULL::PRIORITY) values,
+ enum_first(NULL::PRIORITY) first_value,
+ enum_last(NULL::PRIORITY)  last_value;

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
@@ -1235,4 +1235,42 @@ class PostgreSqlTest {
       assertThat(first().array_without_unq_key_).isFalse()
     }
   }
+
+  @Test
+  fun testEnums() {
+    val low = database.enumsQueries.insert(111, "Testing Low", "low").executeAsOne()
+    val med = database.enumsQueries.insert(122, "Testing Medium", "medium").executeAsOne()
+    val high = database.enumsQueries.insert(133, "Testing High", "high").executeAsOne()
+    database.enumsQueries.select().executeAsList().let {
+      assertThat(it).containsExactly(low, med, high)
+    }
+  }
+
+  @Test
+  fun testEnumsArg() {
+    val low = database.enumsQueries.insert(111, "Testing Low", "low").executeAsOne()
+    val med = database.enumsQueries.insert(122, "Testing Medium", "medium").executeAsOne()
+    val high = database.enumsQueries.insert(133, "Testing High", "high").executeAsOne()
+    database.enumsQueries.selectByPriority("medium").executeAsList().let {
+      assertThat(it).containsExactly(med)
+    }
+  }
+
+  @Test
+  fun testEnumsMin() {
+    val low = database.enumsQueries.insert(111, "Testing Low", "low").executeAsOne()
+    val med = database.enumsQueries.insert(122, "Testing Medium", "medium").executeAsOne()
+    val high = database.enumsQueries.insert(133, "Testing High", "high").executeAsOne()
+    database.enumsQueries.selectMinPriority().executeAsList().let {
+      assertThat(it).containsExactly(low)
+    }
+  }
+
+  fun testEnumsFunctions() {
+    database.enumsQueries.selectEnumValues().executeAsOne().let {
+      assertThat(it.values).isEqualTo("{low,medium,high}")
+      assertThat(it.first_value).isEqualTo("low")
+      assertThat(it.last_value).isEqualTo("high")
+    }
+  }
 }


### PR DESCRIPTION
fixes #4339

🔢 🐘 Support for PostgreSql Enum types  - https://wiki.postgresql.org/wiki/Enum

These are mapped as `String` type,  *there is no compiler support yet for generating as Kotlin Enum classes*. see https://github.com/sqldelight/sqldelight/issues/3773. This would be tricky as the Enum Type can be changed with `ALTER TYPE` - so currently type safety outside the database is lost.

*Recommend SqlDelight enum type adapters used instead* as these are type safe, there maybe some performance reasons for using native enums or using them as ranges.

`CREATE ENUM` must be executed before `CREATE TABLE` in create schema - there is a change to `TreeUtil` to add a marker interface `PreCreateTableInitialization` to process these statements before `createTableStmt`. Statements in migration files are preserved in the declaration order and this is the preferred way to manage PostgreSql schema.

Note: PostgreSql doesn't support `CREATE TYPE IF EXISTS ...` or `CREATE OR REPLACE TYPE`.  Using `CREATE TYPE` with initialization scripts is not idempotent.

`DROP TYPE [IF EXISTS] ...` likely depends on tables using the enum type so is not using `PreCreateTableInitialization`.

``` sql

CREATE TYPE PRIORITY AS ENUM('low','medium','high');

CREATE TABLE Requests(
    id INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
    title VARCHAR(255) NOT NULL,
    priority PRIORITY NOT NULL,
    request_date DATE NOT NULL
);
```

Functions 

``` sql
SELECT enum_range(NULL::PRIORITY);

SELECT enum_first(NULL::PRIORITY) first_value, enum_last(NULL::PRIORITY) last_value;
```

Other supported DDL for use with enum

Note: Changing enum types is not type safe outside of the database as we don't currently compile enums to Kotlin types.

``` sql

ALTER TYPE COLORS RENAME VALUE 'purple' TO 'mauve';

ALTER TYPE COLORS ADD VALUE 'orange' AFTER 'red';

DROP TYPE IF EXISTS BUG_STATUS, COLORS; -- only succeeds if there are no table columns using type

DROP TYPE IF EXISTS PRIORITY CASCADE; -- drops any table columns using type

```

NOTE:
SqlDelight/SqlPsi doesn't support the concept of adding/removing types with Schema modify (only tables, indices, columns, views), that is why there is no implementation

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
