### PR TITLE
Fix generated sources wiring on AGP 8.9 through 8.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - [Gradle Plugin] Fix circular dependency error running verify database task (#6221 by @griffio)
 - [Compiler] Fix optimistic lock for multirow update (#6240 by @griffio)
 - [Intellij Plugin] Fix deprecations causing crash in IDEA 2026.2 (#6247 by @griffio)
+- [Gradle Plugin] Fix generated sources not being picked up by Kotlin compilation on AGP 8.9 through 8.11
 
 ## [2.3.2] - 2026-03-16
 [2.3.2]: https://github.com/sqldelight/sqldelight/releases/tag/2.3.2

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/kotlin/SourceRoots.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/kotlin/SourceRoots.kt
@@ -49,7 +49,7 @@ internal fun SqlDelightDatabase.configureOnSources(action: (Source) -> Unit) {
   }
 
   project.extensions.findByName("androidComponents")?.let {
-    (it as AndroidComponentsExtension<*, *, *>).onSources(action)
+    (it as AndroidComponentsExtension<*, *, *>).onSources(project, action)
     return
   }
 
@@ -99,7 +99,7 @@ private fun KotlinMultiplatformExtension.sources(): List<Source> {
   )
 }
 
-private fun AndroidComponentsExtension<*, *, *>.onSources(action: (Source) -> Unit) {
+private fun AndroidComponentsExtension<*, *, *>.onSources(project: Project, action: (Source) -> Unit) {
   registerSourceType("sqldelight")
 
   onVariants { variant ->
@@ -109,13 +109,26 @@ private fun AndroidComponentsExtension<*, *, *>.onSources(action: (Source) -> Un
       variantName = variant.name,
       sourceDirectories = variant.sources.getByName("sqldelight").all,
       registerSourceGeneration = { task ->
-        if (pluginVersion < AndroidPluginVersion(9, 0)) {
-          // AGP versions before 9.0 wouldn't pick up the task dependency correctly when using the kotlin sources here,
-          // so we use the java ones instead
-          // https://issuetracker.google.com/issues/446220448
-          variant.sources.java?.addGeneratedSourceDirectory(task, SqlDelightTask::outputDirectory)
-        } else {
-          variant.sources.kotlin?.addGeneratedSourceDirectory(task, SqlDelightTask::outputDirectory)
+        when {
+          pluginVersion < AndroidPluginVersion(8, 12, 0) -> {
+            // AGP 8.9-8.11 addGeneratedSourceDirectory overwrites the task's
+            // @OutputDirectory (DirectoryProperty.set vs .convention), so AGP registers
+            // an empty path as the variant source. Fixed in AGP 8.12.0. Bypass AGP and
+            // wire directly into KGP's variant source set.
+            val kotlinSourceSets =
+              project.extensions.getByType(KotlinProjectExtension::class.java).sourceSets
+            kotlinSourceSets.named(variant.name) { it.kotlin.srcDir(task) }
+          }
+          pluginVersion < AndroidPluginVersion(9, 0) -> {
+            // kotlin-android on AGP 8.x only wires AndroidSourceSet.java into Kotlin
+            // compilation; variant.sources.kotlin registrations are ignored. AGP 9.0's
+            // built-in Kotlin makes variant.sources.kotlin the canonical path.
+            // https://issuetracker.google.com/issues/446220448
+            variant.sources.java?.addGeneratedSourceDirectory(task, SqlDelightTask::outputDirectory)
+          }
+          else -> {
+            variant.sources.kotlin?.addGeneratedSourceDirectory(task, SqlDelightTask::outputDirectory)
+          }
         }
       },
     )

--- a/sqldelight-gradle-plugin/src/test/android-generated-source-compilation/build.gradle
+++ b/sqldelight-gradle-plugin/src/test/android-generated-source-compilation/build.gradle
@@ -1,0 +1,31 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
+
+plugins {
+  id("com.android.library").version("8.9.1")
+  alias(libs.plugins.sqldelight)
+  alias(libs.plugins.kotlin.android)
+}
+
+sqldelight {
+  databases {
+    Database {
+      packageName = "com.example.sqldelight"
+    }
+  }
+}
+
+android {
+  namespace = "com.example.sqldelight"
+
+  compileSdk = libs.versions.compileSdk.get() as int
+
+  compileOptions {
+    sourceCompatibility = '1.8'
+    targetCompatibility = '1.8'
+  }
+}
+
+tasks.withType(KotlinCompilationTask.class).configureEach {
+  compilerOptions.jvmTarget = JvmTarget.JVM_1_8
+}

--- a/sqldelight-gradle-plugin/src/test/android-generated-source-compilation/settings.gradle
+++ b/sqldelight-gradle-plugin/src/test/android-generated-source-compilation/settings.gradle
@@ -1,0 +1,9 @@
+pluginManagement {
+    includeBuild("../build-logic-tests")
+}
+
+plugins {
+    id("sqldelightTests")
+}
+
+rootProject.name = "android-generated-source-compilation"

--- a/sqldelight-gradle-plugin/src/test/android-generated-source-compilation/src/main/java/com/example/sqldelight/DatabaseFactory.kt
+++ b/sqldelight-gradle-plugin/src/test/android-generated-source-compilation/src/main/java/com/example/sqldelight/DatabaseFactory.kt
@@ -1,0 +1,9 @@
+package com.example.sqldelight
+
+import app.cash.sqldelight.db.SqlDriver
+
+class DatabaseFactory(
+  private val driver: SqlDriver,
+) {
+  fun create(): Database = Database(driver)
+}

--- a/sqldelight-gradle-plugin/src/test/android-generated-source-compilation/src/main/sqldelight/com/example/sqldelight/HockeyPlayer.sq
+++ b/sqldelight-gradle-plugin/src/test/android-generated-source-compilation/src/main/sqldelight/com/example/sqldelight/HockeyPlayer.sq
@@ -1,0 +1,7 @@
+CREATE TABLE hockeyPlayer (
+  id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL
+);
+
+selectAll:
+SELECT * FROM hockeyPlayer;

--- a/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/tests/PluginTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/tests/PluginTest.kt
@@ -50,6 +50,22 @@ class PluginTest {
   }
 
   @Test
+  fun `Android Kotlin compilation depends on generated sqldelight sources`() {
+    val fixtureRoot = File("src/test/android-generated-source-compilation")
+    val buildDir = File(fixtureRoot, "build/generated/sqldelight")
+    buildDir.delete()
+
+    val result = GradleRunner.create()
+      .withCommonConfiguration(fixtureRoot)
+      .withArguments("clean", "compileDebugKotlin", "--stacktrace")
+      .build()
+
+    assertThat(result.output).contains("generateDebugDatabaseInterface")
+    assertThat(result.output).contains("BUILD SUCCESSFUL")
+    assertThat(buildDir.exists()).isTrue()
+  }
+
+  @Test
   fun `Applying the plugin works fine for js projects`() {
     val runner = GradleRunner.create()
       .withCommonConfiguration(File("src/test/kotlin-js"))


### PR DESCRIPTION
`SourceDirectoriesImpl.addGeneratedSourceDirectory` in AGP 8.9 through 8.11 overwrites the task's `@OutputDirectory` via `DirectoryProperty.set` instead of `.convention`. The SqlDelight task's `outputDirectory` ends up pointing at an AGP-managed path the work action never writes to, AGP registers that empty path as the variant source, and Kotlin compile can't resolve the generated `Database` class. Both `variant.sources.java` and `variant.sources.kotlin` share the same `SourceDirectoriesImpl`, so the source kind makes no difference. Fixed upstream in AGP 8.12.0 by switching to `DirectoryProperty.convention`.

#6140 introduced the `addGeneratedSourceDirectory` wiring and a `variant.sources.java` fallback for AGP < 9.0. That fallback works on AGP 8.12+ but not on AGP 8.9 through 8.11, where this bug applies to both source kinds. Released as broken in 2.3.0, 2.3.1, and 2.3.2.

Restore the pre-#6140 KGP source-set wiring (`kotlinSourceSets.named(variant.name) { it.kotlin.srcDir(task) }`) on the affected AGP range, and keep the existing `addGeneratedSourceDirectory` paths on AGP 8.12+ and 9.0+ where the API works correctly.
