### PR TITLE
Improve resolving kotlin type alias

### DIFF
--- a/dialects/hsql/src/main/kotlin/app/cash/sqldelight/dialects/hsql/HsqlTypeResolver.kt
+++ b/dialects/hsql/src/main/kotlin/app/cash/sqldelight/dialects/hsql/HsqlTypeResolver.kt
@@ -12,7 +12,9 @@ import app.cash.sqldelight.dialects.hsql.HsqlType.BIG_INT
 import app.cash.sqldelight.dialects.hsql.HsqlType.SMALL_INT
 import app.cash.sqldelight.dialects.hsql.HsqlType.TINY_INT
 import app.cash.sqldelight.dialects.hsql.grammar.psi.HsqlTypeName
+import com.alecstrong.sql.psi.core.psi.SqlExpr
 import com.alecstrong.sql.psi.core.psi.SqlFunctionExpr
+import com.alecstrong.sql.psi.core.psi.SqlLiteralExpr
 import com.alecstrong.sql.psi.core.psi.SqlTypeName
 
 class HsqlTypeResolver(private val parentResolver: TypeResolver) : TypeResolver by parentResolver {
@@ -34,6 +36,22 @@ class HsqlTypeResolver(private val parentResolver: TypeResolver) : TypeResolver 
         intervalDataType != null -> IntermediateType(PrimitiveType.BLOB)
         else -> throw IllegalArgumentException("Unknown kotlin type for sql type ${typeName.text}")
       }
+    }
+  }
+
+  override fun resolvedType(expr: SqlExpr): IntermediateType {
+    return when (expr) {
+      is SqlLiteralExpr -> when {
+        expr.literalValue.numericLiteral != null -> {
+          if (expr.literalValue.text.contains('.')) {
+            IntermediateType(PrimitiveType.REAL)
+          } else {
+            IntermediateType(HsqlType.INTEGER)
+          }
+        }
+        else -> parentResolver.resolvedType(expr)
+      }
+      else -> parentResolver.resolvedType(expr)
     }
   }
 

--- a/dialects/mysql/src/main/kotlin/app/cash/sqldelight/dialects/mysql/MySqlTypeResolver.kt
+++ b/dialects/mysql/src/main/kotlin/app/cash/sqldelight/dialects/mysql/MySqlTypeResolver.kt
@@ -22,6 +22,7 @@ import com.alecstrong.sql.psi.core.psi.SqlBinaryMultExpr
 import com.alecstrong.sql.psi.core.psi.SqlBinaryPipeExpr
 import com.alecstrong.sql.psi.core.psi.SqlExpr
 import com.alecstrong.sql.psi.core.psi.SqlFunctionExpr
+import com.alecstrong.sql.psi.core.psi.SqlLiteralExpr
 import com.alecstrong.sql.psi.core.psi.SqlTypeName
 import com.alecstrong.sql.psi.core.psi.SqlTypes
 import com.intellij.psi.PsiElement
@@ -82,6 +83,16 @@ class MySqlTypeResolver(
             BLOB,
           )
         }
+      }
+      is SqlLiteralExpr -> when {
+        expr.literalValue.numericLiteral != null -> {
+          if (expr.literalValue.text.contains('.')) {
+            IntermediateType(MySqlType.NUMERIC)
+          } else {
+            IntermediateType(MySqlType.INTEGER)
+          }
+        }
+        else -> parentResolver.resolvedType(expr)
       }
       else -> parentResolver.resolvedType(expr)
     }

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
@@ -312,7 +312,7 @@ open class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : Ty
       if (node.findChildByType(binaryExprChildTypesResolvingToBool) != null) {
         IntermediateType(BOOLEAN)
       } else {
-        encapsulatingType(
+        encapsulatingTypePreferringKotlin(
           exprList = getExprList(),
           nullability = { exprListNullability ->
             (this is SqlBinaryAddExpr || this is SqlBinaryMultExpr || this is SqlBinaryPipeExpr) &&

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
@@ -159,14 +159,7 @@ open class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : Ty
       }
     }
     "sum" -> {
-      val type = resolvedType(exprList.single())
-      when (type.dialectType) {
-        REAL -> IntermediateType(REAL).asNullable()
-        PostgreSqlType.NUMERIC -> IntermediateType(PostgreSqlType.NUMERIC).asNullable()
-        SMALL_INT -> IntermediateType(PostgreSqlType.SMALL_INT).asNullable()
-        PostgreSqlType.INTEGER -> IntermediateType(PostgreSqlType.INTEGER).asNullable()
-        else -> IntermediateType(PostgreSqlType.BIG_INT).asNullable()
-      }
+      encapsulatingTypePreferringKotlin(exprList, SMALL_INT, PostgreSqlType.INTEGER, BIG_INT, PostgreSqlType.NUMERIC) { true }
     }
     "to_hex", "quote_literal", "quote_ident", "md5" -> IntermediateType(TEXT)
     "quote_nullable" -> IntermediateType(TEXT).asNullable()

--- a/sqldelight-compiler/dialect/src/main/kotlin/app/cash/sqldelight/dialect/api/TypeResolver.kt
+++ b/sqldelight-compiler/dialect/src/main/kotlin/app/cash/sqldelight/dialect/api/TypeResolver.kt
@@ -6,6 +6,7 @@ import com.alecstrong.sql.psi.core.psi.SqlFunctionExpr
 import com.alecstrong.sql.psi.core.psi.SqlStmt
 import com.alecstrong.sql.psi.core.psi.SqlTypeName
 import com.intellij.psi.PsiElement
+import com.squareup.kotlinpoet.TypeName
 
 interface TypeResolver {
   /**
@@ -67,7 +68,6 @@ fun TypeResolver.encapsulatingType(
 ): IntermediateType {
   val types = exprList.map { resolvedType(it) }
   val sqlTypes = types.map { it.dialectType }
-  val dialectJavaTypes = typeOrder.map { it.javaType }
 
   if (PrimitiveType.ARGUMENT in sqlTypes) {
     if (typeOrder.size == 1) {
@@ -79,15 +79,10 @@ fun TypeResolver.encapsulatingType(
     }
     throw AnnotationException("The Kotlin type of the argument cannot be inferred, use CAST instead.", exprList.first())
   }
-
-  val dialectTypesGroup = types.groupBy { it.dialectType }
-
-  val isTypeAlias = dialectTypesGroup.size == 1 &&
-    dialectTypesGroup.values.first().filterNot { it.javaType in dialectJavaTypes }.distinct().size == 1
-  // stripping nullability because that shouldn't affect the type comparison
+  // stripping nullability on the java type is required for comparison with dialect java type
   val isTypesHomogeneous = types.map { it.dialectType to it.javaType.copy(nullable = false) }.distinct().size == 1
 
-  val type = if (preferKotlinType && (isTypesHomogeneous || isTypeAlias)) {
+  val type = if (preferKotlinType && (isTypesHomogeneous || hasTypeAlias(types, typeOrder.map { it.javaType }))) {
     types.first()
   } else {
     IntermediateType(typeOrder.last { it in sqlTypes })
@@ -101,4 +96,12 @@ fun TypeResolver.encapsulatingType(
     }
     else -> type.nullableIf(nullability(exprListNullability))
   }
+}
+
+// Prefer custom java types if all the dialect types are the same,
+// such as when the dialect types are all INTEGER and all the java types are not dialect java types
+private fun hasTypeAlias(resolvedTypes: List<IntermediateType>, javaTypes: List<TypeName>): Boolean {
+  val dialectTypesGroup = resolvedTypes.groupBy { it.dialectType }
+  return dialectTypesGroup.size == 1 &&
+    dialectTypesGroup.values.first().map { it.javaType.copy(nullable = false) }.filterNot { it in javaTypes }.distinct().size == 1
 }

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/ExprUtil.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/ExprUtil.kt
@@ -111,12 +111,7 @@ internal object AnsiSqlTypeResolver : TypeResolver {
      *
      */
     "sum" -> {
-      val type = exprList[0].type()
-      if (type.dialectType == INTEGER && !type.javaType.isNullable) {
-        type.asNullable()
-      } else {
-        IntermediateType(REAL).asNullable()
-      }
+      encapsulatingTypePreferringKotlin(exprList, INTEGER, REAL) { true }
     }
 
     "lower", "ltrim", "replace", "rtrim", "substr", "trim", "upper", "group_concat" -> {
@@ -234,17 +229,16 @@ private fun SqlExpr.ansiType(): IntermediateType = when (this) {
     ) {
       IntermediateType(PrimitiveType.BOOLEAN)
     } else {
-      typeResolver.encapsulatingType(
-        exprList = getExprList(),
-        nullability = { exprListNullability ->
-          (this is SqlBinaryAddExpr || this is SqlBinaryMultExpr || this is SqlBinaryPipeExpr) &&
-            exprListNullability.any { it }
-        },
+      typeResolver.encapsulatingTypePreferringKotlin(
+        getExprList(),
         INTEGER,
         REAL,
         TEXT,
         BLOB,
-      )
+      ) { exprListNullability ->
+        (this is SqlBinaryAddExpr || this is SqlBinaryMultExpr || this is SqlBinaryPipeExpr) &&
+          exprListNullability.any { it }
+      }
     }
   }
 

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/ExpressionTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/ExpressionTest.kt
@@ -942,4 +942,39 @@ class ExpressionTest {
 
     assertThat(file.errors).isEmpty()
   }
+
+  @Test fun `coalesce returns the custom Kotlin type for given argument types`(dialect: TestDialect) {
+    val file = FixtureCompiler.parseSql(
+      """
+      |import com.example.Foo;
+      |
+      |CREATE TABLE test (
+      |  bar INTEGER,
+      |  foo1 INTEGER AS Foo,
+      |  foo2 INTEGER AS Foo NOT NULL
+      |);
+      |
+      |someSelect:
+      |SELECT coalesce(foo1, 0),
+      |       coalesce(foo2, bar),
+      |       coalesce(foo1, foo2, bar)
+      |FROM test;
+      """.trimMargin(),
+      tempFolder,
+      dialect = dialect.dialect,
+    )
+
+    val integerKotlinType = when (dialect) {
+      POSTGRESQL, HSQL, MYSQL -> INT
+      else -> LONG
+    }
+
+    val query = file.namedQueries.first()
+    assertThat(query.resultColumns.map { it.javaType }).containsExactly(
+
+      ClassName("com.example", "Foo"),
+      ClassName("com.example", "Foo"),
+      ClassName("com.example", "Foo"),
+    ).inOrder()
+  }
 }

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/ExpressionTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/ExpressionTest.kt
@@ -185,7 +185,7 @@ class ExpressionTest {
     )
 
     val query = file.namedQueries.first()
-    assertThat(query.resultColumns.single().javaType).isEqualTo(DOUBLE.copy(nullable = true))
+    assertThat(query.resultColumns.single().javaType).isEqualTo(LONG.copy(nullable = true))
   }
 
   @Test fun `string functions return nullable string only if parameter is nullable`() {


### PR DESCRIPTION
☢️ fixes #6124 This is just a sketch as it should be possible to support with a limited implementation for the specific case.

The original issue https://github.com/sqldelight/sqldelight/issues/3572 had `Homogeneous` only considers `COALESCE(foo1, foo2`) column expression types where the same dialect type (e.g INTEGER) and java type (e.g Foo.class).

We want to promote the java type over a dialect type in a limited way that is not considered `Homogeneous` but the type alias is the dominant type.

e.g `COALESCE(foo, 0)` results in choosing `Foo.class` if there is a column type alias for `foo INTEGER AS Foo`

Below:- Foo and Bar are type aliases are of `INTEGER` Sql dialect

|Resolution | Dialect type | Kotlin type 1 | Kotlin type 2 | Result Kotlin type |
|-------|------|--------|--------|--------|
|Homogeneous `COALESCE(foo1, foo2)` | INTEGER | some.Foo | some.Foo | some.Foo |
|Dominator `COALESCE(foo, 0)` | INTEGER| some.Foo | kotlin.Long | some.Foo |
|Heterogeneous `COALESCE(foo, bar)` |INTEGER| some.Foo | some.Bar | kotlin.Long | 
---

* Currently the type ordering can be used to eliminate base dialect types, so any type alias to be promoted remains

TODO

Add tests 

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
