### PR TITLE
Fix android mapper NullPointerException issue

### DIFF
--- a/drivers/android-driver/src/test/java/com/squareup/sqldelight/android/StaleWindowTest.kt
+++ b/drivers/android-driver/src/test/java/com/squareup/sqldelight/android/StaleWindowTest.kt
@@ -1,0 +1,129 @@
+package com.squareup.sqldelight.android
+
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider.getApplicationContext
+import app.cash.sqldelight.db.QueryResult
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.db.SqlSchema
+import app.cash.sqldelight.db.StaleWindowException
+import app.cash.sqldelight.driver.android.AndroidSqliteDriver
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+class StaleWindowTest {
+  private lateinit var driver: SqlDriver
+
+  private val schema = object : SqlSchema<QueryResult.Value<Unit>> {
+    override val version: Long = 1
+
+    override fun create(driver: SqlDriver): QueryResult.Value<Unit> {
+      driver.execute(
+        null,
+        """
+          CREATE TABLE test_table (
+            id INTEGER NOT NULL PRIMARY KEY,
+            name TEXT NOT NULL,
+            value INTEGER NOT NULL
+          )
+        """.trimIndent(),
+        0,
+      )
+      return QueryResult.Unit
+    }
+
+    override fun migrate(
+      driver: SqlDriver,
+      oldVersion: Long,
+      newVersion: Long,
+      vararg callbacks: app.cash.sqldelight.db.AfterVersion,
+    ): QueryResult.Value<Unit> = QueryResult.Unit
+  }
+
+  @Before
+  fun setup() {
+    driver = AndroidSqliteDriver(schema, getApplicationContext())
+  }
+
+  @After
+  fun teardown() {
+    driver.close()
+  }
+
+  @Test
+  @Config(sdk = [Build.VERSION_CODES.P])
+  fun `concurrent deletes trigger stale window`() {
+    driver.close()
+    driver = AndroidSqliteDriver(
+      schema = schema,
+      context = getApplicationContext(),
+      windowSizeBytes = 2048L,
+    )
+
+    // Insert 100 entries
+    for (i in 1..100) {
+      driver.execute(
+        null,
+        "INSERT INTO test_table (id, name, value) VALUES ($i, 'Name$i', ${i * 10})",
+        0,
+      )
+    }
+
+    var exceptionCaught: Exception? = null
+    var rowsProcessed = 0
+
+    try {
+      driver.executeQuery(
+        null,
+        "SELECT * FROM test_table ORDER BY id",
+        { cursor ->
+          while (cursor.next().value) {
+            // Use !! to mirror generated mapper behavior. With the fix in place,
+            // StaleWindowException should be thrown before any mapper-level NPE.
+            cursor.getLong(0)!!
+            cursor.getString(1)!!
+            cursor.getLong(2)!!
+
+            rowsProcessed++
+
+            // After 20 rows, delete ids > 80 to shrink the window
+            if (rowsProcessed == 20) {
+              driver.execute(null, "DELETE FROM test_table WHERE id > 80", 0)
+            }
+          }
+          QueryResult.Unit
+        },
+        0,
+      )
+    } catch (e: Exception) {
+      exceptionCaught = e
+    }
+
+    val exception = exceptionCaught ?: run {
+      fail("Expected StaleWindowException, but no exception was thrown")
+      return
+    }
+
+    assertTrue(
+      "Expected StaleWindowException, but got ${exception::class.java.name}",
+      exception is StaleWindowException,
+    )
+    assertTrue(
+      "Exception message should contain position info",
+      exception.message?.contains("position=") == true,
+    )
+    // We delete rows 80+
+    assertEquals(
+      "Detected stale window after processing rows",
+      80,
+      rowsProcessed,
+    )
+  }
+}

--- a/runtime/api/runtime.api
+++ b/runtime/api/runtime.api
@@ -213,6 +213,10 @@ public abstract interface class app/cash/sqldelight/db/SqlSchema {
 	public abstract fun migrate (Lapp/cash/sqldelight/db/SqlDriver;JJ[Lapp/cash/sqldelight/db/AfterVersion;)Lapp/cash/sqldelight/db/QueryResult;
 }
 
+public final class app/cash/sqldelight/db/StaleWindowException : java/lang/RuntimeException {
+	public fun <init> (Ljava/lang/String;)V
+}
+
 public final class app/cash/sqldelight/logs/LogSqliteDriver : app/cash/sqldelight/db/SqlDriver {
 	public fun <init> (Lapp/cash/sqldelight/db/SqlDriver;Lkotlin/jvm/functions/Function1;)V
 	public fun addListener ([Ljava/lang/String;Lapp/cash/sqldelight/Query$Listener;)V

--- a/runtime/src/commonMain/kotlin/app/cash/sqldelight/db/StaleWindowException.kt
+++ b/runtime/src/commonMain/kotlin/app/cash/sqldelight/db/StaleWindowException.kt
@@ -1,0 +1,10 @@
+package app.cash.sqldelight.db
+
+/**
+ * Thrown when the underlying driver detects that the current cursor row
+ * is no longer backed by the active platform cursor window (e.g.
+ * Android's CursorWindow) due to concurrent mutations.
+ *
+ * This indicates that the row cannot be read reliably.
+ */
+class StaleWindowException(message: String) : RuntimeException(message)


### PR DESCRIPTION
Attempts to fix https://github.com/sqldelight/sqldelight/issues/6049 (More detailed analysis and background are included in the issue, along with a minimal reproducible example.)

---

## Bug

This issue is surprisingly easy to trigger on Android devices, especially when running reactive queries over larger tables or on slower hardware.

A **very small reproducible example** is here:  
https://github.com/JsFlo/sqldelight-mapper-npe-repro

And the same three files integrated directly into SQLDelight’s sample Android app (for easier step-through debugging) are here:  
https://github.com/sqldelight/sqldelight/compare/master...JsFlo:sqldelight:reproAndroidNpeIssue?expand=1

**Repro gist:**  
Start a reactive query (e.g., `asFlow().mapToList()`) and delete rows while the cursor is mid-iteration. Android’s `CursorWindow` may shrink due to the deletes. When this happens, Android does *not* throw an error,  instead all `get*()` calls return `null`, even for NON NULL columns.

If the mapper generated `!!` (for `NOT NULL` columns) then this crashes with:
```
CursorWindow: Failed to read row 1285, column 0 from a window with 1285 rows, 2 columns
java.lang.NullPointerException
    at UserQueries.selectAll$lambda$0(UserQueries.kt:17)
    ...
```

When all mapped columns are nullable, SQLDelight generates mappers without !!, so the behavior is:

* same cpp log is emitted ("Failed to read row X...")
* `get*()` returns null silently
* The row is treated as valid
* Incorrect null values flow downstream

If enough stale rows are read, the cursor eventually walks past the real number of rows and `AndroidCursor.next()` is called  -> which eventually calls [SQLiteCursor.onMove](https://android.googlesource.com/platform/frameworks/base/+/refs/heads/master/core/java/android/database/sqlite/SQLiteCursor.java#123) where `fillWindow` is called and because we're past the real number of rows an exception like this is thrown: 

```
Row too big to fit into CursorWindow requiredPos=92, totalRows=80
android.database.sqlite.SQLiteBlobTooBigException
```
---

This can happen regularly in  apps, and in practice can be triggered by deleting even a **single** row in the right conditions.

---

## PR

This PR introduces:

### 1. Explicit detection of stale CursorWindow rows  
A new `StaleWindowException` is thrown when the cursor’s logical position is no longer backed by the active window.

### 2. Per-row handling in `awaitAsList()`  
Instead of crashing (due to `!!`) or emitting incorrect nulls (all-nullable schema), only the affected row is skipped. All valid rows still map correctly.

### Why this is needed

On Android, when a cursor is iterating and concurrent DELETEs occur:

- The `CursorWindow` may shrink  
- Android does **not** throw  
- `getLong()`, `getString()`, etc. return **null** silently  
- A log entry is printed by native code:

```
CursorWindow: Failed to read row X, column 0 from a window with Y rows
```

### What this PR changes

- Adds `StaleWindowException`
- `AndroidCursor` checks that `position` is within `[startPosition, startPosition + numRows)`
- `awaitAsList()` catches `StaleWindowException` per row and skips the stale row

This prevents **both** mapper crashes and silent data corruption.

---

## Notes on testing and observed behavior

While experimenting with tests, I noticed an additional behavior that the window-bounds check also intercepts certain `SQLiteBlobTooBigException` cases and at first I thought it meant that my solution was too broad but after looking at the issue some more I believe it legitimately fixes another related issue to the stale window issue.

Specifically, when the cursor iterates far enough past the real dataset (due to silent stale-row reads), Android eventually throws:

```
SQLiteBlobTooBigException: Row too big to fit into CursorWindow
requiredPos=92, totalRows=80
```

In this scenario, `requiredPos > totalRows`, which indicates the cursor has walked beyond the actual rows, a downstream effect of stale-window iteration (not a "real" Blob too big case)

---

## Open questions for maintainers

- Is the cursor-bounds check appropriate at this layer of the driver?
- Would you prefer a different strategy, e.g., abort the entire query instead of skipping rows? I was thinking about my case for this and with reactive flows I'm not sure that would work well especially given how often this happens. 

I have not added tests for the row-skipping behavior yet because I would like to confirm whether this direction is acceptable. Both for the detection and the awaitAsList behavior changes. I opened the PR mostly to share more about the issue and propose possible solutions for discussion.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
