### PR TITLE
Suppress extra Kotlin compiler warnings in generated code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [Gradle Plugin] Implement stricter MigrationFile versioning (#5730 by @madisp)
 
 ### Fixed
+- [Compiler] Suppress Kotlin extra warnings in generated code (#6029 by @eyupcanakman)
 - [Compiler] Other columns in a non-grouped aggregate result set are always nullable
 - [PostgreSQL Dialect] Resolve nullability correctly for coalesce and ifnull
 - [PostgreSQL Dialect] Fixed IDE integration of the PostgreSQL dialect

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - [Gradle Plugin] Support gradle isolated projects (#6217 by @maxsav)
 
 ### Fixed
-- [Compiler] Suppress Kotlin extra warnings in generated code (#6029 by @eyupcanakman)
+- [Compiler] Suppress Kotlin extra warnings in generated code (#6208 by @eyupcanakman)
 - [Compiler] Other columns in a non-grouped aggregate result set are always nullable
 - [PostgreSQL Dialect] Resolve nullability correctly for coalesce and ifnull
 - [PostgreSQL Dialect] Fixed IDE integration of the PostgreSQL dialect

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [Gradle Plugin] Support gradle isolated projects (#6217 by @maxsav)
 
 ### Fixed
+- [Compiler] Suppress Kotlin extra warnings in generated code (#6029 by @eyupcanakman)
 - [Compiler] Other columns in a non-grouped aggregate result set are always nullable
 - [PostgreSQL Dialect] Resolve nullability correctly for coalesce and ifnull
 - [PostgreSQL Dialect] Fixed IDE integration of the PostgreSQL dialect

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/app/cash/sqldelight/core/integration/IntegrationTest.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/app/cash/sqldelight/core/integration/IntegrationTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+
 package app.cash.sqldelight.core.integration
 
 import app.cash.sqldelight.EnumColumnAdapter

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/app/cash/sqldelight/core/integration/IntegrationTest.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/app/cash/sqldelight/core/integration/IntegrationTest.kt
@@ -1,4 +1,4 @@
-@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
 
 package app.cash.sqldelight.core.integration
 

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/app/cash/sqldelight/core/integration/Shoots.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/app/cash/sqldelight/core/integration/Shoots.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+
 package app.cash.sqldelight.core.integration
 
 enum class Shoots {

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/app/cash/sqldelight/core/integration/Shoots.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/app/cash/sqldelight/core/integration/Shoots.kt
@@ -1,4 +1,4 @@
-@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
 
 package app.cash.sqldelight.core.integration
 

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/Group.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/Group.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+
 package com.example
 
 import kotlin.Long

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/Group.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/Group.kt
@@ -1,4 +1,4 @@
-@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
 
 package com.example
 

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/GroupQueries.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/GroupQueries.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+
 package com.example
 
 import app.cash.sqldelight.Query

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/GroupQueries.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/GroupQueries.kt
@@ -1,4 +1,4 @@
-@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
 
 package com.example
 

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/Player.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/Player.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+
 package com.example
 
 import app.cash.sqldelight.ColumnAdapter

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/Player.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/Player.kt
@@ -1,4 +1,4 @@
-@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
 
 package com.example
 

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/PlayerQueries.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/PlayerQueries.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+
 package com.example
 
 import app.cash.sqldelight.ExecutableQuery

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/PlayerQueries.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/PlayerQueries.kt
@@ -1,4 +1,4 @@
-@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
 
 package com.example
 

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/SelectFromTable2.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/SelectFromTable2.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+
 package com.example
 
 import kotlin.String

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/SelectFromTable2.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/SelectFromTable2.kt
@@ -1,4 +1,4 @@
-@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
 
 package com.example
 

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/SelectNull.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/SelectNull.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+
 package com.example
 
 import kotlin.Nothing

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/SelectNull.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/SelectNull.kt
@@ -1,4 +1,4 @@
-@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
 
 package com.example
 

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/Team.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/Team.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+
 package com.example
 
 import app.cash.sqldelight.ColumnAdapter

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/Team.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/Team.kt
@@ -1,4 +1,4 @@
-@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
 
 package com.example
 

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/TeamForCoach.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/TeamForCoach.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+
 package com.example
 
 import kotlin.Long

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/TeamForCoach.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/TeamForCoach.kt
@@ -1,4 +1,4 @@
-@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
 
 package com.example
 

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/TeamQueries.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/TeamQueries.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+
 package com.example
 
 import app.cash.sqldelight.ExecutableQuery

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/TeamQueries.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/TeamQueries.kt
@@ -1,4 +1,4 @@
-@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
 
 package com.example
 

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/TestDatabase.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/TestDatabase.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+
 package com.example
 
 import app.cash.sqldelight.Transacter

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/TestDatabase.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/TestDatabase.kt
@@ -1,4 +1,4 @@
-@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
 
 package com.example
 

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/player/SelectStuff.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/player/SelectStuff.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+
 package com.example.player
 
 import kotlin.Long

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/player/SelectStuff.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/player/SelectStuff.kt
@@ -1,4 +1,4 @@
-@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
 
 package com.example.player
 

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/team/SelectStuff.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/team/SelectStuff.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+
 package com.example.team
 
 import kotlin.Long

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/team/SelectStuff.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/team/SelectStuff.kt
@@ -1,4 +1,4 @@
-@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
 
 package com.example.team
 

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/testmodule/TestDatabaseImpl.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/testmodule/TestDatabaseImpl.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+
 package com.example.testmodule
 
 import app.cash.sqldelight.TransacterImpl

--- a/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/testmodule/TestDatabaseImpl.kt
+++ b/sqldelight-compiler/integration-tests/src/test/kotlin/com/example/testmodule/TestDatabaseImpl.kt
@@ -1,4 +1,4 @@
-@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
 
 package com.example.testmodule
 

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/SqlDelightCompiler.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/SqlDelightCompiler.kt
@@ -214,6 +214,7 @@ object SqlDelightCompiler {
     }
 
   private fun FileSpec.writeToAndClose(appendable: Appendable) {
+    appendable.append("@file:Suppress(\"RedundantVisibilityModifier\", \"ASSIGNED_VALUE_IS_NEVER_READ\")\n\n")
     writeTo(appendable)
     if (appendable is Closeable) appendable.close()
   }

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/SqlDelightCompiler.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/SqlDelightCompiler.kt
@@ -214,7 +214,7 @@ object SqlDelightCompiler {
     }
 
   private fun FileSpec.writeToAndClose(appendable: Appendable) {
-    appendable.append("@file:Suppress(\"RedundantVisibilityModifier\", \"ASSIGNED_VALUE_IS_NEVER_READ\")\n\n")
+    appendable.append("@file:Suppress(\"REDUNDANT_VISIBILITY_MODIFIER\", \"ASSIGNED_VALUE_IS_NEVER_READ\")\n\n")
     writeTo(appendable)
     if (appendable is Closeable) appendable.close()
   }

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/QueriesTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/QueriesTypeTest.kt
@@ -51,6 +51,8 @@ class QueriesTypeTest {
     assertThat(result.compilerOutput).containsKey(database)
     assertThat(result.compilerOutput[database].toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example.testmodule
       |
       |import app.cash.sqldelight.TransacterImpl
@@ -119,6 +121,8 @@ class QueriesTypeTest {
     assertThat(result.compilerOutput).containsKey(dataQueries)
     assertThat(result.compilerOutput[dataQueries].toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import app.cash.sqldelight.Query
@@ -235,6 +239,8 @@ class QueriesTypeTest {
     assertThat(result.compilerOutput).containsKey(database)
     assertThat(result.compilerOutput[database].toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example.testmodule
       |
       |import app.cash.sqldelight.TransacterImpl
@@ -291,6 +297,8 @@ class QueriesTypeTest {
     assertThat(result.compilerOutput).containsKey(dataQueries)
     assertThat(result.compilerOutput[dataQueries].toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import app.cash.sqldelight.TransacterImpl
@@ -343,6 +351,8 @@ class QueriesTypeTest {
     assertThat(result.compilerOutput).containsKey(database)
     assertThat(result.compilerOutput[database].toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example.testmodule
       |
       |import app.cash.sqldelight.TransacterImpl
@@ -420,6 +430,8 @@ class QueriesTypeTest {
     assertThat(result.compilerOutput).containsKey(database)
     assertThat(result.compilerOutput[database].toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example.testmodule
       |
       |import app.cash.sqldelight.TransacterImpl
@@ -476,6 +488,8 @@ class QueriesTypeTest {
     assertThat(result.compilerOutput).containsKey(dataQueries)
     assertThat(result.compilerOutput[dataQueries].toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import app.cash.sqldelight.Query
@@ -577,6 +591,8 @@ class QueriesTypeTest {
     assertThat(result.compilerOutput).containsKey(database)
     assertThat(result.compilerOutput[database].toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example.testmodule
       |
       |import app.cash.sqldelight.TransacterImpl
@@ -631,6 +647,8 @@ class QueriesTypeTest {
     assertThat(result.compilerOutput).containsKey(dataQueries)
     assertThat(result.compilerOutput[dataQueries].toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import app.cash.sqldelight.Query
@@ -757,6 +775,8 @@ class QueriesTypeTest {
     assertThat(result.compilerOutput).containsKey(dataQueries)
     assertThat(result.compilerOutput[dataQueries].toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import app.cash.sqldelight.Query
@@ -859,6 +879,8 @@ class QueriesTypeTest {
     val queryString = result.compilerOutput[dataQueries].toString()
     assertThat(queryString).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import app.cash.sqldelight.ExecutableQuery
@@ -916,6 +938,8 @@ class QueriesTypeTest {
     assertThat(result.compilerOutput).containsKey(dataQueries)
     assertThat(result.compilerOutput[dataQueries].toString()).isEqualTo(
       """
+        @file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+
         package com.example
 
         import app.cash.sqldelight.TransacterImpl
@@ -963,6 +987,8 @@ class QueriesTypeTest {
     assertThat(result.compilerOutput).containsKey(dataQueries)
     assertThat(result.compilerOutput[dataQueries].toString()).isEqualTo(
       """
+        @file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+
         package com.example
 
         import app.cash.sqldelight.TransacterImpl
@@ -1011,6 +1037,8 @@ class QueriesTypeTest {
     assertThat(result.compilerOutput).containsKey(dataQueries)
     assertThat(result.compilerOutput[dataQueries].toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import app.cash.sqldelight.ExecutableQuery

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/QueriesTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/QueriesTypeTest.kt
@@ -51,7 +51,7 @@ class QueriesTypeTest {
     assertThat(result.compilerOutput).containsKey(database)
     assertThat(result.compilerOutput[database].toString()).isEqualTo(
       """
-      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example.testmodule
       |
@@ -121,7 +121,7 @@ class QueriesTypeTest {
     assertThat(result.compilerOutput).containsKey(dataQueries)
     assertThat(result.compilerOutput[dataQueries].toString()).isEqualTo(
       """
-      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example
       |
@@ -239,7 +239,7 @@ class QueriesTypeTest {
     assertThat(result.compilerOutput).containsKey(database)
     assertThat(result.compilerOutput[database].toString()).isEqualTo(
       """
-      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example.testmodule
       |
@@ -297,7 +297,7 @@ class QueriesTypeTest {
     assertThat(result.compilerOutput).containsKey(dataQueries)
     assertThat(result.compilerOutput[dataQueries].toString()).isEqualTo(
       """
-      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example
       |
@@ -351,7 +351,7 @@ class QueriesTypeTest {
     assertThat(result.compilerOutput).containsKey(database)
     assertThat(result.compilerOutput[database].toString()).isEqualTo(
       """
-      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example.testmodule
       |
@@ -430,7 +430,7 @@ class QueriesTypeTest {
     assertThat(result.compilerOutput).containsKey(database)
     assertThat(result.compilerOutput[database].toString()).isEqualTo(
       """
-      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example.testmodule
       |
@@ -488,7 +488,7 @@ class QueriesTypeTest {
     assertThat(result.compilerOutput).containsKey(dataQueries)
     assertThat(result.compilerOutput[dataQueries].toString()).isEqualTo(
       """
-      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example
       |
@@ -591,7 +591,7 @@ class QueriesTypeTest {
     assertThat(result.compilerOutput).containsKey(database)
     assertThat(result.compilerOutput[database].toString()).isEqualTo(
       """
-      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example.testmodule
       |
@@ -647,7 +647,7 @@ class QueriesTypeTest {
     assertThat(result.compilerOutput).containsKey(dataQueries)
     assertThat(result.compilerOutput[dataQueries].toString()).isEqualTo(
       """
-      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example
       |
@@ -775,7 +775,7 @@ class QueriesTypeTest {
     assertThat(result.compilerOutput).containsKey(dataQueries)
     assertThat(result.compilerOutput[dataQueries].toString()).isEqualTo(
       """
-      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example
       |
@@ -879,7 +879,7 @@ class QueriesTypeTest {
     val queryString = result.compilerOutput[dataQueries].toString()
     assertThat(queryString).isEqualTo(
       """
-      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example
       |
@@ -938,7 +938,7 @@ class QueriesTypeTest {
     assertThat(result.compilerOutput).containsKey(dataQueries)
     assertThat(result.compilerOutput[dataQueries].toString()).isEqualTo(
       """
-        @file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+        @file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
 
         package com.example
 
@@ -987,7 +987,7 @@ class QueriesTypeTest {
     assertThat(result.compilerOutput).containsKey(dataQueries)
     assertThat(result.compilerOutput[dataQueries].toString()).isEqualTo(
       """
-        @file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+        @file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
 
         package com.example
 
@@ -1037,7 +1037,7 @@ class QueriesTypeTest {
     assertThat(result.compilerOutput).containsKey(dataQueries)
     assertThat(result.compilerOutput[dataQueries].toString()).isEqualTo(
       """
-      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example
       |

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/QueryWrapperTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/QueryWrapperTest.kt
@@ -33,6 +33,8 @@ class QueryWrapperTest {
     assertThat(queryWrapperFile).isNotNull()
     assertThat(queryWrapperFile.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example.testmodule
       |
       |import app.cash.sqldelight.TransacterImpl
@@ -113,7 +115,9 @@ class QueryWrapperTest {
     assertThat(queryWrapperFile).isNotNull()
     assertThat(queryWrapperFile.toString()).isEqualTo(
       """
-        |package com.example.testmodule
+        |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
+      |package com.example.testmodule
         |
         |import app.cash.sqldelight.TransacterImpl
         |import app.cash.sqldelight.db.AfterVersion
@@ -200,7 +204,9 @@ class QueryWrapperTest {
     assertThat(queryWrapperFile).isNotNull()
     assertThat(queryWrapperFile.toString()).isEqualTo(
       """
-        |package com.example.testmodule
+        |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
+      |package com.example.testmodule
         |
         |import app.cash.sqldelight.TransacterImpl
         |import app.cash.sqldelight.db.AfterVersion
@@ -294,7 +300,9 @@ class QueryWrapperTest {
     assertThat(queryWrapperFile).isNotNull()
     assertThat(queryWrapperFile.toString()).isEqualTo(
       """
-        |package com.example.testmodule
+        |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
+      |package com.example.testmodule
         |
         |import app.cash.sqldelight.TransacterImpl
         |import app.cash.sqldelight.db.AfterVersion
@@ -380,7 +388,9 @@ class QueryWrapperTest {
     assertThat(queryWrapperFile).isNotNull()
     assertThat(queryWrapperFile.toString()).isEqualTo(
       """
-        |package com.example.testmodule
+        |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
+      |package com.example.testmodule
         |
         |import app.cash.sqldelight.TransacterImpl
         |import app.cash.sqldelight.db.AfterVersion
@@ -464,7 +474,9 @@ class QueryWrapperTest {
     assertThat(queryWrapperFile).isNotNull()
     assertThat(queryWrapperFile.toString()).isEqualTo(
       """
-        |package com.example.testmodule
+        |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
+      |package com.example.testmodule
         |
         |import app.cash.sqldelight.TransacterImpl
         |import app.cash.sqldelight.db.AfterVersion
@@ -539,7 +551,9 @@ class QueryWrapperTest {
     assertThat(queryWrapperFile).isNotNull()
     assertThat(queryWrapperFile.toString()).isEqualTo(
       """
-        |package com.example.testmodule
+        |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
+      |package com.example.testmodule
         |
         |import app.cash.sqldelight.TransacterImpl
         |import app.cash.sqldelight.db.AfterVersion
@@ -618,7 +632,9 @@ class QueryWrapperTest {
     assertThat(queryWrapperFile).isNotNull()
     assertThat(queryWrapperFile.toString()).isEqualTo(
       """
-        |package com.example.testmodule
+        |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
+      |package com.example.testmodule
         |
         |import app.cash.sqldelight.TransacterImpl
         |import app.cash.sqldelight.db.AfterVersion
@@ -713,7 +729,9 @@ class QueryWrapperTest {
     assertThat(queryWrapperFile).isNotNull()
     assertThat(queryWrapperFile.toString()).isEqualTo(
       """
-        |package com.example.testmodule
+        |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
+      |package com.example.testmodule
         |
         |import app.cash.sqldelight.TransacterImpl
         |import app.cash.sqldelight.db.AfterVersion
@@ -828,7 +846,9 @@ class QueryWrapperTest {
     assertThat(queryWrapperFile).isNotNull()
     assertThat(queryWrapperFile.toString()).isEqualTo(
       """
-        |package com.example.testmodule
+        |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
+      |package com.example.testmodule
         |
         |import app.cash.sqldelight.TransacterImpl
         |import app.cash.sqldelight.db.AfterVersion
@@ -941,7 +961,9 @@ class QueryWrapperTest {
     assertThat(queryWrapperFile.toString()).apply {
       startsWith(
         """
-        |package com.example.testmodule
+        |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
+      |package com.example.testmodule
         |
         |import app.cash.sqldelight.TransacterImpl
         |import app.cash.sqldelight.db.AfterVersion

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/QueryWrapperTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/QueryWrapperTest.kt
@@ -116,8 +116,8 @@ class QueryWrapperTest {
     assertThat(queryWrapperFile.toString()).isEqualTo(
       """
         |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
-      |
-      |package com.example.testmodule
+        |
+        |package com.example.testmodule
         |
         |import app.cash.sqldelight.TransacterImpl
         |import app.cash.sqldelight.db.AfterVersion
@@ -205,8 +205,8 @@ class QueryWrapperTest {
     assertThat(queryWrapperFile.toString()).isEqualTo(
       """
         |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
-      |
-      |package com.example.testmodule
+        |
+        |package com.example.testmodule
         |
         |import app.cash.sqldelight.TransacterImpl
         |import app.cash.sqldelight.db.AfterVersion
@@ -301,8 +301,8 @@ class QueryWrapperTest {
     assertThat(queryWrapperFile.toString()).isEqualTo(
       """
         |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
-      |
-      |package com.example.testmodule
+        |
+        |package com.example.testmodule
         |
         |import app.cash.sqldelight.TransacterImpl
         |import app.cash.sqldelight.db.AfterVersion
@@ -389,8 +389,8 @@ class QueryWrapperTest {
     assertThat(queryWrapperFile.toString()).isEqualTo(
       """
         |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
-      |
-      |package com.example.testmodule
+        |
+        |package com.example.testmodule
         |
         |import app.cash.sqldelight.TransacterImpl
         |import app.cash.sqldelight.db.AfterVersion
@@ -475,8 +475,8 @@ class QueryWrapperTest {
     assertThat(queryWrapperFile.toString()).isEqualTo(
       """
         |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
-      |
-      |package com.example.testmodule
+        |
+        |package com.example.testmodule
         |
         |import app.cash.sqldelight.TransacterImpl
         |import app.cash.sqldelight.db.AfterVersion
@@ -552,8 +552,8 @@ class QueryWrapperTest {
     assertThat(queryWrapperFile.toString()).isEqualTo(
       """
         |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
-      |
-      |package com.example.testmodule
+        |
+        |package com.example.testmodule
         |
         |import app.cash.sqldelight.TransacterImpl
         |import app.cash.sqldelight.db.AfterVersion
@@ -633,8 +633,8 @@ class QueryWrapperTest {
     assertThat(queryWrapperFile.toString()).isEqualTo(
       """
         |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
-      |
-      |package com.example.testmodule
+        |
+        |package com.example.testmodule
         |
         |import app.cash.sqldelight.TransacterImpl
         |import app.cash.sqldelight.db.AfterVersion
@@ -730,8 +730,8 @@ class QueryWrapperTest {
     assertThat(queryWrapperFile.toString()).isEqualTo(
       """
         |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
-      |
-      |package com.example.testmodule
+        |
+        |package com.example.testmodule
         |
         |import app.cash.sqldelight.TransacterImpl
         |import app.cash.sqldelight.db.AfterVersion
@@ -847,8 +847,8 @@ class QueryWrapperTest {
     assertThat(queryWrapperFile.toString()).isEqualTo(
       """
         |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
-      |
-      |package com.example.testmodule
+        |
+        |package com.example.testmodule
         |
         |import app.cash.sqldelight.TransacterImpl
         |import app.cash.sqldelight.db.AfterVersion
@@ -962,8 +962,8 @@ class QueryWrapperTest {
       startsWith(
         """
         |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
-      |
-      |package com.example.testmodule
+        |
+        |package com.example.testmodule
         |
         |import app.cash.sqldelight.TransacterImpl
         |import app.cash.sqldelight.db.AfterVersion

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/QueryWrapperTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/QueryWrapperTest.kt
@@ -33,7 +33,7 @@ class QueryWrapperTest {
     assertThat(queryWrapperFile).isNotNull()
     assertThat(queryWrapperFile.toString()).isEqualTo(
       """
-      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example.testmodule
       |
@@ -115,7 +115,7 @@ class QueryWrapperTest {
     assertThat(queryWrapperFile).isNotNull()
     assertThat(queryWrapperFile.toString()).isEqualTo(
       """
-        |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+        |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example.testmodule
         |
@@ -204,7 +204,7 @@ class QueryWrapperTest {
     assertThat(queryWrapperFile).isNotNull()
     assertThat(queryWrapperFile.toString()).isEqualTo(
       """
-        |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+        |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example.testmodule
         |
@@ -300,7 +300,7 @@ class QueryWrapperTest {
     assertThat(queryWrapperFile).isNotNull()
     assertThat(queryWrapperFile.toString()).isEqualTo(
       """
-        |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+        |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example.testmodule
         |
@@ -388,7 +388,7 @@ class QueryWrapperTest {
     assertThat(queryWrapperFile).isNotNull()
     assertThat(queryWrapperFile.toString()).isEqualTo(
       """
-        |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+        |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example.testmodule
         |
@@ -474,7 +474,7 @@ class QueryWrapperTest {
     assertThat(queryWrapperFile).isNotNull()
     assertThat(queryWrapperFile.toString()).isEqualTo(
       """
-        |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+        |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example.testmodule
         |
@@ -551,7 +551,7 @@ class QueryWrapperTest {
     assertThat(queryWrapperFile).isNotNull()
     assertThat(queryWrapperFile.toString()).isEqualTo(
       """
-        |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+        |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example.testmodule
         |
@@ -632,7 +632,7 @@ class QueryWrapperTest {
     assertThat(queryWrapperFile).isNotNull()
     assertThat(queryWrapperFile.toString()).isEqualTo(
       """
-        |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+        |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example.testmodule
         |
@@ -729,7 +729,7 @@ class QueryWrapperTest {
     assertThat(queryWrapperFile).isNotNull()
     assertThat(queryWrapperFile.toString()).isEqualTo(
       """
-        |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+        |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example.testmodule
         |
@@ -846,7 +846,7 @@ class QueryWrapperTest {
     assertThat(queryWrapperFile).isNotNull()
     assertThat(queryWrapperFile.toString()).isEqualTo(
       """
-        |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+        |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example.testmodule
         |
@@ -961,7 +961,7 @@ class QueryWrapperTest {
     assertThat(queryWrapperFile.toString()).apply {
       startsWith(
         """
-        |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+        |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example.testmodule
         |

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/async/AsyncQueriesTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/async/AsyncQueriesTypeTest.kt
@@ -52,6 +52,8 @@ class AsyncQueriesTypeTest {
     Truth.assertThat(result.compilerOutput).containsKey(database)
     Truth.assertThat(result.compilerOutput[database].toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example.testmodule
       |
       |import app.cash.sqldelight.SuspendingTransacterImpl
@@ -120,6 +122,8 @@ class AsyncQueriesTypeTest {
     Truth.assertThat(result.compilerOutput).containsKey(dataQueries)
     Truth.assertThat(result.compilerOutput[dataQueries].toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import app.cash.sqldelight.Query

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/async/AsyncQueriesTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/async/AsyncQueriesTypeTest.kt
@@ -52,7 +52,7 @@ class AsyncQueriesTypeTest {
     Truth.assertThat(result.compilerOutput).containsKey(database)
     Truth.assertThat(result.compilerOutput[database].toString()).isEqualTo(
       """
-      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example.testmodule
       |
@@ -122,7 +122,7 @@ class AsyncQueriesTypeTest {
     Truth.assertThat(result.compilerOutput).containsKey(dataQueries)
     Truth.assertThat(result.compilerOutput[dataQueries].toString()).isEqualTo(
       """
-      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example
       |

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/async/AsyncQueryWrapperTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/async/AsyncQueryWrapperTest.kt
@@ -53,7 +53,9 @@ class AsyncQueryWrapperTest {
     Truth.assertThat(queryWrapperFile).isNotNull()
     Truth.assertThat(queryWrapperFile.toString()).isEqualTo(
       """
-        |package com.example.testmodule
+        |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
+      |package com.example.testmodule
         |
         |import app.cash.sqldelight.SuspendingTransacterImpl
         |import app.cash.sqldelight.db.AfterVersion

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/async/AsyncQueryWrapperTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/async/AsyncQueryWrapperTest.kt
@@ -53,7 +53,7 @@ class AsyncQueryWrapperTest {
     Truth.assertThat(queryWrapperFile).isNotNull()
     Truth.assertThat(queryWrapperFile.toString()).isEqualTo(
       """
-        |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+        |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example.testmodule
         |

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/async/AsyncQueryWrapperTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/async/AsyncQueryWrapperTest.kt
@@ -54,8 +54,8 @@ class AsyncQueryWrapperTest {
     Truth.assertThat(queryWrapperFile.toString()).isEqualTo(
       """
         |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
-      |
-      |package com.example.testmodule
+        |
+        |package com.example.testmodule
         |
         |import app.cash.sqldelight.SuspendingTransacterImpl
         |import app.cash.sqldelight.db.AfterVersion

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/InterfaceGeneration.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/InterfaceGeneration.kt
@@ -404,6 +404,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import kotlin.String
@@ -454,6 +456,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import kotlin.Long
@@ -495,6 +499,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import kotlin.String
@@ -532,6 +538,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import kotlin.Long
@@ -570,6 +578,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import kotlin.Long
@@ -608,6 +618,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import kotlin.Double
@@ -657,6 +669,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import java.util.List
@@ -708,6 +722,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import kotlin.Double
@@ -764,6 +780,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import kotlin.Long
@@ -821,6 +839,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import kotlin.Long
@@ -921,6 +941,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import app.cash.sqldelight.Query
@@ -1010,6 +1032,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import app.cash.sqldelight.Query
@@ -1117,6 +1141,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import kotlin.Long
@@ -1133,6 +1159,8 @@ class InterfaceGeneration {
     assertThat(generatedQueries).isNotNull()
     assertThat(generatedQueries.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import app.cash.sqldelight.Query
@@ -1229,6 +1257,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import kotlin.Long
@@ -1245,6 +1275,8 @@ class InterfaceGeneration {
     assertThat(generatedQueries).isNotNull()
     assertThat(generatedQueries.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import app.cash.sqldelight.Query
@@ -1334,6 +1366,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import app.cash.sqldelight.Query
@@ -1421,7 +1455,9 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
-    |package com.example
+    |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
+      |package com.example
     |
     |import app.cash.sqldelight.Query
     |import app.cash.sqldelight.TransacterImpl
@@ -1638,7 +1674,9 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
-    |package com.example
+    |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
+      |package com.example
     |
     |import app.cash.sqldelight.Query
     |import app.cash.sqldelight.TransacterImpl
@@ -1714,6 +1752,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import kotlin.Int

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/InterfaceGeneration.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/InterfaceGeneration.kt
@@ -884,6 +884,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import kotlin.Long

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/InterfaceGeneration.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/InterfaceGeneration.kt
@@ -404,7 +404,7 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
-      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example
       |
@@ -456,7 +456,7 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
-      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example
       |
@@ -499,7 +499,7 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
-      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example
       |
@@ -538,7 +538,7 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
-      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example
       |
@@ -578,7 +578,7 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
-      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example
       |
@@ -618,7 +618,7 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
-      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example
       |
@@ -669,7 +669,7 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
-      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example
       |
@@ -722,7 +722,7 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
-      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example
       |
@@ -780,7 +780,7 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
-      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example
       |
@@ -839,7 +839,7 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
-      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example
       |
@@ -983,7 +983,7 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
-      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example
       |
@@ -1074,7 +1074,7 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
-      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example
       |
@@ -1183,7 +1183,7 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
-      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example
       |
@@ -1201,7 +1201,7 @@ class InterfaceGeneration {
     assertThat(generatedQueries).isNotNull()
     assertThat(generatedQueries.toString()).isEqualTo(
       """
-      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example
       |
@@ -1299,7 +1299,7 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
-      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example
       |
@@ -1317,7 +1317,7 @@ class InterfaceGeneration {
     assertThat(generatedQueries).isNotNull()
     assertThat(generatedQueries.toString()).isEqualTo(
       """
-      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example
       |
@@ -1408,7 +1408,7 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
-      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example
       |
@@ -1497,7 +1497,7 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
-    |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+    |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example
     |
@@ -1716,7 +1716,7 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
-    |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+    |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example
     |
@@ -1794,7 +1794,7 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
-      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example
       |

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/InterfaceGeneration.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/InterfaceGeneration.kt
@@ -1498,8 +1498,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface.toString()).isEqualTo(
       """
     |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
-      |
-      |package com.example
+    |
+    |package com.example
     |
     |import app.cash.sqldelight.Query
     |import app.cash.sqldelight.TransacterImpl
@@ -1717,8 +1717,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface.toString()).isEqualTo(
       """
     |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
-      |
-      |package com.example
+    |
+    |package com.example
     |
     |import app.cash.sqldelight.Query
     |import app.cash.sqldelight.TransacterImpl

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/InterfaceGeneration.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/InterfaceGeneration.kt
@@ -404,6 +404,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import kotlin.String
@@ -454,6 +456,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import kotlin.Long
@@ -495,6 +499,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import kotlin.String
@@ -532,6 +538,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import kotlin.Long
@@ -570,6 +578,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import kotlin.Long
@@ -608,6 +618,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import kotlin.Double
@@ -657,6 +669,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import java.util.List
@@ -708,6 +722,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import kotlin.Double
@@ -764,6 +780,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import kotlin.Long
@@ -821,6 +839,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import kotlin.Long
@@ -963,6 +983,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import app.cash.sqldelight.Query
@@ -1052,6 +1074,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import app.cash.sqldelight.Query
@@ -1159,6 +1183,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import kotlin.Long
@@ -1175,6 +1201,8 @@ class InterfaceGeneration {
     assertThat(generatedQueries).isNotNull()
     assertThat(generatedQueries.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import app.cash.sqldelight.Query
@@ -1271,6 +1299,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import kotlin.Long
@@ -1287,6 +1317,8 @@ class InterfaceGeneration {
     assertThat(generatedQueries).isNotNull()
     assertThat(generatedQueries.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import app.cash.sqldelight.Query
@@ -1376,6 +1408,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import app.cash.sqldelight.Query
@@ -1463,7 +1497,9 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
-    |package com.example
+    |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
+      |package com.example
     |
     |import app.cash.sqldelight.Query
     |import app.cash.sqldelight.TransacterImpl
@@ -1680,7 +1716,9 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
-    |package com.example
+    |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
+      |package com.example
     |
     |import app.cash.sqldelight.Query
     |import app.cash.sqldelight.TransacterImpl
@@ -1756,6 +1794,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import kotlin.Int

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/tables/InterfaceGeneration.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/tables/InterfaceGeneration.kt
@@ -47,6 +47,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import app.cash.sqldelight.ColumnAdapter
@@ -93,6 +95,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import kotlin.String
@@ -372,6 +376,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import kotlin.Long
@@ -410,6 +416,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import kotlin.Int

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/tables/InterfaceGeneration.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/tables/InterfaceGeneration.kt
@@ -48,7 +48,7 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
-      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example
       |
@@ -96,7 +96,7 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
-      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example
       |
@@ -377,7 +377,7 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
-      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example
       |
@@ -417,7 +417,7 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
-      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example
       |

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/tables/InterfaceGeneration.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/tables/InterfaceGeneration.kt
@@ -48,6 +48,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import app.cash.sqldelight.ColumnAdapter
@@ -94,6 +96,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import kotlin.String
@@ -373,6 +377,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import kotlin.Long
@@ -411,6 +417,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import kotlin.Int

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/tables/OptimisticLockTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/tables/OptimisticLockTest.kt
@@ -52,6 +52,8 @@ class OptimisticLockTest {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import kotlin.Long

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/tables/OptimisticLockTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/tables/OptimisticLockTest.kt
@@ -73,6 +73,8 @@ class OptimisticLockTest {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import kotlin.Long

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/tables/OptimisticLockTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/tables/OptimisticLockTest.kt
@@ -73,7 +73,7 @@ class OptimisticLockTest {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
-      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example
       |

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/views/InterfaceGeneration.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/views/InterfaceGeneration.kt
@@ -47,6 +47,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import kotlin.Boolean
@@ -89,6 +91,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import kotlin.Boolean
@@ -129,6 +133,8 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
+      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
       |package com.example
       |
       |import kotlin.Long

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/views/InterfaceGeneration.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/views/InterfaceGeneration.kt
@@ -47,7 +47,7 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
-      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example
       |
@@ -91,7 +91,7 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
-      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example
       |
@@ -133,7 +133,7 @@ class InterfaceGeneration {
     assertThat(generatedInterface).isNotNull()
     assertThat(generatedInterface.toString()).isEqualTo(
       """
-      |@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
       |
       |package com.example
       |

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-add-constraint/output/com/example/DataQueries.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-add-constraint/output/com/example/DataQueries.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+
 package com.example
 
 import app.cash.sqldelight.Query

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-add-constraint/output/com/example/DataQueries.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-add-constraint/output/com/example/DataQueries.kt
@@ -1,4 +1,4 @@
-@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
 
 package com.example
 

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-add-constraint/output/com/example/TestCompound.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-add-constraint/output/com/example/TestCompound.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+
 package com.example
 
 import kotlin.Int

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-add-constraint/output/com/example/TestCompound.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-add-constraint/output/com/example/TestCompound.kt
@@ -1,4 +1,4 @@
-@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
 
 package com.example
 

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-add-constraint/output/com/example/TestSingle.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-add-constraint/output/com/example/TestSingle.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+
 package com.example
 
 import kotlin.Int

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-add-constraint/output/com/example/TestSingle.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-add-constraint/output/com/example/TestSingle.kt
@@ -1,4 +1,4 @@
-@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
 
 package com.example
 

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-alter-column/output/com/example/DataQueries.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-alter-column/output/com/example/DataQueries.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+
 package com.example
 
 import app.cash.sqldelight.ExecutableQuery

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-alter-column/output/com/example/DataQueries.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-alter-column/output/com/example/DataQueries.kt
@@ -1,4 +1,4 @@
-@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
 
 package com.example
 

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-alter-column/output/com/example/Test3.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-alter-column/output/com/example/Test3.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+
 package com.example
 
 import kotlin.String

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-alter-column/output/com/example/Test3.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-alter-column/output/com/example/Test3.kt
@@ -1,4 +1,4 @@
-@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
 
 package com.example
 

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-rename-column-sqlite/output/com/example/DataQueries.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-rename-column-sqlite/output/com/example/DataQueries.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+
 package com.example
 
 import app.cash.sqldelight.Query

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-rename-column-sqlite/output/com/example/DataQueries.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-rename-column-sqlite/output/com/example/DataQueries.kt
@@ -1,4 +1,4 @@
-@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
 
 package com.example
 

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-rename-column-sqlite/output/com/example/Test.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-rename-column-sqlite/output/com/example/Test.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+
 package com.example
 
 import kotlin.String

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-rename-column-sqlite/output/com/example/Test.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-rename-column-sqlite/output/com/example/Test.kt
@@ -1,4 +1,4 @@
-@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
 
 package com.example
 

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-rename-column/output/com/example/DataQueries.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-rename-column/output/com/example/DataQueries.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+
 package com.example
 
 import app.cash.sqldelight.TransacterImpl

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-rename-column/output/com/example/DataQueries.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-rename-column/output/com/example/DataQueries.kt
@@ -1,4 +1,4 @@
-@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
 
 package com.example
 

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-rename-column/output/com/example/Test.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-rename-column/output/com/example/Test.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+
 package com.example
 
 import app.cash.sqldelight.ColumnAdapter

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-rename-column/output/com/example/Test.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-rename-column/output/com/example/Test.kt
@@ -1,4 +1,4 @@
-@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
 
 package com.example
 

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table/output/com/example/DataQueries.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table/output/com/example/DataQueries.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+
 package com.example
 
 import app.cash.sqldelight.Query

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table/output/com/example/DataQueries.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table/output/com/example/DataQueries.kt
@@ -1,4 +1,4 @@
-@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
 
 package com.example
 

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table/output/com/example/New_test.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table/output/com/example/New_test.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+
 package com.example
 
 import app.cash.sqldelight.ColumnAdapter

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table/output/com/example/New_test.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table/output/com/example/New_test.kt
@@ -1,4 +1,4 @@
-@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
 
 package com.example
 

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/create-or-replace-view/output/com/example/DataQueries.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/create-or-replace-view/output/com/example/DataQueries.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+
 package com.example.queries
 
 import app.cash.sqldelight.Query

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/create-or-replace-view/output/com/example/DataQueries.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/create-or-replace-view/output/com/example/DataQueries.kt
@@ -1,4 +1,4 @@
-@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
 
 package com.example.queries
 

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/create-or-replace-view/output/com/example/migrations/Test.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/create-or-replace-view/output/com/example/migrations/Test.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+
 package com.example.migrations
 
 import java.math.BigDecimal

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/create-or-replace-view/output/com/example/migrations/Test.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/create-or-replace-view/output/com/example/migrations/Test.kt
@@ -1,4 +1,4 @@
-@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
 
 package com.example.migrations
 

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/create-or-replace-view/output/com/example/migrations/V_test.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/create-or-replace-view/output/com/example/migrations/V_test.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+
 package com.example.migrations
 
 import java.math.BigDecimal

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/create-or-replace-view/output/com/example/migrations/V_test.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/create-or-replace-view/output/com/example/migrations/V_test.kt
@@ -1,4 +1,4 @@
-@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
 
 package com.example.migrations
 

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/create-or-replace-view/output/com/example/queries/DataQueries.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/create-or-replace-view/output/com/example/queries/DataQueries.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+
 package com.example.queries
 
 import app.cash.sqldelight.Query

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/create-or-replace-view/output/com/example/queries/DataQueries.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/create-or-replace-view/output/com/example/queries/DataQueries.kt
@@ -1,4 +1,4 @@
-@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
 
 package com.example.queries
 

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/varying-query-migration-packages/output/com/example/migrations/Test.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/varying-query-migration-packages/output/com/example/migrations/Test.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+
 package com.example.migrations
 
 import kotlin.Int

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/varying-query-migration-packages/output/com/example/migrations/Test.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/varying-query-migration-packages/output/com/example/migrations/Test.kt
@@ -1,4 +1,4 @@
-@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
 
 package com.example.migrations
 

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/varying-query-migration-packages/output/com/example/queries/DataQueries.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/varying-query-migration-packages/output/com/example/queries/DataQueries.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+
 package com.example.queries
 
 import app.cash.sqldelight.ExecutableQuery

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/varying-query-migration-packages/output/com/example/queries/DataQueries.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/varying-query-migration-packages/output/com/example/queries/DataQueries.kt
@@ -1,4 +1,4 @@
-@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
 
 package com.example.queries
 

--- a/sqldelight-compiler/src/test/query-interface-fixtures/prefer-kotlin-type/output/com/sample/PreferKotlinType.kt
+++ b/sqldelight-compiler/src/test/query-interface-fixtures/prefer-kotlin-type/output/com/sample/PreferKotlinType.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+
 package com.sample
 
 public data class PreferKotlinType(

--- a/sqldelight-compiler/src/test/query-interface-fixtures/prefer-kotlin-type/output/com/sample/PreferKotlinType.kt
+++ b/sqldelight-compiler/src/test/query-interface-fixtures/prefer-kotlin-type/output/com/sample/PreferKotlinType.kt
@@ -1,4 +1,4 @@
-@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
 
 package com.sample
 

--- a/sqldelight-compiler/src/test/query-interface-fixtures/query-requires-type/output/com/sample/JoinedWithUsing.kt
+++ b/sqldelight-compiler/src/test/query-interface-fixtures/query-requires-type/output/com/sample/JoinedWithUsing.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+
 package com.sample
 
 import kotlin.Boolean

--- a/sqldelight-compiler/src/test/query-interface-fixtures/query-requires-type/output/com/sample/JoinedWithUsing.kt
+++ b/sqldelight-compiler/src/test/query-interface-fixtures/query-requires-type/output/com/sample/JoinedWithUsing.kt
@@ -1,4 +1,4 @@
-@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
 
 package com.sample
 

--- a/sqldelight-compiler/src/test/table-interface-fixtures/requires-adapter/output/com/sample/Person.kt
+++ b/sqldelight-compiler/src/test/table-interface-fixtures/requires-adapter/output/com/sample/Person.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+
 package com.sample
 
 import app.cash.sqldelight.ColumnAdapter

--- a/sqldelight-compiler/src/test/table-interface-fixtures/requires-adapter/output/com/sample/Person.kt
+++ b/sqldelight-compiler/src/test/table-interface-fixtures/requires-adapter/output/com/sample/Person.kt
@@ -1,4 +1,4 @@
-@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
 
 package com.sample
 

--- a/sqldelight-compiler/src/test/view-interface-fixtures/only-table-type/output/com/sample/Person.kt
+++ b/sqldelight-compiler/src/test/view-interface-fixtures/only-table-type/output/com/sample/Person.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+
 package com.sample
 
 import app.cash.sqldelight.ColumnAdapter

--- a/sqldelight-compiler/src/test/view-interface-fixtures/only-table-type/output/com/sample/Person.kt
+++ b/sqldelight-compiler/src/test/view-interface-fixtures/only-table-type/output/com/sample/Person.kt
@@ -1,4 +1,4 @@
-@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
 
 package com.sample
 

--- a/sqldelight-compiler/src/test/view-interface-fixtures/requires-adapter/output/com/sample/Person.kt
+++ b/sqldelight-compiler/src/test/view-interface-fixtures/requires-adapter/output/com/sample/Person.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+
 package com.sample
 
 import app.cash.sqldelight.ColumnAdapter

--- a/sqldelight-compiler/src/test/view-interface-fixtures/requires-adapter/output/com/sample/Person.kt
+++ b/sqldelight-compiler/src/test/view-interface-fixtures/requires-adapter/output/com/sample/Person.kt
@@ -1,4 +1,4 @@
-@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
 
 package com.sample
 

--- a/sqldelight-compiler/src/test/view-interface-fixtures/requires-adapter/output/com/sample/PersonAndFriends.kt
+++ b/sqldelight-compiler/src/test/view-interface-fixtures/requires-adapter/output/com/sample/PersonAndFriends.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+
 package com.sample
 
 import com.squareup.Redacted

--- a/sqldelight-compiler/src/test/view-interface-fixtures/requires-adapter/output/com/sample/PersonAndFriends.kt
+++ b/sqldelight-compiler/src/test/view-interface-fixtures/requires-adapter/output/com/sample/PersonAndFriends.kt
@@ -1,4 +1,4 @@
-@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
 
 package com.sample
 

--- a/sqldelight-compiler/src/test/view-interface-fixtures/requires-adapter/output/com/sample/PersonAndMaxFriends.kt
+++ b/sqldelight-compiler/src/test/view-interface-fixtures/requires-adapter/output/com/sample/PersonAndMaxFriends.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+
 package com.sample
 
 import com.squareup.Redacted

--- a/sqldelight-compiler/src/test/view-interface-fixtures/requires-adapter/output/com/sample/PersonAndMaxFriends.kt
+++ b/sqldelight-compiler/src/test/view-interface-fixtures/requires-adapter/output/com/sample/PersonAndMaxFriends.kt
@@ -1,4 +1,4 @@
-@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
 
 package com.sample
 

--- a/sqldelight-compiler/src/test/view-interface-fixtures/requires-adapter/output/com/sample/PersonCool.kt
+++ b/sqldelight-compiler/src/test/view-interface-fixtures/requires-adapter/output/com/sample/PersonCool.kt
@@ -1,3 +1,5 @@
+@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+
 package com.sample
 
 import com.squareup.Redacted

--- a/sqldelight-compiler/src/test/view-interface-fixtures/requires-adapter/output/com/sample/PersonCool.kt
+++ b/sqldelight-compiler/src/test/view-interface-fixtures/requires-adapter/output/com/sample/PersonCool.kt
@@ -1,4 +1,4 @@
-@file:Suppress("RedundantVisibilityModifier", "ASSIGNED_VALUE_IS_NEVER_READ")
+@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
 
 package com.sample
 


### PR DESCRIPTION
Fixes #6029

Kotlin 2.1+ flags `RedundantVisibilityModifier` and `ASSIGNED_VALUE_IS_NEVER_READ` in SQLDelight's generated files when `extraWarnings` and `allWarningsAsErrors` are both on.
The fix prepends `@file:Suppress` to all generated files.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.