### PR TITLE
Add PostgreSql Dialect ANY operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [SQLite Dialect] Add support for SQLite 3.37 STRICT table (#6230 by @griffio)
 - [Gradle Plugin] Add support for excluding columns from generated models with `codegenExcludedColumns` (#6243 by @sokolikp)
 - [Compiler] Add `allTableNames` function to schema (#6245 by @edenman)
+- [PostgreSQL Dialect] Add support for ANY operator (#6253 by @griffio)
 
 ### Changed
 - [PostgreSQL Dialect] Change arrayIntermediateType visibility to public (#5835 by @griffio)

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
@@ -18,11 +18,13 @@ import app.cash.sqldelight.dialects.postgresql.PostgreSqlType.SMALL_INT
 import app.cash.sqldelight.dialects.postgresql.PostgreSqlType.TIMESTAMP
 import app.cash.sqldelight.dialects.postgresql.PostgreSqlType.TIMESTAMP_TIMEZONE
 import app.cash.sqldelight.dialects.postgresql.grammar.mixins.AggregateExpressionMixin
+import app.cash.sqldelight.dialects.postgresql.grammar.mixins.AnyOperatorExprMixin
 import app.cash.sqldelight.dialects.postgresql.grammar.mixins.ArrayValueExpressionMixin
 import app.cash.sqldelight.dialects.postgresql.grammar.mixins.AtTimeZoneOperatorExpressionMixin
 import app.cash.sqldelight.dialects.postgresql.grammar.mixins.DoubleColonCastOperatorExpressionMixin
 import app.cash.sqldelight.dialects.postgresql.grammar.mixins.ExtractTemporalExpressionMixin
 import app.cash.sqldelight.dialects.postgresql.grammar.mixins.WindowFunctionMixin
+import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlAnyOperatorExpr
 import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlAtTimeZoneOperator
 import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlDeleteStmtLimited
 import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlDoubleColonCastOperatorExpression
@@ -310,6 +312,11 @@ open class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : Ty
       is PostgreSqlJsonExpression -> {
         IntermediateType(PostgreSqlType.JSON)
       }
+      is PostgreSqlAnyOperatorExpr -> {
+        // the column expr required to resolve the java type is not part of the ANY extension expression
+        val anyType = (parent.parent.parent.parent.firstChild as SqlExpr).postgreSqlType()
+        arrayIntermediateType(anyType) // The assumption is that any bind parameter is an array
+      }
       else -> {
         parentResolver.argumentType(parent, argument)
       }
@@ -424,6 +431,9 @@ open class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : Ty
         )
         arrayIntermediateType(elementType)
       }
+
+      anyOperatorExpr != null -> resolvedType((anyOperatorExpr as AnyOperatorExprMixin).expr)
+
       else -> parentResolver.resolvedType(this)
     }
 
@@ -481,6 +491,7 @@ open class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : Ty
     fun arrayIntermediateType(type: IntermediateType): IntermediateType {
       return IntermediateType(
         ArrayDialectType(type),
+        column = type.column,
       )
     }
 

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -515,6 +515,14 @@ select_stmt ::= SELECT ( distinct_on_expr | [ DISTINCT | ALL ] ) {result_column}
   pin = 1
 }
 
+any_operator ::= ( 'ANY' | 'SOME' )
+
+any_operator_expr ::= any_operator LP ( {compound_select_stmt} | {bind_expr} | <<expr '-1'>> ) RP {
+  mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.AnyOperatorExprMixin"
+  implements = "com.alecstrong.sql.psi.core.psi.SqlCompositeElement"
+  pin = 2
+}
+
 lateral ::= 'LATERAL'
 join_operator ::= ( COMMA [ lateral ]
                   | [ NATURAL ] [ ( {left_join_operator} | {right_join_operator} | {full_join_operator} ) [ OUTER ] | INNER | CROSS ] JOIN [ lateral ] ) {
@@ -583,7 +591,7 @@ compound_select_stmt ::= [ {with_clause} ] {select_stmt}  ( {compound_operator} 
   override = true
 }
 
-extension_expr ::= geometry_setsrid_function_stmt | geometry_point_function_stmt | json_object_agg_stmt | json_agg_stmt | plsql_trigger_var_expression | is_json_expression | overlaps_operator_expression | range_operator_expression | extract_temporal_expression | double_colon_cast_operator_expression | array_value_expression | contains_operator_expression | at_time_zone_operator_expression | regex_match_operator_expression | match_operator_expression | json_function_stmt | array_agg_stmt| string_agg_stmt | json_expression | exists_operator_expression | boolean_not_expression | window_function_expr {
+extension_expr ::= any_operator_expr | geometry_setsrid_function_stmt | geometry_point_function_stmt | json_object_agg_stmt | json_agg_stmt | plsql_trigger_var_expression | is_json_expression | overlaps_operator_expression | range_operator_expression | extract_temporal_expression | double_colon_cast_operator_expression | array_value_expression | contains_operator_expression | at_time_zone_operator_expression | regex_match_operator_expression | match_operator_expression | json_function_stmt | array_agg_stmt| string_agg_stmt | json_expression | exists_operator_expression | boolean_not_expression | window_function_expr {
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlExtensionExprImpl"
   implements = "com.alecstrong.sql.psi.core.psi.SqlExtensionExpr"
   override = true

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/AnyOperatorExprMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/AnyOperatorExprMixin.kt
@@ -1,0 +1,12 @@
+package app.cash.sqldelight.dialects.postgresql.grammar.mixins
+
+import com.alecstrong.sql.psi.core.psi.SqlCompositeElementImpl
+import com.alecstrong.sql.psi.core.psi.SqlExpr
+import com.intellij.lang.ASTNode
+
+internal abstract class AnyOperatorExprMixin(
+  node: ASTNode,
+) : SqlCompositeElementImpl(node),
+  SqlExpr {
+  val expr get() = children.filterIsInstance<SqlExpr>().first()
+}

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/any-operator/Test.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/any-operator/Test.s
@@ -1,0 +1,50 @@
+CREATE TABLE data (
+  id INTEGER NOT NULL,
+  txt TEXT NOT NULL
+);
+
+SELECT *
+FROM data
+WHERE data.id = ANY (?);
+
+SELECT *
+FROM data
+WHERE txt ILIKE ANY ('{"%bar", "%baz"}');
+
+CREATE TABLE employees (
+   id SERIAL PRIMARY KEY,
+   first_name VARCHAR(255) NOT NULL,
+   last_name VARCHAR(255) NOT NULL,
+   salary DECIMAL(10, 2) NOT NULL
+);
+
+CREATE TABLE managers(
+   id SERIAL PRIMARY KEY,
+   first_name VARCHAR(255) NOT NULL,
+   last_name VARCHAR(255) NOT NULL,
+   salary DECIMAL(10, 2) NOT NULL
+);
+
+SELECT
+  *
+FROM
+  employees
+WHERE
+  salary = ANY (
+    SELECT
+      salary
+    FROM
+      managers
+  );
+
+SELECT
+  *
+FROM
+  employees
+WHERE
+  salary > ANY (
+    SELECT
+      salary
+    FROM
+      managers
+  );

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/QueryGenerator.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/QueryGenerator.kt
@@ -15,7 +15,7 @@ import app.cash.sqldelight.core.lang.util.TableNameElement
 import app.cash.sqldelight.core.lang.util.childOfType
 import app.cash.sqldelight.core.lang.util.columnDefSource
 import app.cash.sqldelight.core.lang.util.findChildrenOfType
-import app.cash.sqldelight.core.lang.util.isArrayParameter
+import app.cash.sqldelight.core.lang.util.isSqlInExprArrayParameter
 import app.cash.sqldelight.core.lang.util.range
 import app.cash.sqldelight.core.lang.util.rawSqlText
 import app.cash.sqldelight.core.lang.util.sqFile
@@ -129,7 +129,7 @@ abstract class QueryGenerator(
     val extractedVariables = mutableMapOf<IntermediateType, String>()
     // extract the variable for duplicate types, so we don't encode twice
     for (type in duplicateTypes) {
-      if (type.bindArg?.isArrayParameter() == true) continue
+      if (type.bindArg?.isSqlInExprArrayParameter() == true) continue
       val encodedJavaType = type.encodedJavaType() ?: continue
       val variableName = argumentNameAllocator.newName(type.name)
       extractedVariables[type] = variableName
@@ -142,7 +142,7 @@ abstract class QueryGenerator(
     // For each argument in the sql
     orderedBindArgs.forEach { (_, argument, bindArg) ->
       val type = argument.type
-      if (bindArg?.isArrayParameter() == true) {
+      if (bindArg?.isSqlInExprArrayParameter() == true) {
         needsFreshStatement = true
 
         if (!handledArrayArgs.contains(argument) && seenArrayArguments.add(argument)) {

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/IntermediateType.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/IntermediateType.kt
@@ -18,7 +18,8 @@ package app.cash.sqldelight.core.lang
 import app.cash.sqldelight.core.compiler.integration.adapterName
 import app.cash.sqldelight.core.compiler.integration.adapterProperty
 import app.cash.sqldelight.core.lang.psi.ColumnTypeMixin
-import app.cash.sqldelight.core.lang.util.isArrayParameter
+import app.cash.sqldelight.core.lang.util.isAnyExprArrayParameter
+import app.cash.sqldelight.core.lang.util.isSqlInExprArrayParameter
 import app.cash.sqldelight.dialect.api.IntermediateType
 import com.alecstrong.sql.psi.core.psi.Queryable
 import com.intellij.psi.util.PsiTreeUtil
@@ -27,7 +28,7 @@ import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.asClassName
 
-internal fun IntermediateType.argumentType() = if (bindArg?.isArrayParameter() == true) {
+internal fun IntermediateType.argumentType() = if (bindArg?.isSqlInExprArrayParameter() == true) {
   Collection::class.asClassName().parameterizedBy(javaType)
 } else {
   javaType
@@ -42,7 +43,7 @@ internal fun IntermediateType.preparedStatementBinder(
   columnIndex: CodeBlock,
   extractedVariable: String? = null,
 ): CodeBlock {
-  val codeBlock = extractedVariable?.let { CodeBlock.of(it) } ?: encodedJavaType()
+  val codeBlock = extractedVariable?.let { CodeBlock.of(it) } ?: encodedJavaTypeForAnyExprArray() ?: encodedJavaType()
   if (codeBlock != null) {
     return dialectType.prepareStatementBinder(columnIndex, codeBlock)
   }
@@ -74,6 +75,17 @@ internal fun IntermediateType.encodedJavaType(): CodeBlock? {
     } else {
       value
     }
+  }
+}
+
+internal fun IntermediateType.encodedJavaTypeForAnyExprArray(): CodeBlock? {
+  if (!((bindArg?.isAnyExprArrayParameter()) ?: false)) return null
+
+  val name = this.name
+  return (column?.columnType as ColumnTypeMixin?)?.adapter()?.let { adapter ->
+    val parent = PsiTreeUtil.getParentOfType(column, Queryable::class.java)
+    val adapterName = parent!!.tableExposed().adapterName
+    CodeBlock.of("Array($name.size) { %N.%N.encode($name[it]) }", adapterName, adapter)
   }
 }
 

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/Arguments.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/Arguments.kt
@@ -60,8 +60,13 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.util.PsiTreeUtil
 import com.squareup.kotlinpoet.asClassName
 
-internal fun SqlBindExpr.isArrayParameter(): Boolean {
+internal fun SqlBindExpr.isSqlInExprArrayParameter(): Boolean {
   return (parent is SqlInExpr && this == parent.lastChild)
+}
+
+internal fun SqlBindExpr.isAnyExprArrayParameter(): Boolean {
+  val child = parent.firstChild
+  return ((child.textMatches("ANY") || child.textMatches("SOME")) && parent.children.last() == this)
 }
 
 internal fun SqlExpr.inferredType(): IntermediateType {

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/BindArgsTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/BindArgsTest.kt
@@ -1,10 +1,10 @@
 package app.cash.sqldelight.core
 
-import app.cash.sqldelight.core.lang.argumentType
 import app.cash.sqldelight.core.lang.types.typeResolver
 import app.cash.sqldelight.core.lang.util.argumentType
 import app.cash.sqldelight.core.lang.util.findChildrenOfType
-import app.cash.sqldelight.core.lang.util.isArrayParameter
+import app.cash.sqldelight.core.lang.util.isAnyExprArrayParameter
+import app.cash.sqldelight.core.lang.util.isSqlInExprArrayParameter
 import app.cash.sqldelight.dialect.api.PrimitiveType
 import app.cash.sqldelight.dialects.postgresql.PostgreSqlDialect
 import app.cash.sqldelight.dialects.sqlite_3_24.SqliteDialect
@@ -12,6 +12,8 @@ import app.cash.sqldelight.test.util.FixtureCompiler
 import com.alecstrong.sql.psi.core.psi.SqlBindExpr
 import com.alecstrong.sql.psi.core.psi.SqlColumnDef
 import com.google.common.truth.Truth.assertThat
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.asClassName
 import java.time.Instant
 import kotlin.test.assertFailsWith
@@ -284,7 +286,7 @@ class BindArgsTest {
       assertThat(it.javaType).isEqualTo(List::class.asClassName())
       assertThat(it.name).isEqualTo("id")
       assertThat(it.column).isSameInstanceAs(column)
-      assertThat(it.bindArg!!.isArrayParameter()).isTrue()
+      assertThat(it.bindArg!!.isSqlInExprArrayParameter()).isTrue()
     }
   }
 
@@ -561,4 +563,60 @@ class BindArgsTest {
   }
 
   private fun SqlBindExpr.argumentType() = typeResolver.argumentType(this)
+
+  @Test fun `bind args for postgresql ANY operator inherit column type`() {
+    val file = FixtureCompiler.parseSql(
+      """
+      |CREATE TABLE data (
+      |  id INTEGER NOT NULL,
+      |  txt TEXT NOT NULL
+      |);
+      |
+      |selectWithAny:
+      |SELECT *
+      |FROM data
+      |WHERE data.id = ANY (?);
+      """.trimMargin(),
+      tempFolder,
+      dialect = PostgreSqlDialect(),
+    )
+
+    val column = file.findChildrenOfType<SqlColumnDef>().first()
+    val bindArgType = file.findChildrenOfType<SqlBindExpr>().first().argumentType()
+    assertThat(bindArgType.bindArg!!.isAnyExprArrayParameter()).isTrue()
+    // The dialectType for ANY operator is ArrayDialectType, not the primitive type
+    assertThat(bindArgType.dialectType.javaType.toString()).isEqualTo("kotlin.Array<kotlin.Int>")
+    assertThat(bindArgType.javaType.toString()).isEqualTo("kotlin.Array<kotlin.Int>")
+    // For ANY operator, the argument name defaults to "value" because it's wrapped in parentheses
+    assertThat(bindArgType.name).isEqualTo("value")
+    assertThat(bindArgType.column).isSameInstanceAs(column)
+  }
+
+  @Test fun `bind args for postgresql ANY operator with custom adapter inherit type`() {
+    val file = FixtureCompiler.parseSql(
+      """
+      |CREATE TABLE data (
+      |  id INTEGER AS example.AnyId NOT NULL,
+      |  txt TEXT NOT NULL
+      |);
+      |
+      |selectWithAnyAdapter:
+      |SELECT *
+      |FROM data
+      |WHERE data.id = ANY (?);
+      """.trimMargin(),
+      tempFolder,
+      dialect = PostgreSqlDialect(),
+    )
+
+    val column = file.findChildrenOfType<SqlColumnDef>().first()
+    val bindArgType = file.findChildrenOfType<SqlBindExpr>().first().argumentType()
+    assertThat(bindArgType.bindArg!!.isAnyExprArrayParameter()).isTrue()
+    // The dialectType for ANY operator is ArrayDialectType, not the primitive type
+    assertThat(bindArgType.dialectType.javaType).isEqualTo(Array<Any>::class.asClassName().parameterizedBy(ClassName("example", "AnyId")))
+    assertThat(bindArgType.javaType).isEqualTo(Array<Any>::class.asClassName().parameterizedBy(ClassName("example", "AnyId")))
+    // For ANY operator, the argument name defaults to "value" because it's wrapped in parentheses
+    assertThat(bindArgType.name).isEqualTo("value")
+    assertThat(bindArgType.column).isSameInstanceAs(column)
+  }
 }

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/MutatorQueryTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/MutatorQueryTypeTest.kt
@@ -4,6 +4,7 @@ import app.cash.sqldelight.core.TestDialect
 import app.cash.sqldelight.core.compiler.ExecuteQueryGenerator
 import app.cash.sqldelight.core.compiler.MutatorQueryGenerator
 import app.cash.sqldelight.core.dialects.intType
+import app.cash.sqldelight.dialects.postgresql.PostgreSqlDialect
 import app.cash.sqldelight.test.util.FixtureCompiler
 import app.cash.sqldelight.test.util.withUnderscores
 import com.google.common.truth.Truth.assertThat
@@ -1020,6 +1021,56 @@ class MutatorQueryTypeTest {
       |  notifyQueries(${mutator.id.withUnderscores}) { emit ->
       |    emit("data")
       |  }
+      |}
+      |
+      """.trimMargin(),
+    )
+  }
+
+  @Test fun `delete using ANY operator with custom adapter uses encodedJavaTypeForAnyExprArray`() {
+    val file = FixtureCompiler.parseSql(
+      """
+      |import example.MyId;
+      |
+      |CREATE TABLE data (
+      |  id Integer AS MyId PRIMARY KEY,
+      |  name TEXT NOT NULL
+      |);
+      |
+      |deleteByIds:
+      |DELETE FROM data
+      |WHERE id = ANY (?);
+      """.trimMargin(),
+      tempFolder,
+      fileName = "Data.sq",
+      dialect = PostgreSqlDialect(),
+    )
+
+    val mutator = file.namedMutators.first()
+    val generator = MutatorQueryGenerator(mutator)
+
+    val functionStr = generator.function().toString()
+
+    assertThat(functionStr).contains("Array(value.size) { data_Adapter.idAdapter.encode(value[it]) }")
+
+    assertThat(functionStr).isEqualTo(
+      """
+      |/**
+      | * @return The number of rows updated.
+      | */
+      |public fun deleteByIds(`value`: kotlin.Array<example.MyId>): app.cash.sqldelight.db.QueryResult<kotlin.Long> {
+      |  val result = driver.execute(${mutator.id.withUnderscores}, ""${'"'}
+      |      |DELETE FROM data
+      |      |WHERE id = ANY (?)
+      |      ""${'"'}.trimMargin(), 1) {
+      |        check(this is app.cash.sqldelight.driver.jdbc.JdbcPreparedStatement)
+      |        var parameterIndex = 0
+      |        bindObject(parameterIndex++, Array(value.size) { data_Adapter.idAdapter.encode(value[it]) })
+      |      }
+      |  notifyQueries(${mutator.id.withUnderscores}) { emit ->
+      |    emit("data")
+      |  }
+      |  return result
       |}
       |
       """.trimMargin(),

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Any.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Any.sq
@@ -1,0 +1,19 @@
+CREATE TABLE AnySome (
+  id INTEGER NOT NULL,
+  other_id INTEGER AS kotlin.Long NOT NULL,
+  txt TEXT NOT NULL
+);
+
+INSERT INTO AnySome (id, other_id, txt) VALUES (1, 100, 'alpha');
+INSERT INTO AnySome (id, other_id,  txt) VALUES (2, 200, 'beta');
+INSERT INTO AnySome (id, other_id, txt) VALUES (3, 300, 'gamma');
+
+selectAny:
+SELECT id
+FROM AnySome
+WHERE id = ANY(?);
+
+selectSome:
+SELECT txt
+FROM AnySome
+WHERE txt ILIKE SOME(?);

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
@@ -1612,4 +1612,20 @@ class PostgreSqlTest {
       )
     }
   }
+
+  @Test
+  fun testAny() {
+    val ids = arrayOf(1, 2, 3)
+    database.anyQueries.selectAny(ids).executeAsList().let {
+      assertThat(it).containsExactly(1, 2, 3)
+    }
+  }
+
+  @Test
+  fun testSome() {
+    val txts = arrayOf("%alpha", "%beta", "%gamma")
+    database.anyQueries.selectSome(txts).executeAsList().let {
+      assertThat(it).containsExactly("alpha", "beta", "gamma")
+    }
+  }
 }


### PR DESCRIPTION
fixes #6175

PostgreSql dialect `ANY/SOME` operator - is supported in PostgreSQL, MySQL, Oracle, DB2, and SQL Server - returning true if the comparison test holds for at least one value. 

`ANY/SOME`: works with `>, <, >=, <=, <>, =, like, iLike` where as `IN` only performs equality check.

Additionally, PostgreSql adds efficient support for comparing a column value to an array of values.

Because a java type column adapter could exist, the array needs to encode each java type element to the column type. This is done with the code gen:
`CodeBlock.of("Array($name.size) { %N.%N.encode($name[it]) }", adapterName, adapter)`

``` sql
CREATE TABLE data (
   id Integer AS MyId PRIMARY KEY,
   name TEXT NOT NULL
);

SELECT *
FROM data
WHERE data.id = ANY (:myArray); <-- query bind arg is `Array<MyId>`
```

Although the array binding is a PostgreSql Dialect extension, accessing the internal adapter code-gen has to be added to QueryGenerator for `SqlBindExpr.isAnyExprArrayParameter()` and `IntermediateType.encodedJavaTypeForAnyExprArray()`

* Add support for ANY/SOME operator https://www.postgresql.org/docs/current/functions-comparisons.html#FUNCTIONS-COMPARISONS-ANY-SOME
* Add `SqlBindExpr.isAnyExprArrayParameter()` extension to determine `ANY/SOME` node bind arg 
  * This checks node matches text name, Ideally would be added to `sql-psi` grammar as a SqlTypeElement 
* Add `IntermediateType.encodedJavaTypeForAnyExprArray()` adapter to encode column array to adapter array
  * `bindObject(parameterIndex++, Array(ids.size) { data_Adapter.idAdapter.encode(ids[it]) })` 
 
Note:

The `ALL` operator which requires the comparison to hold for every value, is not implemented in this PR.  

Adds [PR in sql-psi](https://github.com/sqldelight/sql-psi/pull/760
) for `ANY/SOME/ALL` sql type, can be updated here later with:

``` kotlin
internal fun SqlBindExpr.isAnyExprArrayParameter(): Boolean {
  return parent.firstChild.elementType == SqlTypes.ANY_OPERATOR && parent.children.last() == this
}
```

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
