### PR TITLE
Add Postgresql Json aggregate function FILTER

### DIFF
--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
@@ -190,7 +190,9 @@ open class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : Ty
     "jsonb_path_query_array", "jsonb_path_query_first", "jsonb_path_query_array_tz", "jsonb_path_query_first_tz",
     "jsonb_pretty",
     "json_typeof", "jsonb_typeof",
-    "json_agg", "jsonb_agg", "json_object_agg", "jsonb_object_agg",
+    "json_agg", "jsonb_agg", "json_agg_strict", "jsonb_agg_strict",
+    "json_object_agg", "jsonb_object_agg", "json_object_agg_strict", "jsonb_object_agg_strict",
+    "json_object_agg_unique", "jsonb_object_agg_unique", "json_object_agg_unique_strict", "jsonb_object_agg_unique_strict",
     -> IntermediateType(PostgreSqlType.JSON)
     "json_build_object", "jsonb_build_object",
     -> IntermediateType(TEXT)
@@ -322,7 +324,7 @@ open class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : Ty
     }
     is PostgreSqlAtTimeZoneOperator -> IntermediateType(TEXT)
     is PostgreSqlExtensionExpr -> when {
-      jsonFunctionStmt != null -> IntermediateType(PostgreSqlType.JSON)
+      jsonFunctionStmt != null || jsonAggStmt != null || jsonObjectAggStmt != null -> IntermediateType(PostgreSqlType.JSON)
 
       arrayAggStmt != null -> {
         val typeForArray = (arrayAggStmt as AggregateExpressionMixin).expr.postgreSqlType() // same as resolvedType(expr)

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -525,7 +525,7 @@ compound_select_stmt ::= [ {with_clause} ] {select_stmt}  ( {compound_operator} 
   override = true
 }
 
-extension_expr ::= plsql_trigger_var_expression | is_json_expression | overlaps_operator_expression | range_operator_expression | extract_temporal_expression | double_colon_cast_operator_expression | contains_operator_expression | at_time_zone_operator_expression | regex_match_operator_expression | match_operator_expression | json_function_stmt | array_agg_stmt| string_agg_stmt | json_expression | boolean_not_expression | window_function_expr {
+extension_expr ::= json_object_agg_stmt | json_agg_stmt | plsql_trigger_var_expression | is_json_expression | overlaps_operator_expression | range_operator_expression | extract_temporal_expression | double_colon_cast_operator_expression | contains_operator_expression | at_time_zone_operator_expression | regex_match_operator_expression | match_operator_expression | json_function_stmt | array_agg_stmt| string_agg_stmt | json_expression | boolean_not_expression | window_function_expr {
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlExtensionExprImpl"
   implements = "com.alecstrong.sql.psi.core.psi.SqlExtensionExpr"
   override = true
@@ -698,7 +698,21 @@ truncate_option ::= truncate_option_identity | truncate_option_cascade
 truncate_option_identity ::= ( 'RESTART' | 'CONTINUE' ) 'IDENTITY'
 truncate_option_cascade ::=  'CASCADE' | 'RESTRICT'
 
-json_function_stmt ::= ( 'row_to_json' | 'json_agg' | 'to_json' | 'to_jsonb' ) LP ( {table_alias} | {table_name} ) RP
+json_function_stmt ::= ( 'row_to_json' | 'to_json' | 'to_jsonb' ) LP ( {table_alias} | {table_name} ) RP
+
+json_agg_stmt ::= ( 'json_agg' | 'jsonb_agg' | 'json_agg_strict' | 'jsonb_agg_strict')
+LP [ ALL | DISTINCT ] ( json_expression | {table_alias} | {table_name} | <<expr '-1'>> ) [ ORDER BY {ordering_term} ( COMMA {ordering_term} ) * ] RP
+[ 'FILTER' LP WHERE <<expr '-1'>> [ double_colon_cast_operator ] RP ] {
+pin = 2
+}
+
+json_object_agg_stmt ::= ('json_object_agg' | 'jsonb_object_agg' | 'json_object_agg_strict' | 'jsonb_object_agg_strict'
+| 'json_object_agg_unique' | 'jsonb_object_agg_unique' | 'json_object_agg_unique_strict' | 'jsonb_object_agg_unique_strict' ) {
+LP [ ALL | DISTINCT ] ( json_expression | {column_expr} | <<expr '-1'>> ) COMMA ( json_expression | {column_expr} | <<expr '-1'>> )
+[ ORDER BY {ordering_term} ( COMMA {ordering_term} ) * ] RP
+[ 'FILTER' LP WHERE <<expr '-1'>> [ double_colon_cast_operator ] RP ] {
+pin = 2
+}
 
 string_agg_stmt ::= 'string_agg' LP [ ALL | DISTINCT ] <<expr '-1'>> COMMA string_literal [ ORDER BY {ordering_term} ( COMMA {ordering_term} ) * ] RP
 [ 'FILTER' LP WHERE <<expr '-1'>> RP ] {

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/json_functions/Test.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/json_functions/Test.s
@@ -45,3 +45,23 @@ SELECT row_to_json(r)
 FROM (
   SELECT t FROM myTable
 ) r;
+
+SELECT jsonb_agg(myTable) FILTER (WHERE (datab->>'in_stock')::BOOLEAN) FROM myTable;
+
+SELECT jsonb_agg(datab->'color') FILTER (WHERE datab ?? 'color') AS colors
+FROM myTable;
+
+SELECT jsonb_object_agg(datab->>'color', datab)
+FROM myTable;
+
+SELECT jsonb_object_agg(t, datab) FILTER (WHERE t IS NOT NULL)
+FROM myTable;
+
+SELECT json_object_agg_unique(t, data)
+FROM myTable;
+
+SELECT jsonb_object_agg_strict(t, datab)
+FROM myTable;
+
+SELECT jsonb_object_agg_strict(t, datab ORDER BY t DESC)
+FROM myTable;

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Json.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Json.sq
@@ -100,3 +100,20 @@ SELECT
   data IS JSON ARRAY WITHOUT UNIQUE KEYS "array without unq key?"
 FROM TestJsonCheck
 WHERE data IS NOT NULL;
+
+selectJsonAggFilterWhere:
+SELECT json_agg(data) FILTER (WHERE (data->>'in_stock')::BOOLEAN) AS in_stock_rows
+FROM TestJson;
+
+selectJsonbAggFilter:
+SELECT jsonb_agg(datab->'color') AS colors
+FROM TestJson
+WHERE datab ?? 'color';
+
+selectJsonObjectAggFilterWhere:
+SELECT json_object_agg(data->>'color', data) FILTER (WHERE (data->'size') IS NOT NULL)
+FROM TestJson;
+
+selectJsonbObjectAgg:
+SELECT jsonb_object_agg(datab->>'color', datab)
+FROM TestJson;

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
@@ -839,6 +839,38 @@ class PostgreSqlTest {
   }
 
   @Test
+  fun testJsonAggFilter() {
+    database.jsonQueries.insertLiteral("""{"color":"red","size":"small","in_stock":true}""", """{}""", """{}""", emptyArray<String>())
+    with(database.jsonQueries.selectJsonAggFilterWhere().executeAsList()) {
+      assertThat(first()).isEqualTo("""[{"color":"red","size":"small","in_stock":true}]""")
+    }
+  }
+
+  @Test
+  fun testJsonbAggFilter() {
+    database.jsonQueries.insertLiteral("""{}""", """{"color":"red","size":"small","in_stock":true}""", """{}""", emptyArray<String>())
+    with(database.jsonQueries.selectJsonbAggFilter().executeAsList()) {
+      assertThat(first()).isEqualTo("""["red"]""")
+    }
+  }
+
+  @Test
+  fun testJsonObjectAggFilterWhere() {
+    database.jsonQueries.insertLiteral("""{"color":"red","size":"small","in_stock":true}""", """{}""", """{}""", emptyArray<String>())
+    with(database.jsonQueries.selectJsonObjectAggFilterWhere().executeAsList()) {
+      assertThat(first()).isEqualTo("""{ "red" : {"color":"red","size":"small","in_stock":true} }""")
+    }
+  }
+
+  @Test
+  fun testJsonbObjectAgg() {
+    database.jsonQueries.insertLiteral("""{}""", """{"color":"red","size":"small","in_stock":true}""", """{}""", emptyArray<String>())
+    with(database.jsonQueries.selectJsonbObjectAgg().executeAsList()) {
+      assertThat(first()).isEqualTo("""{"red": {"size": "small", "color": "red", "in_stock": true}}""")
+    }
+  }
+
+  @Test
   fun testUpdateSetFromId() {
     database.updatesQueries.insertTest(31)
     database.updatesQueries.insertTest2("X")


### PR DESCRIPTION
Add JSON Aggregate Functions FILTER useful for working with schema-less column data

https://www.postgresql.org/docs/current/functions-aggregate.html

Add aggregate functions

```
json_object_agg(key, value)
jsonb_object_agg(key, value)
```

Add json aggregate `FILTER` clause

```sql
SELECT json_agg(data) FILTER (WHERE (data->>'in_stock')::BOOLEAN) FROM SomeTable;

SELECT jsonb_agg(data->'color') FILTER (WHERE data ?? 'color') AS colors FROM SomeTable;

SELECT jsonb_object_agg(key, value ORDER BY key DESC) FILTER (WHERE key IS NOT NULL) FROM SomeTable;

SELECT jsonb_object_agg_strict(key, value) FROM SomeTable;
```

* Adds grammar changes
   * Case where expressions could be double colon casted
   * Case where aggregate functions take a table reference or column reference (function expressions only take a column reference)
* Adds fixture tests for grammar examples
* Adds integration tests 

New Functions in Pg16

``` sql
json_agg_strict
jsonb_agg_strict

json_object_agg_strict
jsonb_object_agg_strict

json_object_agg_unique
jsonb_object_agg_unique

json_object_agg_unique_strict
jsonb_object_agg_unique_strict
```
---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
