### PR TITLE
Fix migration alter column insert adapter nullability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - [Intellij Plugin] Fix deprecations causing crash in IDEA 2026.2 (#6247 by @griffio)
 - [Gradle Plugin] Fix generated sources not being picked up by Kotlin compilation on AGP 8.9 through 8.11
 - [PostgreSQL Dialect] Fix lower and upper functions using Primitive bind argument to default as TEXT (#6262 by @griffio)
+- [Compiler] Fix insert values with data class binding using adapters and migrations changing nullability (#6269 by griffio)
 - [Compiler] Use nullable bind argument with null safe operators(IS and IS DISTINCT FROM) (#6265 by @griffio)
 - [Gradle Plugin] Use AGP's variant resolution for project dependencies (#6217 by @maxsav)
 - [Gradle Plugin] Fix build cache miss for generateDatabaseInterface when the list of AGP variants differ between builds

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/model/BindableQuery.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/model/BindableQuery.kt
@@ -23,8 +23,8 @@ import app.cash.sqldelight.core.lang.psi.StmtIdentifierMixin
 import app.cash.sqldelight.core.lang.types.typeResolver
 import app.cash.sqldelight.core.lang.util.argumentType
 import app.cash.sqldelight.core.lang.util.childOfType
-import app.cash.sqldelight.core.lang.util.columns
 import app.cash.sqldelight.core.lang.util.findChildrenOfType
+import app.cash.sqldelight.core.lang.util.queryColumns
 import app.cash.sqldelight.core.lang.util.sqFile
 import app.cash.sqldelight.core.lang.util.type
 import app.cash.sqldelight.dialect.api.IntermediateType
@@ -75,14 +75,16 @@ abstract class BindableQuery(
    */
   val arguments: List<Argument> by lazy {
     if (statement is SqlInsertStmt && statement.acceptsTableInterface()) {
-      return@lazy statement.columns.mapIndexed { index, column ->
+      return@lazy statement.queryColumns.mapIndexed { index, queryColumn ->
+        val element = queryColumn.element
+        val type = element.type().let {
+          if (queryColumn.nullable != null) it.nullableIf(queryColumn.nullable!!) else it
+        }
         Argument(
           index + 1,
-          column.type().let {
-            it.copy(
-              name = "${allocateName(statement.tableName)}.${it.name}",
-            )
-          },
+          type.copy(
+            name = "${allocateName(statement.tableName)}.${type.name}",
+          ),
         )
       }
     }

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/InsertStmtUtil.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/InsertStmtUtil.kt
@@ -2,21 +2,24 @@ package app.cash.sqldelight.core.lang.util
 
 import com.alecstrong.sql.psi.core.psi.LazyQuery
 import com.alecstrong.sql.psi.core.psi.NamedElement
+import com.alecstrong.sql.psi.core.psi.QueryElement.QueryColumn
 import com.alecstrong.sql.psi.core.psi.SqlInsertStmt
+
+internal val SqlInsertStmt.queryColumns: List<QueryColumn>
+  get() {
+    val columns = table.query.columns
+      .filterCodegenExcludedColumns { it.element as? NamedElement }
+    if (columnNameList.isEmpty()) return columns
+
+    val columnMap = linkedMapOf(*columns.map { (it.element as NamedElement).name to it }.toTypedArray())
+    return columnNameList.mapNotNull { columnMap[it.name] }
+  }
 
 /**
  * The list of columns that values are being provided for.
  */
 internal val SqlInsertStmt.columns: List<NamedElement>
-  get() {
-    val columns = table.query.columns
-      .filterCodegenExcludedColumns { it.element as? NamedElement }
-      .map { (it.element as NamedElement) }
-    if (columnNameList.isEmpty()) return columns
-
-    val columnMap = linkedMapOf(*columns.map { it.name to it }.toTypedArray())
-    return columnNameList.mapNotNull { columnMap[it.name] }
-  }
+  get() = queryColumns.map { it.element as NamedElement }
 
 internal val SqlInsertStmt.table: LazyQuery
   get() = tablesAvailable(this).first { it.tableName.name == tableName.name }

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/migrations/MigrationQueryTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/migrations/MigrationQueryTest.kt
@@ -41,6 +41,10 @@ class MigrationQueryTest {
     checkFixtureCompiles("create-or-replace-view", PostgreSqlDialect())
   }
 
+  @Test fun `alter table alter column set not null with adapter`() {
+    checkFixtureCompiles("alter-table-alter-column-adapter", PostgreSqlDialect())
+  }
+
   private fun checkFixtureCompiles(fixtureRoot: String, dialect: SqlDelightDialect = SqliteDialect()) {
     val result = FixtureCompiler.compileFixture(
       overrideDialect = dialect,

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-alter-column-adapter/com/example/1.sqm
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-alter-column-adapter/com/example/1.sqm
@@ -1,0 +1,3 @@
+CREATE TABLE test (
+   lastModifiedAt TIMESTAMPTZ AS Instant
+);

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-alter-column-adapter/com/example/1.sqm
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-alter-column-adapter/com/example/1.sqm
@@ -1,3 +1,3 @@
 CREATE TABLE test (
-   lastModifiedAt TIMESTAMPTZ AS Instant
+   lastModifiedAt TIMESTAMPTZ AS java.time.Instant
 );

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-alter-column-adapter/com/example/2.sqm
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-alter-column-adapter/com/example/2.sqm
@@ -1,0 +1,1 @@
+ALTER TABLE test ALTER COLUMN lastModifiedAt SET NOT NULL;

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-alter-column-adapter/com/example/Test.sq
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-alter-column-adapter/com/example/Test.sq
@@ -1,0 +1,2 @@
+insert:
+INSERT INTO test VALUES ?;

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-alter-column-adapter/output/com/example/Test.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-alter-column-adapter/output/com/example/Test.kt
@@ -1,7 +1,7 @@
 package com.example
 
-import Instant
 import app.cash.sqldelight.ColumnAdapter
+import java.time.Instant
 import java.time.OffsetDateTime
 
 public data class Test(

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-alter-column-adapter/output/com/example/Test.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-alter-column-adapter/output/com/example/Test.kt
@@ -1,0 +1,13 @@
+package com.example
+
+import Instant
+import app.cash.sqldelight.ColumnAdapter
+import java.time.OffsetDateTime
+
+public data class Test(
+  public val lastModifiedAt: Instant,
+) {
+  public class Adapter(
+    public val lastModifiedAtAdapter: ColumnAdapter<Instant, OffsetDateTime>,
+  )
+}

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-alter-column-adapter/output/com/example/Test.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-alter-column-adapter/output/com/example/Test.kt
@@ -1,3 +1,5 @@
+@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
+
 package com.example
 
 import app.cash.sqldelight.ColumnAdapter

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-alter-column-adapter/output/com/example/TestQueries.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-alter-column-adapter/output/com/example/TestQueries.kt
@@ -1,0 +1,27 @@
+package com.example
+
+import app.cash.sqldelight.TransacterImpl
+import app.cash.sqldelight.db.QueryResult
+import app.cash.sqldelight.db.SqlDriver
+import app.cash.sqldelight.driver.jdbc.JdbcPreparedStatement
+import kotlin.Long
+
+public class TestQueries(
+  driver: SqlDriver,
+  private val testAdapter: Test.Adapter,
+) : TransacterImpl(driver) {
+  /**
+   * @return The number of rows updated.
+   */
+  public fun insert(test: Test): QueryResult<Long> {
+    val result = driver.execute(-1_904_748_490, """INSERT INTO test (lastModifiedAt) VALUES (?)""", 1) {
+          check(this is JdbcPreparedStatement)
+          var parameterIndex = 0
+          bindObject(parameterIndex++, testAdapter.lastModifiedAtAdapter.encode(test.lastModifiedAt))
+        }
+    notifyQueries(-1_904_748_490) { emit ->
+      emit("test")
+    }
+    return result
+  }
+}

--- a/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-alter-column-adapter/output/com/example/TestQueries.kt
+++ b/sqldelight-compiler/src/test/migration-interface-fixtures/alter-table-alter-column-adapter/output/com/example/TestQueries.kt
@@ -1,3 +1,5 @@
+@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
+
 package com.example
 
 import app.cash.sqldelight.TransacterImpl


### PR DESCRIPTION
fixes #6263 

`INSERT INTO foo VALUES ?` doesn't use query columns for current state of nullability.

This is for PostgreSql dialect where altering column nullability is supported ( Sqlite doesn't support this until 3.53).

Fix `InsertStmtUtil` to use the query columns that values are being provided for, unlike [columns] these retain the
 [QueryColumn.nullable] override, which carries nullability changes applied by migrations
 (e.g `ALTER TABLE ... ALTER COLUMN ... SET NOT NULL`) that are not present on the original column definition.

Fix `BindableQuery` to use the query columns and check if the nullability is overridden.

Adds migration test for PostgreSqlDialect

Note:

It appears that MySql dialect already works because the modify statement uses a complete column_def  :

```sql
ALTER TABLE test MODIFY lastModifiedAt TIMESTAMP AS java.time.Instant NOT NULL;
```

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
