### PR TITLE
Fix prepare_mkdocs.sh error in sed command

### DIFF
--- a/.github/workflows/prepare_mkdocs.sh
+++ b/.github/workflows/prepare_mkdocs.sh
@@ -15,7 +15,7 @@ set -ex
 set +x
 find docs/2.x/ -name '*.html' \
   -exec perl -i~ -0777 -pe 's/<a href="(.*)">([\n\s]+)?(<span>)?([\n\s]+)?SQLDelight([\n\s]+)?(<\/span>)?([\n\s]+)?<\/a>/<a href="\/sqldelight\/'"$1"'"><span>SQLDelight<\/span><\/a>/g' {} \; \
-  -exec sed -i 's/<\/head>/<link rel="icon" href="\/sqldelight\/'"$1"'/images\/icon-cashapp.png"><\/head>/g' {} \;
+  -exec sed -i 's@</head>@<link rel="icon" href="/sqldelight/'"$1"'/images/icon-cashapp.png"></head>@g' {} \;
 set -x
 
 # Copy in special files that GitHub wants in the project root.


### PR DESCRIPTION
While looking into updating Python  https://github.com/sqldelight/sqldelight/pull/5950

I can see the current `Prep Mkdocs` job is broken and printing sed command errors.

The job still completes successfully as the `sed` command is just unable to perform a replacement  

Error `sed: -e expression #1, char 66: unknown option to 's'` is repeated for every html file e.g
https://github.com/sqldelight/sqldelight/actions/runs/18037360978/job/51327355255  see `Prep Mkdocs` job

This is caused because the sed escape character '/' needs to be different from the replacement character '/'

Fix: use another character for sed replacement command e.g s@/@/@g

Also means the forward slash '\/' doesn't need to be escaped now - so this now `/`

The purpose of the sed command is to append a favicon before the html api docs `</head>` 

E.g output expected where the script takes an argument for the version.

```html
<link rel="icon" href="/sqldelight/2.2.0-SNAPSHOT/images/icon-cashapp.png">
</head>
```
The icon does exist at this location https://sqldelight.github.io/sqldelight/2.2.0-SNAPSHOT/images/icon-cashapp.png

Once merged - It can be verified that docs in https://sqldelight.github.io/sqldelight/2.2.0-SNAPSHOT/2.x/ have the $ fav icon inserted 

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
