### PR TITLE
PostgreSql Dialect - Fix lower and upper functions using Primitive bind arg to default as TEXT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - [Compiler] Fix optimistic lock for multirow update (#6240 by @griffio)
 - [Intellij Plugin] Fix deprecations causing crash in IDEA 2026.2 (#6247 by @griffio)
 - [Gradle Plugin] Fix generated sources not being picked up by Kotlin compilation on AGP 8.9 through 8.11
+- [PostgreSQL Dialect] Fix lower and upper functions using Primitive bind argument to default as TEXT (#6262 by @griffio)
 
 ## [2.3.2] - 2026-03-16
 [2.3.2]: https://github.com/sqldelight/sqldelight/releases/tag/2.3.2

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
@@ -159,7 +159,7 @@ open class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : Ty
     "min" -> encapsulatingTypePreferringKotlin(exprList, BLOB, TEXT, SMALL_INT, PostgreSqlType.INTEGER, BIG_INT, REAL, PostgreSqlType.NUMERIC, TIMESTAMP_TIMEZONE, TIMESTAMP, DATE, ENUM).asNullable()
     "lower", "upper" -> {
       if (resolvedType(exprList.first()).dialectType == PrimitiveType.ARGUMENT) {
-        IntermediateType(TEXT)
+        IntermediateType(TEXT).asNullable()
       } else {
         val exprType = encapsulatingTypePreferringKotlin(exprList, TEXT, PostgreSqlType.TSRANGE, PostgreSqlType.TSTZRANGE)
         when (exprType.dialectType) {

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
@@ -158,11 +158,15 @@ open class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : Ty
     "max" -> encapsulatingTypePreferringKotlin(exprList, SMALL_INT, PostgreSqlType.INTEGER, BIG_INT, REAL, PostgreSqlType.NUMERIC, TEXT, BLOB, TIMESTAMP_TIMEZONE, TIMESTAMP, DATE, ENUM).asNullable()
     "min" -> encapsulatingTypePreferringKotlin(exprList, BLOB, TEXT, SMALL_INT, PostgreSqlType.INTEGER, BIG_INT, REAL, PostgreSqlType.NUMERIC, TIMESTAMP_TIMEZONE, TIMESTAMP, DATE, ENUM).asNullable()
     "lower", "upper" -> {
-      val exprType = encapsulatingTypePreferringKotlin(exprList, TEXT, PostgreSqlType.TSRANGE, PostgreSqlType.TSTZRANGE)
-      when (exprType.dialectType) {
-        PostgreSqlType.TSRANGE -> IntermediateType(PostgreSqlType.TIMESTAMP).nullableIf(exprType.javaType.isNullable)
-        PostgreSqlType.TSTZRANGE -> IntermediateType(PostgreSqlType.TIMESTAMP_TIMEZONE).nullableIf(exprType.javaType.isNullable)
-        else -> exprType
+      if (resolvedType(exprList.first()).dialectType == PrimitiveType.ARGUMENT) {
+        IntermediateType(TEXT)
+      } else {
+        val exprType = encapsulatingTypePreferringKotlin(exprList, TEXT, PostgreSqlType.TSRANGE, PostgreSqlType.TSTZRANGE)
+        when (exprType.dialectType) {
+          PostgreSqlType.TSRANGE -> IntermediateType(PostgreSqlType.TIMESTAMP).nullableIf(exprType.javaType.isNullable)
+          PostgreSqlType.TSTZRANGE -> IntermediateType(PostgreSqlType.TIMESTAMP_TIMEZONE).nullableIf(exprType.javaType.isNullable)
+          else -> exprType
+        }
       }
     }
     "sum" -> {

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/TemporalRanges.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/TemporalRanges.sq
@@ -26,3 +26,5 @@ SELECT tstzmultirange(
   tstzrange(CURRENT_TIMESTAMP + INTERVAL '3 day' , CURRENT_TIMESTAMP + INTERVAL '6 day'))
   @> CURRENT_TIMESTAMP + INTERVAL '1 day';
 
+selectLowerUpper:
+SELECT LOWER(?::tstzrange) low, UPPER(?::tstzrange) high;

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Unnest.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Unnest.sq
@@ -20,7 +20,7 @@ FROM Business, UNNEST(zipcodes, headcounts) AS location(zipcode, headcount);
 selectLocation:
 SELECT name, location.zipcode
 FROM Business, UNNEST(zipcodes) AS location(zipcode)
-  WHERE LOWER(location.zipcode) LIKE '%' || LOWER(:zipcode::TEXT) || '%';
+  WHERE LOWER(location.zipcode) LIKE '%' || LOWER(:zipcode) || '%';
 
 selectHeadcount:
 SELECT name, UNNEST(headcounts) AS headcount
@@ -53,4 +53,4 @@ FROM Business
 WHERE EXISTS (
    SELECT 1
    FROM UNNEST(Business.zipcodes) AS location(zipcode)
-   WHERE LOWER(location.zipcode) LIKE '%' || LOWER(?::TEXT) || '%');
+   WHERE LOWER(location.zipcode) LIKE '%' || LOWER(?) || '%');

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
@@ -1246,6 +1246,15 @@ class PostgreSqlTest {
   }
 
   @Test
+  fun testLowerUpperFunctionWithTemporalRange() {
+    val range = "[2020-07-01 09:00+00, 2020-07-01 17:00+00]"
+    with(database.temporalRangesQueries.selectLowerUpper(range, range).executeAsOne()) {
+      assertThat(low).isEqualTo(OffsetDateTime.of(2020, 7, 1, 9, 0, 0, 0, ZoneOffset.ofHours(0)))
+      assertThat(high).isEqualTo(OffsetDateTime.of(2020, 7, 1, 17, 0, 0, 0, ZoneOffset.ofHours(0)))
+    }
+  }
+
+  @Test
   fun testUnnestSelect() {
     database.unnestQueries.insertBusiness("Ok Burger", arrayOf("A12345", "AB5522", "T74134"), arrayOf(76, 12, 18))
     with(database.unnestQueries.selectHeadcount().executeAsList()) {


### PR DESCRIPTION
Currently as `lower` and `upper` functions support `TEXT`, `PostgreSqlType.TSRANGE`, `PostgreSqlType.TSTZRANGE` a cast must be used to discriminate and avoids error `Cannot infer argument type ...`
when using `lower(?)`.

Make `TEXT` default argument type  for `lower(?)` as this is expected.

e.g. Currently must be cast.

```sql
SELECT *
FROM data
WHERE LOWER(data.txt) = LOWER(?::TEXT); 
```

The bind arg of type `Primitive.ARGUMENT` should default to `TEXT` and avoid extra casting.
This is in keeping with PostgreSql behavior.

```sql
SELECT *
FROM data
WHERE LOWER(data.txt) = LOWER(?); 
```

Bind Arg must be cast for ranges.

```sql
SELECT *
FROM data
WHERE data.someTimeStamp = UPPER(:someRange::TSTZRANGE); 
```

* Updates and adds an integration test
* Existing code will still work as using explicit cast is supported already

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
