### PR TITLE
Change ANY array to collection

### DIFF
--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
@@ -2,6 +2,7 @@ package app.cash.sqldelight.dialects.postgresql
 
 import app.cash.sqldelight.dialect.api.DialectType
 import app.cash.sqldelight.dialect.api.IntermediateType
+import app.cash.sqldelight.dialect.api.PrimitiveType
 import app.cash.sqldelight.dialect.api.PrimitiveType.BLOB
 import app.cash.sqldelight.dialect.api.PrimitiveType.BOOLEAN
 import app.cash.sqldelight.dialect.api.PrimitiveType.REAL
@@ -52,6 +53,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.tree.TokenSet
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.asTypeName
 
 open class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : TypeResolver by parentResolver {
@@ -313,9 +315,8 @@ open class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : Ty
         IntermediateType(PostgreSqlType.JSON)
       }
       is PostgreSqlAnyOperatorExpr -> {
-        // the column expr required to resolve the java type is not part of the ANY extension expression
         val anyType = (parent.parent.parent.parent.firstChild as SqlExpr).postgreSqlType()
-        arrayIntermediateType(anyType) // The assumption is that any bind parameter is an array
+        IntermediateType(CollectionDialectType(anyType), column = anyType.column)
       }
       else -> {
         parentResolver.argumentType(parent, argument)
@@ -502,6 +503,13 @@ open class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : Ty
     // ArrayDialectType stores the original IntermediateType as parameterizedType so that the type can be returned by unnested
     private class ArrayDialectType(val parameterizedType: IntermediateType) : DialectType {
       override val javaType = Array::class.asTypeName().parameterizedBy(parameterizedType.javaType)
+      override fun prepareStatementBinder(columnIndex: CodeBlock, value: CodeBlock) = CodeBlock.of("bindObject(%L, %L)\n", columnIndex, value)
+      override fun cursorGetter(columnIndex: Int, cursorName: String) = CodeBlock.of("$cursorName.getArray<%T>($columnIndex)", parameterizedType.javaType)
+    }
+
+    // CollectionDialectType is used for ANY/ALL bind args where a Collection<T> is preferred over Array<T> - cursorGetter is not used
+    private class CollectionDialectType(val parameterizedType: IntermediateType) : DialectType {
+      override val javaType = Collection::class.asTypeName().parameterizedBy(parameterizedType.javaType)
       override fun prepareStatementBinder(columnIndex: CodeBlock, value: CodeBlock) = CodeBlock.of("bindObject(%L, %L)\n", columnIndex, value)
       override fun cursorGetter(columnIndex: Int, cursorName: String) = CodeBlock.of("$cursorName.getArray<%T>($columnIndex)", parameterizedType.javaType)
     }

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -517,7 +517,7 @@ select_stmt ::= SELECT ( distinct_on_expr | [ DISTINCT | ALL ] ) {result_column}
 
 any_operator ::= ( 'ANY' | 'SOME' )
 
-any_operator_expr ::= any_operator LP ( {compound_select_stmt} | {bind_expr} | <<expr '-1'>> ) RP {
+any_operator_expr ::= any_operator LP ( {compound_select_stmt} | <<expr '-1'>> ) RP {
   mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.AnyOperatorExprMixin"
   implements = "com.alecstrong.sql.psi.core.psi.SqlCompositeElement"
   pin = 2

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/IntermediateType.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/IntermediateType.kt
@@ -85,7 +85,14 @@ internal fun IntermediateType.encodedJavaTypeForAnyExprArray(): CodeBlock? {
   return (column?.columnType as ColumnTypeMixin?)?.adapter()?.let { adapter ->
     val parent = PsiTreeUtil.getParentOfType(column, Queryable::class.java)
     val adapterName = parent!!.tableExposed().adapterName
-    CodeBlock.of("$name.map { %N.%N.encode(it) }.toTypedArray()", adapterName, adapter)
+    CodeBlock.builder()
+      .beginControlFlow("run")
+      .add("val iter0 = %N.iterator()", name)
+      .add("\n")
+      .add("Array(%N.size) { %N.%N.encode(iter0.next()) }", name, adapterName, adapter)
+      .add("\n")
+      .endControlFlow()
+      .build()
   } ?: CodeBlock.of("$name.toTypedArray()")
 }
 

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/IntermediateType.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/IntermediateType.kt
@@ -85,13 +85,16 @@ internal fun IntermediateType.encodedJavaTypeForAnyExprArray(): CodeBlock? {
   return (column?.columnType as ColumnTypeMixin?)?.adapter()?.let { adapter ->
     val parent = PsiTreeUtil.getParentOfType(column, Queryable::class.java)
     val adapterName = parent!!.tableExposed().adapterName
+
     CodeBlock.builder()
-      .beginControlFlow("run")
+      .add("run {\n")
+      .indent()
       .add("val iter0 = %N.iterator()", name)
       .add("\n")
       .add("Array(%N.size) { %N.%N.encode(iter0.next()) }", name, adapterName, adapter)
       .add("\n")
-      .endControlFlow()
+      .unindent()
+      .add("}")
       .build()
   } ?: CodeBlock.of("$name.toTypedArray()")
 }

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/IntermediateType.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/IntermediateType.kt
@@ -85,8 +85,8 @@ internal fun IntermediateType.encodedJavaTypeForAnyExprArray(): CodeBlock? {
   return (column?.columnType as ColumnTypeMixin?)?.adapter()?.let { adapter ->
     val parent = PsiTreeUtil.getParentOfType(column, Queryable::class.java)
     val adapterName = parent!!.tableExposed().adapterName
-    CodeBlock.of("Array($name.size) { %N.%N.encode($name[it]) }", adapterName, adapter)
-  }
+    CodeBlock.of("$name.map { %N.%N.encode(it) }.toTypedArray()", adapterName, adapter)
+  } ?: CodeBlock.of("$name.toTypedArray()")
 }
 
 private fun CodeBlock.wrapInLet(type: IntermediateType): CodeBlock {

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/BindArgsTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/BindArgsTest.kt
@@ -584,9 +584,9 @@ class BindArgsTest {
     val column = file.findChildrenOfType<SqlColumnDef>().first()
     val bindArgType = file.findChildrenOfType<SqlBindExpr>().first().argumentType()
     assertThat(bindArgType.bindArg!!.isAnyExprArrayParameter()).isTrue()
-    // The dialectType for ANY operator is ArrayDialectType, not the primitive type
-    assertThat(bindArgType.dialectType.javaType.toString()).isEqualTo("kotlin.Array<kotlin.Int>")
-    assertThat(bindArgType.javaType.toString()).isEqualTo("kotlin.Array<kotlin.Int>")
+    // The dialectType for ANY operator is CollectionDialectType, not the primitive type
+    assertThat(bindArgType.dialectType.javaType.toString()).isEqualTo("kotlin.collections.Collection<kotlin.Int>")
+    assertThat(bindArgType.javaType.toString()).isEqualTo("kotlin.collections.Collection<kotlin.Int>")
     // For ANY operator, the argument name defaults to "value" because it's wrapped in parentheses
     assertThat(bindArgType.name).isEqualTo("value")
     assertThat(bindArgType.column).isSameInstanceAs(column)
@@ -612,9 +612,9 @@ class BindArgsTest {
     val column = file.findChildrenOfType<SqlColumnDef>().first()
     val bindArgType = file.findChildrenOfType<SqlBindExpr>().first().argumentType()
     assertThat(bindArgType.bindArg!!.isAnyExprArrayParameter()).isTrue()
-    // The dialectType for ANY operator is ArrayDialectType, not the primitive type
-    assertThat(bindArgType.dialectType.javaType).isEqualTo(Array<Any>::class.asClassName().parameterizedBy(ClassName("example", "AnyId")))
-    assertThat(bindArgType.javaType).isEqualTo(Array<Any>::class.asClassName().parameterizedBy(ClassName("example", "AnyId")))
+    // The dialectType for ANY operator is CollectionDialectType, not the primitive type
+    assertThat(bindArgType.dialectType.javaType).isEqualTo(Collection::class.asClassName().parameterizedBy(ClassName("example", "AnyId")))
+    assertThat(bindArgType.javaType).isEqualTo(Collection::class.asClassName().parameterizedBy(ClassName("example", "AnyId")))
     // For ANY operator, the argument name defaults to "value" because it's wrapped in parentheses
     assertThat(bindArgType.name).isEqualTo("value")
     assertThat(bindArgType.column).isSameInstanceAs(column)

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/MutatorQueryTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/MutatorQueryTypeTest.kt
@@ -1066,8 +1066,7 @@ class MutatorQueryTypeTest {
       |        bindObject(parameterIndex++, run {
       |          val iter0 = `value`.iterator()
       |          Array(`value`.size) { data_Adapter.idAdapter.encode(iter0.next()) }
-      |        }
-      |        )
+      |        })
       |      }
       |  notifyQueries(${mutator.id.withUnderscores}) { emit ->
       |    emit("data")

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/MutatorQueryTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/MutatorQueryTypeTest.kt
@@ -1051,8 +1051,6 @@ class MutatorQueryTypeTest {
 
     val functionStr = generator.function().toString()
 
-    assertThat(functionStr).contains("value.map { data_Adapter.idAdapter.encode(it) }.toTypedArray()")
-
     assertThat(functionStr).isEqualTo(
       """
       |/**
@@ -1065,7 +1063,11 @@ class MutatorQueryTypeTest {
       |      ""${'"'}.trimMargin(), 1) {
       |        check(this is app.cash.sqldelight.driver.jdbc.JdbcPreparedStatement)
       |        var parameterIndex = 0
-      |        bindObject(parameterIndex++, value.map { data_Adapter.idAdapter.encode(it) }.toTypedArray())
+      |        bindObject(parameterIndex++, run {
+      |          val iter0 = `value`.iterator()
+      |          Array(`value`.size) { data_Adapter.idAdapter.encode(iter0.next()) }
+      |        }
+      |        )
       |      }
       |  notifyQueries(${mutator.id.withUnderscores}) { emit ->
       |    emit("data")

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/MutatorQueryTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/MutatorQueryTypeTest.kt
@@ -1051,21 +1051,69 @@ class MutatorQueryTypeTest {
 
     val functionStr = generator.function().toString()
 
-    assertThat(functionStr).contains("Array(value.size) { data_Adapter.idAdapter.encode(value[it]) }")
+    assertThat(functionStr).contains("value.map { data_Adapter.idAdapter.encode(it) }.toTypedArray()")
 
     assertThat(functionStr).isEqualTo(
       """
       |/**
       | * @return The number of rows updated.
       | */
-      |public fun deleteByIds(`value`: kotlin.Array<example.MyId>): app.cash.sqldelight.db.QueryResult<kotlin.Long> {
+      |public fun deleteByIds(`value`: kotlin.collections.Collection<example.MyId>): app.cash.sqldelight.db.QueryResult<kotlin.Long> {
       |  val result = driver.execute(${mutator.id.withUnderscores}, ""${'"'}
       |      |DELETE FROM data
       |      |WHERE id = ANY (?)
       |      ""${'"'}.trimMargin(), 1) {
       |        check(this is app.cash.sqldelight.driver.jdbc.JdbcPreparedStatement)
       |        var parameterIndex = 0
-      |        bindObject(parameterIndex++, Array(value.size) { data_Adapter.idAdapter.encode(value[it]) })
+      |        bindObject(parameterIndex++, value.map { data_Adapter.idAdapter.encode(it) }.toTypedArray())
+      |      }
+      |  notifyQueries(${mutator.id.withUnderscores}) { emit ->
+      |    emit("data")
+      |  }
+      |  return result
+      |}
+      |
+      """.trimMargin(),
+    )
+  }
+
+  @Test fun `delete using ANY operator with no adapter uses encodedJavaTypeForAnyExprArray`() {
+    val file = FixtureCompiler.parseSql(
+      """
+      |CREATE TABLE data (
+      |  id Integer PRIMARY KEY,
+      |  name TEXT NOT NULL
+      |);
+      |
+      |deleteByIds:
+      |DELETE FROM data
+      |WHERE id = ANY (?);
+      """.trimMargin(),
+      tempFolder,
+      fileName = "Data.sq",
+      dialect = PostgreSqlDialect(),
+    )
+
+    val mutator = file.namedMutators.first()
+    val generator = MutatorQueryGenerator(mutator)
+
+    val functionStr = generator.function().toString()
+
+    assertThat(functionStr).contains("value.toTypedArray()")
+
+    assertThat(functionStr).isEqualTo(
+      """
+      |/**
+      | * @return The number of rows updated.
+      | */
+      |public fun deleteByIds(`value`: kotlin.collections.Collection<kotlin.Int>): app.cash.sqldelight.db.QueryResult<kotlin.Long> {
+      |  val result = driver.execute(${mutator.id.withUnderscores}, ""${'"'}
+      |      |DELETE FROM data
+      |      |WHERE id = ANY (?)
+      |      ""${'"'}.trimMargin(), 1) {
+      |        check(this is app.cash.sqldelight.driver.jdbc.JdbcPreparedStatement)
+      |        var parameterIndex = 0
+      |        bindObject(parameterIndex++, value.toTypedArray())
       |      }
       |  notifyQueries(${mutator.id.withUnderscores}) { emit ->
       |    emit("data")

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
@@ -1615,7 +1615,7 @@ class PostgreSqlTest {
 
   @Test
   fun testAny() {
-    val ids = arrayOf(1, 2, 3)
+    val ids = listOf(1, 2, 3)
     database.anyQueries.selectAny(ids).executeAsList().let {
       assertThat(it).containsExactly(1, 2, 3)
     }
@@ -1623,7 +1623,7 @@ class PostgreSqlTest {
 
   @Test
   fun testSome() {
-    val txts = arrayOf("%alpha", "%beta", "%gamma")
+    val txts = listOf("%alpha", "%beta", "%gamma")
     database.anyQueries.selectSome(txts).executeAsList().let {
       assertThat(it).containsExactly("alpha", "beta", "gamma")
     }


### PR DESCRIPTION
Following up from https://github.com/sqldelight/sqldelight/pull/6253

I have looked into using `Collection` as the binding type for `ANY(?)`, instead of `Array`, as this is much nicer for consumers to use and likely will have the data for the bind parameter in a List, Set already.

The only down side with using `Collection` is that for adapter types `value.map` will create an intermediate List, and in all cases `toTypedArray()` is used.

Supporting `ANY ?` to handle `Collection` use is much more work at the moment, so just use `Collection<T>` as the preferred type.

Column type will use `bindObject(parameterIndex++, value.toTypedArray())`
Adapter types will use `bindObject(parameterIndex++, value.map { data_Adapter.idAdapter.encode(it) }.toTypedArray())`

* adds extra test for codeblock

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
