### PR TITLE
Fix `generateDatabaseInterface` cache miss when the list of AGP variants or flavors differ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ sqldelight-gradle-plugin/**/gradlew
 sqldelight-gradle-plugin/**/gradlew.bat
 *.iml
 build
+build-cache
 local.properties
 /reports
 gen

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Fixed
 - [Compiler] Other columns in a non-grouped aggregate result set are always nullable
 - [PostgreSQL Dialect] Resolve nullability correctly for coalesce and ifnull
+- [Gradle Plugin] Fix build cache miss for generateDatabaseInterface when the list of AGP variants differ between builds
 
 ## [2.3.2] - 2026-03-16
 [2.3.2]: https://github.com/sqldelight/sqldelight/releases/tag/2.3.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - [PostgreSQL Dialect] Fix lower and upper functions using Primitive bind argument to default as TEXT (#6262 by @griffio)
 - [Compiler] Use nullable bind argument with null safe operators(IS and IS DISTINCT FROM) (#6265 by @griffio)
 - [Gradle Plugin] Use AGP's variant resolution for project dependencies (#6217 by @maxsav)
+- [Gradle Plugin] Fix build cache miss for generateDatabaseInterface when the list of AGP variants differ between builds
 
 ## [2.3.2] - 2026-03-16
 [2.3.2]: https://github.com/sqldelight/sqldelight/releases/tag/2.3.2

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/PropertiesImpl.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/PropertiesImpl.kt
@@ -19,7 +19,11 @@ data class SqlDelightPropertiesFileImpl(
 
 data class SqlDelightDatabasePropertiesImpl(
   @Input override val packageName: String,
-  @Nested override val compilationUnits: List<SqlDelightCompilationUnitImpl>,
+  // Not a cache input: the task-specific compilationUnit property already captures the relevant
+  // compilation unit. Including all variants here makes the cache key depend on how many AGP
+  // variants are configured at build time (e.g. CI configures all variants; assembleDebug only
+  // configures debug), causing cache misses between environments.
+  @Internal override val compilationUnits: List<SqlDelightCompilationUnitImpl>,
   @Input override val className: String,
   @Nested override val dependencies: List<SqlDelightDatabaseNameImpl>,
   @Input override val deriveSchemaFromMigrations: Boolean = false,

--- a/sqldelight-gradle-plugin/src/test/cache-variant/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/cache-variant/build.gradle
@@ -1,0 +1,31 @@
+import com.android.build.api.variant.HostTestBuilder
+
+plugins {
+  id("com.android.library").version("8.13.2")
+  alias(libs.plugins.sqldelight)
+  alias(libs.plugins.kotlin.android)
+}
+
+android {
+  namespace = "com.example.sqldelight"
+
+  compileSdk = libs.versions.compileSdk.get() as int
+
+  lint {
+    textReport true
+  }
+}
+
+androidComponents {
+  beforeVariants(selector().withBuildType("release")) {
+    enable = project.properties["debugOnly"] != "true"
+  }
+}
+
+sqldelight {
+  databases {
+    TestDb {
+      packageName = "com.example.sqldelight"
+    }
+  }
+}

--- a/sqldelight-gradle-plugin/src/test/cache-variant/settings.gradle
+++ b/sqldelight-gradle-plugin/src/test/cache-variant/settings.gradle
@@ -1,0 +1,15 @@
+pluginManagement {
+    includeBuild("../build-logic-tests")
+}
+
+plugins {
+    id("sqldelightTests")
+}
+
+rootProject.name = 'cache-variant'
+
+buildCache {
+  local {
+    directory = new File(rootDir, 'build-cache')
+  }
+}

--- a/sqldelight-gradle-plugin/src/test/cache-variant/src/main/AndroidManifest.xml
+++ b/sqldelight-gradle-plugin/src/test/cache-variant/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest />

--- a/sqldelight-gradle-plugin/src/test/cache-variant/src/main/sqldelight/com/example/sqldelight/Test.sq
+++ b/sqldelight-gradle-plugin/src/test/cache-variant/src/main/sqldelight/com/example/sqldelight/Test.sq
@@ -1,0 +1,7 @@
+CREATE TABLE test_table (
+  id INTEGER NOT NULL PRIMARY KEY,
+  name TEXT NOT NULL
+);
+
+selectAll:
+SELECT * FROM test_table;

--- a/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/integrations/IntegrationTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/integrations/IntegrationTest.kt
@@ -199,6 +199,46 @@ class IntegrationTest {
     assertThat(result.output).contains("BUILD SUCCESSFUL")
   }
 
+  /**
+   * When the release variant is disabled (e.g. via debugOnly=true), the number of compilation units
+   * in SqlDelightDatabasePropertiesImpl.compilationUnits changes. The debug generate task should
+   * still get a cache hit because compilationUnits is @Internal. The task-level compilationUnit
+   * property already captures the relevant unit.
+   */
+  @Test fun `sqldelight output is cacheable when AGP variants change`() {
+    val fixtureRoot = File("src/test/cache-variant")
+    fixtureRoot.resolve("build").deleteRecursively()
+    fixtureRoot.resolve("build-cache").deleteRecursively()
+
+    val gradleRunner = GradleRunner.create()
+      .withCommonConfiguration(fixtureRoot)
+
+    // First run: both debug and release configured, populates the cache for debug.
+    val firstRun = gradleRunner
+      .withArguments("generateDebugTestDbInterface", "--build-cache", "--stacktrace")
+      .build()
+
+    with(firstRun.task(":generateDebugTestDbInterface")) {
+      assertThat(this).isNotNull()
+      assertThat(this!!.outcome).isNotEqualTo(TaskOutcome.FROM_CACHE)
+    }
+
+    fixtureRoot.resolve("build").deleteRecursively()
+
+    // Second run: release variant disabled but the debug unit is unchanged so we expect a cache hit.
+    val secondRun = gradleRunner
+      .withArguments("generateDebugTestDbInterface", "--build-cache", "-PdebugOnly=true", "--stacktrace")
+      .build()
+
+    with(secondRun.task(":generateDebugTestDbInterface")) {
+      assertThat(this).isNotNull()
+      assertThat(this!!.outcome).isEqualTo(TaskOutcome.FROM_CACHE)
+    }
+
+    fixtureRoot.resolve("build").deleteRecursively()
+    fixtureRoot.resolve("build-cache").deleteRecursively()
+  }
+
   @Test fun `deriveSchemaFromMigrations creates a db without queries`() {
     val runner = GradleRunner.create()
       .withCommonConfiguration(File("src/test/derive-schema-no-queries"))

--- a/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/integrations/IntegrationTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/integrations/IntegrationTest.kt
@@ -217,6 +217,46 @@ class IntegrationTest {
     assertThat(result.output).contains("BUILD SUCCESSFUL")
   }
 
+  /**
+   * When the release variant is disabled (e.g. via debugOnly=true), the number of compilation units
+   * in SqlDelightDatabasePropertiesImpl.compilationUnits changes. The debug generate task should
+   * still get a cache hit because compilationUnits is @Internal. The task-level compilationUnit
+   * property already captures the relevant unit.
+   */
+  @Test fun `sqldelight output is cacheable when AGP variants change`() {
+    val fixtureRoot = File("src/test/cache-variant")
+    fixtureRoot.resolve("build").deleteRecursively()
+    fixtureRoot.resolve("build-cache").deleteRecursively()
+
+    val gradleRunner = GradleRunner.create()
+      .withCommonConfiguration(fixtureRoot)
+
+    // First run: both debug and release configured, populates the cache for debug.
+    val firstRun = gradleRunner
+      .withArguments("generateDebugTestDbInterface", "--build-cache", "--stacktrace")
+      .build()
+
+    with(firstRun.task(":generateDebugTestDbInterface")) {
+      assertThat(this).isNotNull()
+      assertThat(this!!.outcome).isNotEqualTo(TaskOutcome.FROM_CACHE)
+    }
+
+    fixtureRoot.resolve("build").deleteRecursively()
+
+    // Second run: release variant disabled but the debug unit is unchanged so we expect a cache hit.
+    val secondRun = gradleRunner
+      .withArguments("generateDebugTestDbInterface", "--build-cache", "-PdebugOnly=true", "--stacktrace")
+      .build()
+
+    with(secondRun.task(":generateDebugTestDbInterface")) {
+      assertThat(this).isNotNull()
+      assertThat(this!!.outcome).isEqualTo(TaskOutcome.FROM_CACHE)
+    }
+
+    fixtureRoot.resolve("build").deleteRecursively()
+    fixtureRoot.resolve("build-cache").deleteRecursively()
+  }
+
   @Test fun `deriveSchemaFromMigrations creates a db without queries`() {
     val runner = GradleRunner.create()
       .withCommonConfiguration(File("src/test/derive-schema-no-queries"))


### PR DESCRIPTION
Our CI runs builds with both the debug and release variants enabled in AGP, but local builds disable release configurations for performance because there are so many projects in the build. This apparently caused sqldelight to have cache misses because the compilation units were tracked as task inputs by `SqlDelightDatabasePropertiesImpl` which is a `@Nested` input to all sqldelight tasks:

<img width="880" height="298" alt="image" src="https://github.com/user-attachments/assets/563c03ab-5e82-496e-8997-59a1d7ab8d7d" />

The compilation unit is already tracked by the task that generates the interface for specific variants and flavors:

https://github.com/sqldelight/sqldelight/blob/fb07a5f2d3a9fab1b9bc794d387f2b2318c056aa/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightDatabase.kt#L166

https://github.com/sqldelight/sqldelight/blob/fb07a5f2d3a9fab1b9bc794d387f2b2318c056aa/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightTask.kt#L54

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
