### PR TITLE
docs: fix JavaScript spelling and clarify srcDirs default

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ SQLite
 * [Android](https://sqldelight.github.io/sqldelight/android_sqlite)
 * [Native (iOS, macOS, or Windows)](https://sqldelight.github.io/sqldelight/native_sqlite)
 * [JVM](https://sqldelight.github.io/sqldelight/jvm_sqlite)
-* [Javascript](https://sqldelight.github.io/sqldelight/js_sqlite)
+* [JavaScript](https://sqldelight.github.io/sqldelight/js_sqlite)
 * [Multiplatform](https://sqldelight.github.io/sqldelight/multiplatform_sqlite)
 
 [MySQL (JVM)](https://sqldelight.github.io/sqldelight/jvm_mysql/)

--- a/docs/common/gradle.md
+++ b/docs/common/gradle.md
@@ -79,7 +79,7 @@ Type: `ConfigurableFileCollection`
 
 A collection of folders that the plugin will look in for your `.sq` and `.sqm` files.
 
-Defaults to `src/[prefix]main/sqldelight` with prefix depending on the applied kotlin plugin eg common for multiplatform.
+Defaults to `src/[prefix]main/sqldelight` with prefix depending on the applied Kotlin plugin, e.g., `common` for multiplatform.
 
 === "Kotlin"
     ```kotlin


### PR DESCRIPTION
- Fixes `Javascript` → `JavaScript` in the README platform list to match the docs site (`docs/index.md`)
- Clarifies the default `srcDirs` path description for multiplatform projects (`e.g., common`)
