### PR TITLE
Fix tooling model crash when plugin applied without databases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - [Compiler] Use nullable bind argument with null safe operators(IS and IS DISTINCT FROM) (#6265 by @griffio)
 - [Gradle Plugin] Use AGP's variant resolution for project dependencies (#6217 by @maxsav)
 - [Gradle Plugin] Fix build cache miss for generateDatabaseInterface when the list of AGP variants differ between builds
+- [Gradle Plugin] Fix IDE sync crash when the plugin is applied without configuring any databases (#6088)
 
 ## [2.3.2] - 2026-03-16
 [2.3.2]: https://github.com/sqldelight/sqldelight/releases/tag/2.3.2

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightPlugin.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightPlugin.kt
@@ -162,7 +162,7 @@ abstract class SqlDelightPlugin : Plugin<Project> {
         databases = databases.map { it.getProperties().get() },
         currentVersion = VERSION,
         minimumSupportedVersion = MINIMUM_SUPPORTED_VERSION,
-        dialectJars = databases.first().configuration.files,
+        dialectJars = databases.firstOrNull()?.configuration?.files.orEmpty(),
       )
     }
   }

--- a/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/properties/PropertiesFileTest.kt
+++ b/sqldelight-gradle-plugin/src/test/kotlin/app/cash/sqldelight/properties/PropertiesFileTest.kt
@@ -95,4 +95,24 @@ class PropertiesFileTest {
       )
     }
   }
+
+  @Test fun `properties model builds when plugin is applied without any databases`() {
+    withTemporaryFixture {
+      gradleFile(
+        """|
+        |plugins {
+        |  alias(libs.plugins.kotlin.multiplatform)
+        |  alias(libs.plugins.sqldelight)
+        |}
+        |
+        |kotlin {
+        |  jvm()
+        |}
+        """.trimMargin(),
+      )
+
+      // Fetching the tooling model must not throw when no databases are configured.
+      assertThat(properties().databases).isEmpty()
+    }
+  }
 }


### PR DESCRIPTION
`databases.first()` threw `NoSuchElementException` during IDE sync for modules that apply the plugin but configure no databases. 

closes #6088, closes #5833, closes #5664, and closes #4763

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
