### PR TITLE
fix(paging3): fix KeyedQueryPagingSource crash on empty database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - [Gradle Plugin] Fix build cache miss for generateDatabaseInterface when the list of AGP variants differ between builds
 - [Gradle Plugin] Fix IDE sync crash when the plugin is applied without configuring any databases (#6088)
 - [PostgreSQL Dialect] Fix json aggregate functions when using nested function call (#6281 by @griffio)
+- [Paging3 Extension] Fix KeyedQueryPagingSource crash on empty database (#6284 by @woods-marshes)
 
 ## [2.3.2] - 2026-03-16
 [2.3.2]: https://github.com/sqldelight/sqldelight/releases/tag/2.3.2

--- a/extensions/androidx-paging3/src/commonMain/kotlin/app/cash/sqldelight/paging3/KeyedQueryPagingSource.kt
+++ b/extensions/androidx-paging3/src/commonMain/kotlin/app/cash/sqldelight/paging3/KeyedQueryPagingSource.kt
@@ -53,22 +53,33 @@ internal class KeyedQueryPagingSource<Key : Any, RowType : Any>(
               .executeAsList()
               .also { pageBoundaries = it }
 
-          val key = params.key ?: boundaries.first()
+          if (boundaries.isEmpty()) {
+            @Suppress("UNCHECKED_CAST")
+            currentQuery = pageBoundariesProvider(params.key, params.loadSize.toLong()) as Query<RowType>
 
-          require(key in boundaries)
+            LoadResult.Page(
+              data = emptyList(),
+              prevKey = null,
+              nextKey = null,
+            )
+          } else {
+            val key = params.key ?: boundaries.first()
 
-          val keyIndex = boundaries.indexOf(key)
-          val previousKey = boundaries.getOrNull(keyIndex - 1)
-          val nextKey = boundaries.getOrNull(keyIndex + 1)
-          val results = queryProvider(key, nextKey)
-            .also { currentQuery = it }
-            .executeAsList()
+            require(key in boundaries)
 
-          LoadResult.Page(
-            data = results,
-            prevKey = previousKey,
-            nextKey = nextKey,
-          )
+            val keyIndex = boundaries.indexOf(key)
+            val previousKey = boundaries.getOrNull(keyIndex - 1)
+            val nextKey = boundaries.getOrNull(keyIndex + 1)
+            val results = queryProvider(key, nextKey)
+              .also { currentQuery = it }
+              .executeAsList()
+
+            LoadResult.Page(
+              data = results,
+              prevKey = previousKey,
+              nextKey = nextKey,
+            )
+          }
         }
         when (transacter) {
           is Transacter -> transacter.transactionWithResult(bodyWithReturn = getPagingSourceLoadResult)

--- a/extensions/androidx-paging3/src/commonTest/kotlin/app/cash/sqldelight/paging3/KeyedQueryPagingSourceTest.kt
+++ b/extensions/androidx-paging3/src/commonTest/kotlin/app/cash/sqldelight/paging3/KeyedQueryPagingSourceTest.kt
@@ -28,10 +28,10 @@ import app.cash.sqldelight.db.SqlDriver
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNull
-import kotlin.test.assertIs
-import kotlin.test.assertTrue
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 
 @ExperimentalCoroutinesApi

--- a/extensions/androidx-paging3/src/commonTest/kotlin/app/cash/sqldelight/paging3/KeyedQueryPagingSourceTest.kt
+++ b/extensions/androidx-paging3/src/commonTest/kotlin/app/cash/sqldelight/paging3/KeyedQueryPagingSourceTest.kt
@@ -29,6 +29,9 @@ import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.test.assertFalse
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 
 @ExperimentalCoroutinesApi
@@ -142,6 +145,26 @@ abstract class BaseKeyedQueryPagingSourceTest : DbTest {
     assertEquals(6L, refreshKey)
   }
 
+  @Test fun empty_database_initial_load_returns_empty_page() = runDbTest {
+    clearTable()
+    val results = source.load(PagingSource.LoadParams.Refresh(key = null, loadSize = 2, false))
+
+    assertIs<PagingSource.LoadResult.Page<Long, Long>>(results)
+    assertTrue(results.data.isEmpty())
+    assertNull(results.prevKey)
+    assertNull(results.nextKey)
+  }
+
+  @Test fun empty_database_load_registers_observer_and_invalidates_on_insert() = runDbTest {
+    clearTable()
+    val results = source.load(PagingSource.LoadParams.Refresh(key = null, loadSize = 2, false))
+
+    assertIs<PagingSource.LoadResult.Page<Long, Long>>(results)
+    assertFalse(source.invalid)
+    insert(0L)
+    assertTrue(source.invalid)
+  }
+
   private fun pageBoundaries(anchor: Long?, limit: Long): Query<Long> {
     val sql = """
       |SELECT value
@@ -165,8 +188,8 @@ abstract class BaseKeyedQueryPagingSourceTest : DbTest {
         bindLong(1, anchor)
       }
 
-      override fun addListener(listener: Listener) = Unit
-      override fun removeListener(listener: Listener) = Unit
+      override fun addListener(listener: Listener) = driver.addListener("testTable", listener = listener)
+      override fun removeListener(listener: Listener) = driver.removeListener("testTable", listener = listener)
     }
   }
 
@@ -185,8 +208,8 @@ abstract class BaseKeyedQueryPagingSourceTest : DbTest {
         bindLong(1, endExclusive)
       }
 
-      override fun addListener(listener: Listener) = Unit
-      override fun removeListener(listener: Listener) = Unit
+      override fun addListener(listener: Listener) = driver.addListener("testTable", listener = listener)
+      override fun removeListener(listener: Listener) = driver.removeListener("testTable", listener = listener)
     }
   }
 
@@ -194,5 +217,11 @@ abstract class BaseKeyedQueryPagingSourceTest : DbTest {
     db.execute(0, "INSERT INTO testTable (value) VALUES (?)", 1) {
       bindLong(0, value)
     }
+    db.notifyListeners("testTable")
+  }
+
+  private fun clearTable() {
+    driver.execute(null, "DELETE FROM testTable", 0)
+    driver.notifyListeners("testTable")
   }
 }


### PR DESCRIPTION
### Description
Fixes a `NoSuchElementException` during the initial load when `KeyedQueryPagingSource` is used on an empty database (or when a query returns no matching rows) .

Previously, when the database was empty, `boundaries.first()` threw `NoSuchElementException` during the initial load before `currentQuery` was set. This prevented the paging source from registering database observers and automatically invalidating itself when new data was subsequently inserted.

### Solution
1. **PagingSource Fix**:
   - Checked if the calculated boundaries are empty.
   - If empty, it now returns an empty `LoadResult.Page` . It also casts and assigns `pageBoundariesProvider` to `currentQuery` (using `@Suppress("UNCHECKED_CAST")` since `currentQuery` expects `Query<RowType>?` but is only used internally for adding/removing listeners). This ensures table insertions can be successfully observed and trigger invalidation.

2. **Test Infrastructure Fix**:
   - Updated the mock query objects returned by `pageBoundaries` and `query` in `BaseKeyedQueryPagingSourceTest` to correctly bind listeners to the driver's `"testTable"`.
   - Updated the mock `insert` method and added a `clearTable` helper to call `db.notifyListeners("testTable")` so database updates are properly propagated.

3. **Added Tests**:
   - `empty_database_initial_load_returns_empty_page`: Verifies that an initial load on an empty database does not crash and safely returns an empty page.
   - `empty_database_load_registers_observer_and_invalidates_on_insert`: Verifies that after loading an empty database, inserting a new item successfully triggers invalidation on the `PagingSource`.
---
- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
---
Closes #6279