### PR TITLE
Keep grouped aggregates nullable when their argument is nullable

### DIFF
--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/model/NamedQuery.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/model/NamedQuery.kt
@@ -239,8 +239,7 @@ data class NamedQuery(
     val selectStmt = this as? SqlSelectStmt
     val hasGroupBy = selectStmt?.groupBy != null
     val hasAggregate = selectStmt?.resultColumnList?.any { resultColumn ->
-      val expr = resultColumn.expr
-      expr is SqlFunctionExpr && expr.functionName.text.lowercase() in AGGREGATE_FUNCTIONS
+      resultColumn.expr?.asAggregateFunction() != null
     } ?: false
 
     return queryExposed().flatMap {
@@ -254,24 +253,29 @@ data class NamedQuery(
             while (!namesUsed.add(name)) name += "_"
           }
 
-          var type = queryColumn.type().copy(name = name)
+          val type = queryColumn.type().copy(name = name)
+          val aggregate = queryColumn.element.asAggregateFunction()
 
-          if (hasAggregate) {
-            val isAggregate = queryColumn.element is SqlFunctionExpr &&
-              (queryColumn.element as SqlFunctionExpr).functionName.text.lowercase() in AGGREGATE_FUNCTIONS
-
-            // Goup by statements filter out empty groups so we don't have to
-            // worry about non-null columns returning as nullable.
-            if (!hasGroupBy && !isAggregate) {
-              type = type.asNullable()
-            } else if (hasGroupBy && isAggregate) {
-              type = type.asNonNullable()
-            }
+          return@map when {
+            !hasAggregate -> type
+            // Without a GROUP BY the aggregate collapses every row, so other columns may
+            // read from no row and become nullable.
+            !hasGroupBy && aggregate == null -> type.asNullable()
+            // A grouped aggregate is non-null only when it can never return NULL.
+            hasGroupBy && aggregate != null && aggregate.alwaysReturnsNonNull() -> type.asNonNullable()
+            else -> type
           }
-
-          return@map type
         }
     }
+  }
+
+  private fun PsiElement.asAggregateFunction(): SqlFunctionExpr? = (this as? SqlFunctionExpr)?.takeIf { it.functionName.text.lowercase() in AGGREGATE_FUNCTIONS }
+
+  // count/total always return a value; max/min/sum/avg/group_concat return NULL when their
+  // argument is NULL (e.g. group_concat over a nullable LEFT JOIN column).
+  private fun SqlFunctionExpr.alwaysReturnsNonNull(): Boolean {
+    if (functionName.text.lowercase() in NON_NULLABLE_AGGREGATE_FUNCTIONS) return true
+    return exprList.isNotEmpty() && exprList.none { it.type().javaType.isNullable }
   }
 
   private fun QueryElement.QueryColumn.type(): IntermediateType {
@@ -305,6 +309,11 @@ data class NamedQuery(
       "avg",
       "total",
       "group_concat",
+    )
+
+    private val NON_NULLABLE_AGGREGATE_FUNCTIONS = setOf(
+      "count",
+      "total",
     )
   }
 }

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/ExpressionTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/ExpressionTest.kt
@@ -371,9 +371,59 @@ class ExpressionTest {
     )
 
     val query = file.namedQueries.first()
+    // MAX over a nullable column stays nullable even with a GROUP BY: the group whose key is
+    // NULL contains only NULL values, so MAX(id) returns NULL for it.
     assertThat(query.resultColumns.map { it.javaType }).containsExactly(
       LONG.copy(nullable = true),
+      LONG.copy(nullable = true),
+    ).inOrder()
+  }
+
+  @Test fun `group_concat over a nullable column stays nullable with a group`() {
+    val file = FixtureCompiler.parseSql(
+      """
+      |CREATE TABLE test (
+      |  id INTEGER NOT NULL,
+      |  name TEXT
+      |);
+      |
+      |someSelect:
+      |SELECT id,
+      |       group_concat(name)
+      |FROM test
+      |GROUP BY id;
+      """.trimMargin(),
+      tempFolder,
+    )
+
+    val query = file.namedQueries.first()
+    assertThat(query.resultColumns.map { it.javaType }).containsExactly(
       LONG,
+      String::class.asClassName().copy(nullable = true),
+    ).inOrder()
+  }
+
+  @Test fun `group_concat over a non null column is non null with a group`() {
+    val file = FixtureCompiler.parseSql(
+      """
+      |CREATE TABLE test (
+      |  id INTEGER NOT NULL,
+      |  name TEXT NOT NULL
+      |);
+      |
+      |someSelect:
+      |SELECT id,
+      |       group_concat(name)
+      |FROM test
+      |GROUP BY id;
+      """.trimMargin(),
+      tempFolder,
+    )
+
+    val query = file.namedQueries.first()
+    assertThat(query.resultColumns.map { it.javaType }).containsExactly(
+      LONG,
+      String::class.asClassName(),
     ).inOrder()
   }
 

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/InterfaceGeneration.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/InterfaceGeneration.kt
@@ -836,6 +836,48 @@ class InterfaceGeneration {
     )
   }
 
+  @Test fun `single argument group_concat of nullable column is nullable with a group`() {
+    val result = FixtureCompiler.compileSql(
+      """
+      |CREATE TABLE place (
+      |  id INTEGER NOT NULL PRIMARY KEY
+      |);
+      |
+      |CREATE TABLE placeTag (
+      |  place INTEGER NOT NULL,
+      |  tag TEXT
+      |);
+      |
+      |placeWithTags:
+      |SELECT place.id, group_concat(placeTag.tag)
+      |FROM place
+      |LEFT JOIN placeTag ON placeTag.place = place.id
+      |GROUP BY place.id;
+      """.trimMargin(),
+      temporaryFolder,
+    )
+
+    assertThat(result.errors).isEmpty()
+    val generatedInterface = result.compilerOutput.get(
+      File(result.outputDirectory, "com/example/PlaceWithTags.kt"),
+    )
+    assertThat(generatedInterface).isNotNull()
+    assertThat(generatedInterface.toString()).isEqualTo(
+      """
+      |package com.example
+      |
+      |import kotlin.Long
+      |import kotlin.String
+      |
+      |public data class PlaceWithTags(
+      |  public val id: Long,
+      |  public val group_concat: String?,
+      |)
+      |
+      """.trimMargin(),
+    )
+  }
+
   @Test fun `cast inherits nullability`() {
     val file = FixtureCompiler.parseSql(
       """


### PR DESCRIPTION
PR #6187 forced every aggregate column in a `GROUP BY` query to be non-null. That is only safe for `count`/`total`. `group_concat`/`max`/`min`/`sum`/`avg` still return `NULL` when their argument is `NULL` (e.g. `group_concat` over a nullable `LEFT JOIN` column), so the generated mapper emitted an unsafe `!!` and threw `NullPointerException` at runtime.

Only force non-null for `count`/`total`, or for aggregates whose arguments are all non-null. Fixes the regression reported in #6211.

https://www.sqlite.org/lang_aggfunc.html

