### PR TITLE
Allow optimistic lock bypass for multirow update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [PostgreSQL Dialect] Improve IDE plugin for PostgreSQL dialect (#6209 by @griffio)
 - [Intellij Plugin] IDE plugin can perform code completions for all dialects (#6210 by @griffio)
 - [Gradle Plugin] Fix circular dependency error running verify database task (#6221 by @griffio)
+- [Compiler] Fix optimistic lock for multirow update (#6240 by @griffio)
 
 ## [2.3.2] - 2026-03-16
 [2.3.2]: https://github.com/sqldelight/sqldelight/releases/tag/2.3.2

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/validation/OptimisticLockValidator.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/validation/OptimisticLockValidator.kt
@@ -76,14 +76,17 @@ open class OptimisticLockValidator : Annotator {
       return
     }
 
-    // Confirm the statement has SET lock = :arg + 1
-    if (!(
-        setter.expr is SqlBinaryAddExpr &&
-          setter.expr.node.getChildren(null).any { it.text == "+" } &&
-          (setter.expr as SqlBinaryExpr).getExprList()[0] is SqlBindExpr &&
-          (setter.expr as SqlBinaryExpr).getExprList()[1].textMatches("1")
-        )
-    ) {
+    val setterExpressions = (setter.expr as? SqlBinaryExpr)?.getExprList()
+    val selfIncrementsByOne = setter.expr is SqlBinaryAddExpr &&
+      setter.expr.node.getChildren(null).any { it.text == "+" } &&
+      setterExpressions?.getOrNull(1)?.textMatches("1") ?: false
+    val bindIncrement = selfIncrementsByOne &&
+      setterExpressions.getOrNull(0) is SqlBindExpr
+    val selfIncrements = selfIncrementsByOne &&
+      (setterExpressions.getOrNull(0) as? SqlColumnExpr)?.columnName?.textMatches(lock.columnName.name) ?: false
+
+    // Confirm the statement has SET lock = :arg + 1 or SET lock = lock + 1
+    if (!bindIncrement && !selfIncrements) {
       displayError(
         element,
         lock,
@@ -95,6 +98,8 @@ open class OptimisticLockValidator : Annotator {
       )
       return
     }
+
+    if (selfIncrements) return // Don't need to check the WHERE clause.
 
     val whereExpression = when (element) {
       is SqlUpdateStmt -> element.expr

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/tables/OptimisticLockTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/tables/OptimisticLockTest.kt
@@ -36,6 +36,27 @@ class OptimisticLockTest {
     )
   }
 
+  @Test fun `multi row updates with self increment are allowed`() {
+    val result = FixtureCompiler.compileSql(
+      """
+      |CREATE TABLE test (
+      |  id INTEGER AS VALUE NOT NULL,
+      |  version INTEGER AS LOCK NOT NULL,
+      |  text TEXT NOT NULL
+      |);
+      |
+      |updateText:
+      |UPDATE test
+      |SET text = :text
+      |, version = version + 1;
+      |
+      """.trimMargin(),
+      tempFolder,
+    )
+
+    assertThat(result.errors).isEmpty()
+  }
+
   @Test fun `optimistic lock generates a value type`() {
     val result = FixtureCompiler.compileSql(
       """

--- a/sqldelight-idea-plugin/src/test/kotlin/app/cash/sqldelight/intellij/annotations/OptimisticLockAnnotatorTest.kt
+++ b/sqldelight-idea-plugin/src/test/kotlin/app/cash/sqldelight/intellij/annotations/OptimisticLockAnnotatorTest.kt
@@ -352,4 +352,26 @@ class OptimisticLockAnnotatorTest : SqlDelightProjectTestCase() {
 
     myFixture.checkHighlighting()
   }
+
+  fun testMultiRowUpdateIsAllowed() {
+    myFixture.configureByText(
+      SqlDelightFileType,
+      """
+        |CREATE TABLE test(
+        |  id TEXT AS VALUE NOT NULL,
+        |  version INTEGER AS LOCK NOT NULL,
+        |  text TEXT NOT NULL
+        |);
+        |
+        |updateText:
+        |UPDATE test
+        |SET
+        |  text = :text,
+        |  version = version + 1
+        |;
+      """.trimMargin(),
+    )
+
+    myFixture.checkHighlighting()
+  }
 }


### PR DESCRIPTION
fixes #6233

Allow optimistic lock bypass for multirow updates as the only other escape hatch is `driver.execute` to run sql.

Where the developer is intentionally bypassing the single row lock and can deal with now invalid row versions.

* Modify the `OptimisticLockValidator` to check for `lock = lock +1`
* Add tests 
* Checked with local build of IDEA Plugin 

Note:

It is possible to self increment the lock field, accidentally missing the bind variable, in the setter will be allowed:

```sql
UPDATE test
SET text = :text, version = version + 1
WHERE version = :version AND id = :id;
```
---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
