### PR TITLE
Fix Postgresql dialect json agg stmt grammar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - [Gradle Plugin] Use AGP's variant resolution for project dependencies (#6217 by @maxsav)
 - [Gradle Plugin] Fix build cache miss for generateDatabaseInterface when the list of AGP variants differ between builds
 - [Gradle Plugin] Fix IDE sync crash when the plugin is applied without configuring any databases (#6088)
+- [PostgreSQL Dialect] Fix json aggregate functions when using nested function call (#6281 by @griffio)
 
 ## [2.3.2] - 2026-03-16
 [2.3.2]: https://github.com/sqldelight/sqldelight/releases/tag/2.3.2

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
@@ -215,8 +215,7 @@ open class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : Ty
     "json_object_agg", "jsonb_object_agg", "json_object_agg_strict", "jsonb_object_agg_strict",
     "json_object_agg_unique", "jsonb_object_agg_unique", "json_object_agg_unique_strict", "jsonb_object_agg_unique_strict",
     -> IntermediateType(PostgreSqlType.JSON)
-    "json_build_object", "jsonb_build_object",
-    -> IntermediateType(TEXT)
+    "json_build_object", "jsonb_build_object" -> IntermediateType(PostgreSqlType.JSON)
     "array_agg" -> {
       val typeForAgg = encapsulatingTypePreferringKotlin(exprList, SMALL_INT, PostgreSqlType.INTEGER, BIG_INT, REAL, PostgreSqlType.NUMERIC, TEXT, TIMESTAMP_TIMEZONE, TIMESTAMP, DATE).asNullable()
       arrayIntermediateType(typeForAgg)

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -828,17 +828,13 @@ json_function_stmt ::= ( 'row_to_json' | 'to_json' | 'to_jsonb' ) LP ( {table_al
 
 json_agg_stmt ::= ( 'json_agg' | 'jsonb_agg' | 'json_agg_strict' | 'jsonb_agg_strict')
 LP [ ALL | DISTINCT ] ( json_expression | {table_alias} | {table_name} | <<expr '-1'>> ) [ ORDER BY {ordering_term} ( COMMA {ordering_term} ) * ] RP
-[ 'FILTER' LP WHERE <<expr '-1'>> [ double_colon_cast_operator ] RP ] {
-pin = 2
-}
+[ 'FILTER' LP WHERE <<expr '-1'>> [ double_colon_cast_operator ] RP ]
 
 json_object_agg_stmt ::= ('json_object_agg' | 'jsonb_object_agg' | 'json_object_agg_strict' | 'jsonb_object_agg_strict'
 | 'json_object_agg_unique' | 'jsonb_object_agg_unique' | 'json_object_agg_unique_strict' | 'jsonb_object_agg_unique_strict' ) {
 LP [ ALL | DISTINCT ] ( json_expression | {column_expr} | <<expr '-1'>> ) COMMA ( json_expression | {column_expr} | <<expr '-1'>> )
 [ ORDER BY {ordering_term} ( COMMA {ordering_term} ) * ] RP
-[ 'FILTER' LP WHERE <<expr '-1'>> [ double_colon_cast_operator ] RP ] {
-pin = 2
-}
+[ 'FILTER' LP WHERE <<expr '-1'>> [ double_colon_cast_operator ] RP ]
 
 geometry_point_function_stmt ::= ( ( 'ST_POINTZM' | 'ST_POINTZ' | 'ST_POINTM' | 'ST_POINT' ) LP ( {bind_expr} | {signed_number} ) ( COMMA ( {bind_expr} | {signed_number} ) ) * [ COMMA {signed_number} ] RP ) |
 ( ( 'ST_MAKEPOINTM' | 'ST_MAKEPOINT' ) LP ( {bind_expr} | {signed_number} ) ( COMMA ( {bind_expr} | {signed_number} ) ) * RP ) {

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/json_functions/Test.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/json_functions/Test.s
@@ -82,3 +82,10 @@ FROM myTable;
 
 SELECT jsonb_object_agg_strict(t, datab ORDER BY t DESC)
 FROM myTable;
+
+SELECT jsonb_agg(jsonb_build_object('id', 1));
+
+SELECT jsonb_agg(t)
+FROM ( SELECT 1 AS id) AS t;
+
+SELECT json_build_object('foo', 1, 2, row(3,'bar'));

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Json.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/Json.sq
@@ -20,8 +20,8 @@ CREATE TABLE TestJsonCheck(
 
 insert:
 INSERT INTO TestJson(data, datab) VALUES(
-  json_build_object(:key, :value),
-  jsonb_build_object('key', 'value')
+  json_build_object(:key::TEXT, :value::TEXT),
+  jsonb_build_object('key'::TEXT, 'value'::TEXT)
 );
 
 setJsonb:


### PR DESCRIPTION
fixes #6278 

Remove `pin = 2` on the `json_agg_stmt` grammar rule that prevented matching on nested function expressions:
`SELECT jsonb_agg(jsonb_build_object('id', 1));`

* add fixture tests for grammar
* fix type mapping to json on `json_build_object | jsonb_build_object` - variadic bind args must be cast

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
