### PR TITLE
Allow using nullable bind argument with null safe operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - [Intellij Plugin] Fix deprecations causing crash in IDEA 2026.2 (#6247 by @griffio)
 - [Gradle Plugin] Fix generated sources not being picked up by Kotlin compilation on AGP 8.9 through 8.11
 - [PostgreSQL Dialect] Fix lower and upper functions using Primitive bind argument to default as TEXT (#6262 by @griffio)
+- [Compiler] Use nullable bind argument with null safe operators(IS and IS DISTINCT FROM) (#6265 by @griffio)
 
 ## [2.3.2] - 2026-03-16
 [2.3.2]: https://github.com/sqldelight/sqldelight/releases/tag/2.3.2

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/Arguments.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/Arguments.kt
@@ -41,6 +41,7 @@ import com.alecstrong.sql.psi.core.psi.SqlFunctionExpr
 import com.alecstrong.sql.psi.core.psi.SqlInExpr
 import com.alecstrong.sql.psi.core.psi.SqlInsertStmt
 import com.alecstrong.sql.psi.core.psi.SqlInsertStmtValues
+import com.alecstrong.sql.psi.core.psi.SqlIsDistinctFromExpr
 import com.alecstrong.sql.psi.core.psi.SqlIsExpr
 import com.alecstrong.sql.psi.core.psi.SqlLikeEscapeCharacterExpr
 import com.alecstrong.sql.psi.core.psi.SqlLimitingTerm
@@ -125,7 +126,12 @@ internal fun SqlExpr.argumentType(argument: SqlExpr): IntermediateType {
       }
     }
 
-    is SqlBinaryPipeExpr, is SqlBinaryEqualityExpr, is SqlIsExpr, is SqlBinaryBooleanExpr -> {
+    is SqlIsExpr, is SqlIsDistinctFromExpr -> {
+      val validArg = children.lastOrNull { it is SqlExpr && it !== argument && it !is SqlBindExpr }
+      (validArg?.type() ?: children.last { it is SqlExpr && it !== argument }.type()).asNullable()
+    }
+
+    is SqlBinaryPipeExpr, is SqlBinaryEqualityExpr, is SqlBinaryBooleanExpr -> {
       val validArg = children.lastOrNull { it is SqlExpr && it !== argument && it !is SqlBindExpr }
       validArg?.type() ?: children.last { it is SqlExpr && it !== argument }.type()
     }

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/IsDistinctFromTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/IsDistinctFromTest.kt
@@ -33,7 +33,7 @@ class IsDistinctFromTest {
     assertThat(generator.querySubtype().toString()).isEqualTo(
       """
         |private inner class SelectOthersQuery<out T : kotlin.Any>(
-        |  public val id: kotlin.Long,
+        |  public val id: kotlin.Long?,
         |  mapper: (app.cash.sqldelight.db.SqlCursor) -> T,
         |) : app.cash.sqldelight.Query<T>(mapper) {
         |  override fun addListener(listener: app.cash.sqldelight.Query.Listener) {
@@ -77,7 +77,7 @@ class IsDistinctFromTest {
     assertThat(generator.querySubtype().toString()).isEqualTo(
       """
         |private inner class SelectItQuery<out T : kotlin.Any>(
-        |  public val id: kotlin.Long,
+        |  public val id: kotlin.Long?,
         |  mapper: (app.cash.sqldelight.db.SqlCursor) -> T,
         |) : app.cash.sqldelight.Query<T>(mapper) {
         |  override fun addListener(listener: app.cash.sqldelight.Query.Listener) {


### PR DESCRIPTION
fixes #6251

Allow nullable bind arg for null safe operators.

`IS [NOT] ?` (SQLite)
`IS [NOT] DISTINCT FROM ?` (Postgres, SQLite 3.39)

This makes sense as these would only be used with a nullable argument.
Currently, the bind arg is only nullable if the column is nullable.

To support expressions like `ORDER BY (whatever IS ?)` allows sorting to be dynamic with null for no order or sort with a value, even if `whatever` is a NOT NULL column.

*  This fix uses the same type resolution as a `SqlBinaryEqualityExpr` but is always nullable.

Note:

In the Sql standard `IS [NOT] [NULL] [TRUE] [FALSE]` cannot take a bind arg, so `IS ?` errors at runtime in PostgreSql (see https://github.com/sqldelight/sqldelight/issues/6176).

If a SqlDelight query accidentally or intentionally uses the equality operator: `ORDER BY (partyId = :partyId) DESC;`
it is rewritten to prevent the incorrect `ORDER BY (partyId = NULL)`
SqlDelight compiles to this when the column is nullable and the bind arg is therefore nullable:
`ORDER BY (partyId ${ if (partyId == null) "IS" else "=" } ?) DESC`

If the column is not null then the equality operator is used with a non-nullable bind arg.
`ORDER BY (partyId = ?) DESC`

Ideally this would output code as same the nullable version to allow a nullable bind arg to be used. 

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
