### PR TITLE
Replace deprecated projectStructureUtil in IDEA plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [Intellij Plugin] IDE plugin can perform code completions for all dialects (#6210 by @griffio)
 - [Gradle Plugin] Fix circular dependency error running verify database task (#6221 by @griffio)
 - [Compiler] Fix optimistic lock for multirow update (#6240 by @griffio)
+- [Intellij Plugin] Fix deprecations causing crash in IDEA 2026.2 (#6247 by @griffio)
 
 ## [2.3.2] - 2026-03-16
 [2.3.2]: https://github.com/sqldelight/sqldelight/releases/tag/2.3.2

--- a/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/ProjectService.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/ProjectService.kt
@@ -19,11 +19,9 @@ import app.cash.sqldelight.core.SqlDelightFileIndex
 import app.cash.sqldelight.core.SqlDelightProjectService
 import app.cash.sqldelight.core.compiler.SqlDelightCompiler
 import app.cash.sqldelight.core.lang.MIGRATION_EXTENSION
-import app.cash.sqldelight.core.lang.MigrationFileType
 import app.cash.sqldelight.core.lang.MigrationParserDefinition
 import app.cash.sqldelight.core.lang.SQLDELIGHT_EXTENSION
 import app.cash.sqldelight.core.lang.SqlDelightFile
-import app.cash.sqldelight.core.lang.SqlDelightFileType
 import app.cash.sqldelight.dialect.api.SqlDelightDialect
 import app.cash.sqldelight.dialect.api.TypeResolver
 import app.cash.sqldelight.intellij.gradle.FileIndexMap
@@ -39,6 +37,7 @@ import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.module.Module
+import com.intellij.openapi.module.ModuleUtilCore
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.vfs.VirtualFile
@@ -57,7 +56,6 @@ import java.io.PrintStream
 import java.nio.file.Path
 import java.nio.file.Paths
 import kotlin.reflect.jvm.jvmName
-import org.jetbrains.kotlin.idea.util.projectStructure.getModule
 import timber.log.Timber
 
 class ProjectService(val project: Project) :
@@ -121,7 +119,7 @@ class ProjectService(val project: Project) :
   }
 
   private fun VirtualFile.findConfiguredFileIndex(): SqlDelightFileIndex? {
-    val module = getModule(project) ?: return null
+    val module = ModuleUtilCore.findModuleForFile(this, project) ?: return null
     val fileIndex = SqlDelightFileIndex.getInstance(module)
     return fileIndex.takeIf { it.isConfigured }
   }

--- a/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/SqlDelightGotoDeclarationHandler.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/SqlDelightGotoDeclarationHandler.kt
@@ -27,6 +27,7 @@ import com.alecstrong.sql.psi.core.psi.SqlStmt
 import com.intellij.codeInsight.navigation.actions.GotoDeclarationHandler
 import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.module.ModuleUtilCore
 import com.intellij.openapi.progress.EmptyProgressIndicator
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.DumbService
@@ -42,7 +43,6 @@ import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.searches.ReferencesSearch
 import com.intellij.psi.util.childrenOfType
 import org.jetbrains.kotlin.idea.references.KtSimpleNameReference
-import org.jetbrains.kotlin.idea.util.projectStructure.getModule
 import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtParameter
@@ -69,7 +69,7 @@ class SqlDelightGotoDeclarationHandler : GotoDeclarationHandler {
     val function = targetData.function
     val elementFile = targetData.containingFile
 
-    val module = elementFile?.getModule(function.project) ?: return emptyArray()
+    val module = elementFile?.let { ModuleUtilCore.findModuleForFile(it, function.project) } ?: return emptyArray()
 
     // Only handle files under the generated sqlite directory.
     val fileIndex = SqlDelightFileIndex.getInstance(module)

--- a/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/actions/file/SqlDelightCreateFileAction.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/actions/file/SqlDelightCreateFileAction.kt
@@ -18,7 +18,6 @@ import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.editor.LogicalPosition
 import com.intellij.openapi.fileEditor.FileEditorManager
-import com.intellij.openapi.module.ModuleUtilCore
 import com.intellij.openapi.module.ModuleUtilCore.findModuleForFile
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
@@ -28,7 +27,6 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.util.IncorrectOperationException
 import java.util.Properties
-import org.jetbrains.kotlin.idea.util.findModule
 
 /**
  * Creates a new SqlDelight file/table/migration from a template (see [fileTemplates.internal])


### PR DESCRIPTION
fixes #6246 

Deprecated:
https://github.com/JetBrains/intellij-community/blob/master/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/util/projectStructureUtil.kt

Replace with `com.intellij.openapi.module.ModuleUtilCore` used by
https://github.com/JetBrains/intellij-community/blob/master/plugins/kotlin/idea/src/org/jetbrains/kotlin/idea/util/projectStructureUtil.kt#L64

* SqlDelightGotoDeclarationHandler.kt - getModule
* ProjectService.kt - getModule
* SqlDelightCreateFileAction.kt - removed file imports - had already been updated to use getModule

Checked in local plugin build for `IntelliJ IDEA 2026.2 EAP`

Note:
Remember to Invalidate Caches... when changing plugin

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
