### PR TITLE
Update renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,7 +4,7 @@
   ],
   "semanticCommits": "disabled",
   "constraints": {
-    "python": "==3.13"
+    "python": "3.14"
   },
   "ignoreDeps": [
     "com.jetbrains.intellij.platform",


### PR DESCRIPTION
🤔  I am going to leave it, now that we are on Python 3.14 - should be on that for a while.

Apart from fixing the `constraints` that apparently is only related to the runtime Python version.

I don't think the comparators `==` work in the `constraints` here and is probably not needed.

Also it doesn't prevent the updates to `python-version` declared in workflows and docker images etc - this would require `packageRules/allowedVersions` policies to be added if we run into more Python bit-rot breaking the docs build.

https://docs.renovatebot.com/configuration-options/#constraints

`Typically, the constraint is detected automatically by Renovate from files within the repository and there is no need to manually configure it.`

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
