### PR TITLE
Fix SqlDelightDatabase circular dependency error 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [PostgreSQL Dialect] Fixed IDE integration of the PostgreSQL dialect
 - [PostgreSQL Dialect] Improve IDE plugin for PostgreSQL dialect (#6209 by @griffio)
 - [Intellij Plugin] IDE plugin can perform code completions for all dialects (#6210 by @griffio)
+- [Gradle Plugin] Fix circular dependency error running verify database task (#6221 by @griffio)
 
 ## [2.3.2] - 2026-03-16
 [2.3.2]: https://github.com/sqldelight/sqldelight/releases/tag/2.3.2

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightDatabase.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightDatabase.kt
@@ -154,6 +154,10 @@ abstract class SqlDelightDatabase @Inject constructor(
     return project.provider { sourceCollector.sourceKeys() }
   }
 
+  internal fun sourceFoldersFor(sourceKey: Source.Key): Provider<Set<SqlDelightSourceFolderImpl>> {
+    return sourceCollector.sourceFoldersFor(sourceKey)
+  }
+
   internal fun registerTasks() {
     configureOnSources { source ->
       val allFiles = sourceCollector.sourceFolders(source)
@@ -337,6 +341,13 @@ abstract class SqlDelightDatabase @Inject constructor(
       return folderProvider
     }
 
+    fun sourceFoldersFor(sourceKey: Source.Key): Provider<Set<SqlDelightSourceFolderImpl>> {
+      return project.provider {
+        compilationUnits[sourceKey]?.get()?.sourceFolders
+          ?: emptySet()
+      }
+    }
+
     private fun provideSourceFolders(source: Source): Provider<Set<SqlDelightSourceFolderImpl>> {
       val sourceFolders = source.sourceDirectories.map { dirs ->
         val declaredSet = srcDirs.mapTo(mutableSetOf()) { dir ->
@@ -354,10 +365,10 @@ abstract class SqlDelightDatabase @Inject constructor(
         dependencies.flatMap { dependency ->
           val dependencySourceKey = source.closestMatch(dependency.sourceKeys().get())
             ?: return@flatMap emptyList<SqlDelightSourceFolderImpl>()
-          val compilationUnit = dependency.getProperties().get().compilationUnits
-            .single { it.name == dependencySourceKey.name }
 
-          return@flatMap compilationUnit.sourceFolders.map {
+          val dependencyFolders = dependency.sourceFoldersFor(dependencySourceKey).get()
+
+          return@flatMap dependencyFolders.map {
             SqlDelightSourceFolderImpl(
               folder = File(project.projectDir, project.relativePath(it.folder.absolutePath)),
               dependency = true,


### PR DESCRIPTION
fixes #6197 

Creating the smallest change possible.

Attempt to remove recursion error trap that is induced with large graph of dependencies or parallelism.

Replace eager `dependency.getProperties()` with lazy `project.provider`.

Locally tested  `gradle clean verifyAllDatabaseMigration --parallel` to check that build does not fail anymore.

We can try this as a snapshot and test https://github.com/sqldelight/sqldelight/issues/6197#issuecomment-4292335681,  ♻️ revert if not successful

NOTE:

This does not fix gradle isolation issues.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
