### PR TITLE
Improve Postgresql set/table returning functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - [Gradle Plugin] Fix IDE sync crash when the plugin is applied without configuring any databases (#6088)
 - [PostgreSQL Dialect] Fix json aggregate functions when using nested function call (#6281 by @griffio)
 - [Paging3 Extension] Fix KeyedQueryPagingSource crash on empty database (#6284 by @woods-marshes)
+- [PostgreSQL Dialect] Improve support for set/table returning functions (#6289 by @griffio)
 
 ## [2.3.2] - 2026-03-16
 [2.3.2]: https://github.com/sqldelight/sqldelight/releases/tag/2.3.2

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
@@ -224,7 +224,7 @@ open class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : Ty
     "json_array_length", "jsonb_array_length" -> IntermediateType(PostgreSqlType.INTEGER)
     "jsonb_path_exists", "jsonb_path_match", "jsonb_path_exists_tz", "jsonb_path_match_tz" -> IntermediateType(BOOLEAN)
     "currval", "lastval", "nextval", "setval" -> IntermediateType(BIG_INT)
-    "generate_series" -> encapsulatingType(exprList, PostgreSqlType.INTEGER, BIG_INT, REAL, PostgreSqlType.NUMERIC, TIMESTAMP_TIMEZONE, TIMESTAMP)
+    "generate_series" -> generateSeriesRowType(exprList)
     "regexp_count", "regexp_instr" -> IntermediateType(PostgreSqlType.INTEGER)
     "regexp_like" -> IntermediateType(BOOLEAN)
     "regexp_replace", "regexp_substr" -> IntermediateType(TEXT)
@@ -518,8 +518,12 @@ open class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : Ty
     }
 
     // assumes that arrayIntermediateType is ArrayDialectType
-    private fun unNestType(arrayIntermediateType: IntermediateType): IntermediateType {
+    internal fun unNestType(arrayIntermediateType: IntermediateType): IntermediateType {
       return (arrayIntermediateType.dialectType as ArrayDialectType).parameterizedType
     }
   }
 }
+
+internal fun TypeResolver.generateSeriesRowType(exprList: List<SqlExpr>): IntermediateType = encapsulatingType(exprList, PostgreSqlType.INTEGER, BIG_INT, REAL, PostgreSqlType.NUMERIC, TIMESTAMP_TIMEZONE, TIMESTAMP)
+
+internal fun TypeResolver.unnestRowType(columnType: SqlTypeName): IntermediateType = PostgreSqlTypeResolver.unNestType(definitionType(columnType)).asNullable()

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -539,6 +539,27 @@ unnest_table_function ::= 'unnest' {
        ]
 }
 
+generate_series_table_function ::= 'generate_series' {
+  mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.GenerateSeriesTableFunctionMixin"
+  implements = [
+         "com.alecstrong.sql.psi.core.psi.NamedElement";
+         "com.alecstrong.sql.psi.core.psi.SqlCompositeElement";
+         "app.cash.sqldelight.dialect.api.TableFunctionExprRowType"
+       ]
+}
+
+json_table_function ::= ( 'json_each' | 'jsonb_each' | 'json_each_text' | 'jsonb_each_text'
+                        | 'json_array_elements' | 'jsonb_array_elements'
+                        | 'json_array_elements_text' | 'jsonb_array_elements_text'
+                        | 'json_object_keys' | 'jsonb_object_keys' ) {
+  mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.JsonTableFunctionMixin"
+  implements = [
+         "com.alecstrong.sql.psi.core.psi.NamedElement";
+         "com.alecstrong.sql.psi.core.psi.SqlCompositeElement";
+         "app.cash.sqldelight.dialect.api.TableFunctionExprRowType"
+       ]
+}
+
 table_function_column_alias ::= ID | STRING {
   mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.TableFunctionColumnAliasMixin"
   implements = [
@@ -558,6 +579,8 @@ table_function_table_alias ::= ID | STRING {
 table_function_alias_name ::= table_function_table_alias [ LP table_function_column_alias ( COMMA table_function_column_alias ) * RP ]
 
 table_or_subquery ::= ( unnest_table_function LP <<expr '-1'>> ( COMMA <<expr '-1'>> ) * RP [ AS table_function_alias_name ]
+                      | generate_series_table_function LP <<expr '-1'>> ( COMMA <<expr '-1'>> ) * RP [ AS table_function_alias_name ]
+                      | json_table_function LP <<expr '-1'>> RP [ AS table_function_alias_name ]
                       | [ {database_name} DOT ] {table_name} [ [ AS ] {table_alias} ] [ INDEXED BY {index_name} | NOT INDEXED ]
                       | LP ( {table_or_subquery} ( COMMA {table_or_subquery} ) * | {join_clause} ) RP
                       | LP {compound_select_stmt} RP [ [ AS ] {table_alias} ] ) {

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/GenerateSeriesTableFunctionMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/GenerateSeriesTableFunctionMixin.kt
@@ -1,0 +1,30 @@
+package app.cash.sqldelight.dialects.postgresql.grammar.mixins
+
+import app.cash.sqldelight.dialect.api.IntermediateType
+import app.cash.sqldelight.dialect.api.TableFunctionExprRowType
+import app.cash.sqldelight.dialect.api.TypeResolver
+import app.cash.sqldelight.dialects.postgresql.generateSeriesRowType
+import app.cash.sqldelight.dialects.postgresql.grammar.PostgreSqlParser
+import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlTableOrSubquery
+import com.alecstrong.sql.psi.core.psi.SqlExpr
+import com.alecstrong.sql.psi.core.psi.SqlNamedElementImpl
+import com.intellij.lang.ASTNode
+import com.intellij.lang.PsiBuilder
+
+/**
+ * The `generate_series` keyword node when used as a set-returning function in a FROM clause, e.g.
+ * `SELECT g FROM generate_series(1, 2, 10) AS g`. The single output column's type is derived from
+ * the argument expressions.
+ */
+internal abstract class GenerateSeriesTableFunctionMixin(
+  node: ASTNode,
+) : SqlNamedElementImpl(node),
+  TableFunctionExprRowType {
+
+  override fun rowType(typeResolver: TypeResolver): IntermediateType {
+    val args = (parent as PostgreSqlTableOrSubquery).children.filterIsInstance<SqlExpr>()
+    return typeResolver.generateSeriesRowType(args)
+  }
+
+  override val parseRule: (builder: PsiBuilder, level: Int) -> Boolean = PostgreSqlParser::generate_series_table_function_real
+}

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/JsonTableFunctionMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/JsonTableFunctionMixin.kt
@@ -1,0 +1,86 @@
+package app.cash.sqldelight.dialects.postgresql.grammar.mixins
+
+import app.cash.sqldelight.dialect.api.IntermediateType
+import app.cash.sqldelight.dialect.api.PrimitiveType.TEXT
+import app.cash.sqldelight.dialect.api.TableFunctionExprRowType
+import app.cash.sqldelight.dialect.api.TypeResolver
+import app.cash.sqldelight.dialects.postgresql.PostgreSqlType
+import app.cash.sqldelight.dialects.postgresql.grammar.PostgreSqlParser
+import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlTableFunctionAliasName
+import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlTableFunctionColumnAlias
+import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlTableOrSubquery
+import com.alecstrong.sql.psi.core.SqlAnnotationHolder
+import com.alecstrong.sql.psi.core.psi.SqlNamedElementImpl
+import com.intellij.lang.ASTNode
+import com.intellij.lang.PsiBuilder
+import com.intellij.psi.util.PsiTreeUtil
+
+/**
+ * A JSON set-returning function used in a FROM clause, e.g.
+ * `SELECT json_object_keys FROM json_object_keys('{"a":1}')` or
+ * `SELECT t.key, t.value FROM json_each('{"a":1}') AS t(key, value)`.
+ *
+ * Output column types are fixed by the function (see [jsonTableFunctionRowType]); every column
+ * (`text`, `json`, `jsonb`) maps to Kotlin `String`. Postgres names the default columns `value`
+ * (array_elements) or `key`/`value` (each), which have no element to resolve against, so those
+ * functions require explicit column aliases. `*_object_keys`, whose default column name *is* the
+ * function name, may be used without an alias.
+ */
+internal abstract class JsonTableFunctionMixin(
+  node: ASTNode,
+) : SqlNamedElementImpl(node),
+  TableFunctionExprRowType {
+
+  // Used when the function node is itself the single exposed column (un-aliased `*_object_keys`).
+  override fun rowType(typeResolver: TypeResolver): IntermediateType = jsonTableFunctionRowType(name.lowercase(), 0)
+
+  override fun annotate(annotationHolder: SqlAnnotationHolder) {
+    val functionName = name.lowercase()
+    val tableOrSubquery = PsiTreeUtil.getParentOfType(this, PostgreSqlTableOrSubquery::class.java) ?: return
+    val aliasColumnCount = tableOrSubquery.children.filterIsInstance<PostgreSqlTableFunctionAliasName>()
+      .flatMap { it.children.filterIsInstance<PostgreSqlTableFunctionColumnAlias>() }
+      .count()
+    val expected = jsonTableFunctionColumnCount(functionName)
+    if (jsonTableFunctionAllowsNoAlias(functionName)) {
+      if (aliasColumnCount > expected) {
+        annotationHolder.createErrorAnnotation(this, "$name exposes $expected column, found $aliasColumnCount column aliases")
+      }
+    } else if (aliasColumnCount != expected) {
+      val example = if (expected == 1) "$name(...) AS t(value)" else "$name(...) AS t(key, value)"
+      annotationHolder.createErrorAnnotation(this, "$name requires $expected column aliases, e.g. $example")
+    }
+  }
+
+  override val parseRule: (PsiBuilder, Int) -> Boolean = PostgreSqlParser::json_table_function_real
+}
+
+/** Number of output columns of a JSON set-returning function. */
+internal fun jsonTableFunctionColumnCount(functionName: String): Int = when (functionName) {
+  "json_each", "jsonb_each", "json_each_text", "jsonb_each_text" -> 2
+  else -> 1
+}
+
+/**
+ * Whether the un-aliased form is valid. Only `*_object_keys` qualifies: Postgres names its column
+ * after the function (no OUT-parameter name), so the function node serves as the column element.
+ */
+internal fun jsonTableFunctionAllowsNoAlias(functionName: String): Boolean = functionName == "json_object_keys" || functionName == "jsonb_object_keys"
+
+/**
+ * Fixed output column type of a JSON set-returning function by column position (the types do not
+ * depend on the argument, unlike `generate_series`/`unnest`). `text`, `json` and `jsonb` all map to
+ * Kotlin `String`:
+ *  - `*_object_keys`             -> text
+ *  - `*_array_elements`          -> json
+ *  - `*_array_elements_text`     -> text
+ *  - `json_each` / `jsonb_each`           -> (key text, value json)
+ *  - `json_each_text` / `jsonb_each_text` -> (key text, value text)
+ */
+internal fun jsonTableFunctionRowType(functionName: String, columnIndex: Int): IntermediateType = when (functionName) {
+  "json_object_keys", "jsonb_object_keys" -> IntermediateType(TEXT)
+  "json_array_elements", "jsonb_array_elements" -> IntermediateType(PostgreSqlType.JSON)
+  "json_array_elements_text", "jsonb_array_elements_text" -> IntermediateType(TEXT)
+  "json_each", "jsonb_each" -> if (columnIndex == 0) IntermediateType(TEXT) else IntermediateType(PostgreSqlType.JSON)
+  "json_each_text", "jsonb_each_text" -> IntermediateType(TEXT)
+  else -> error("Unknown json table function $functionName")
+}

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/TableFunctionColumnAliasMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/TableFunctionColumnAliasMixin.kt
@@ -19,13 +19,13 @@ import com.intellij.lang.PsiBuilder
 import com.intellij.psi.util.PsiTreeUtil
 
 /**
- * Resolves the row type of a single table-function output column alias, e.g. the `y` in
+ * Resolves the row type from a single table-function output column alias, e.g. the `y` in
  * `UNNEST(a, b) AS x(y, z)` or the `a` in `generate_series(0, 14, 7) AS s(a)`.
  *
  * The two table functions derive the type differently:
  *  - `unnest`: zip the source column definitions with the alias columns and unwrap the array (`TEXT[]` -> `TEXT`).
- *  - `generate_series`: a single column whose type is computed from the argument expressions (same resolution
- *    as the scalar `generate_series(...)` form).
+ *  - `generate_series`: a single column whose type is resolved from the argument expressions (same resolution
+ *    as the `generate_series(...)` form).
  */
 internal abstract class TableFunctionColumnAliasMixin(
   node: ASTNode,
@@ -46,17 +46,32 @@ internal abstract class TableFunctionColumnAliasMixin(
   }
 
   /**
-   * Return the `SqlTypeName` of the source array column matching this alias node by zipping the source column
-   * definitions and the row alias columns together, e.g. zip these nodes - `UNNEST(a, b) AS x(y, z)`.
+   * Return the array `SqlTypeName` of the UNNEST argument that lines up with this alias node, by zipping the
+   * argument expressions and the row alias columns together, e.g. zip these nodes - `UNNEST(a, b) AS x(y, z)`.
+   *
+   * The argument may be a column reference (`UNNEST(zipcodes)`) whose declared type is an array, or an inline
+   * array-typed expression (`UNNEST(?::TEXT[])`, `UNNEST('{1,2}'::INTEGER[])`) whose type comes from the cast.
    */
-  private fun unnestSourceColumnType(): SqlTypeName = parent.parent.children.filterIsInstance<SqlColumnExpr>()
-    .map { (it.columnName.reference!!.resolve()!!.parent as SqlColumnDef).columnType.typeName }
-    .zip(
-      parent.parent.children.filterIsInstance<PostgreSqlTableFunctionAliasName>()
-        .flatMap { it.children.filterIsInstance<PostgreSqlTableFunctionColumnAlias>() },
-    )
-    .first { it.second.node == node }
-    .first
+  private fun unnestSourceColumnType(): SqlTypeName {
+    val tableOrSubquery = parent.parent
+    val argExprs = tableOrSubquery.children.filterIsInstance<SqlExpr>()
+    val aliasColumns = tableOrSubquery.children.filterIsInstance<PostgreSqlTableFunctionAliasName>()
+      .flatMap { it.children.filterIsInstance<PostgreSqlTableFunctionColumnAlias>() }
+
+    return argExprs.zip(aliasColumns)
+      .first { it.second.node == node }
+      .first
+      .unnestArrayTypeName()
+  }
 
   override val parseRule: (PsiBuilder, Int) -> Boolean = PostgreSqlParser::table_function_column_alias_real
+}
+
+/** The array `SqlTypeName` an UNNEST argument expression contributes. */
+internal fun SqlExpr.unnestArrayTypeName(): SqlTypeName = when (this) {
+  is SqlColumnExpr ->
+    (columnName.reference!!.resolve()!!.parent as SqlColumnDef).columnType.typeName
+  else ->
+    // cast expressions (?::TEXT[], '{1,2}'::INTEGER[], fn()::INTEGER[]) expose the array type after the `::`
+    PsiTreeUtil.findChildrenOfType(this, SqlTypeName::class.java).last()
 }

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/TableFunctionColumnAliasMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/TableFunctionColumnAliasMixin.kt
@@ -1,45 +1,62 @@
 package app.cash.sqldelight.dialects.postgresql.grammar.mixins
 
-import app.cash.sqldelight.dialect.api.TableFunctionRowType
+import app.cash.sqldelight.dialect.api.IntermediateType
+import app.cash.sqldelight.dialect.api.TableFunctionExprRowType
+import app.cash.sqldelight.dialect.api.TypeResolver
+import app.cash.sqldelight.dialects.postgresql.generateSeriesRowType
 import app.cash.sqldelight.dialects.postgresql.grammar.PostgreSqlParser
 import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlTableFunctionAliasName
 import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlTableFunctionColumnAlias
-import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlTypeName
+import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlTableOrSubquery
+import app.cash.sqldelight.dialects.postgresql.unnestRowType
 import com.alecstrong.sql.psi.core.psi.SqlColumnDef
 import com.alecstrong.sql.psi.core.psi.SqlColumnExpr
+import com.alecstrong.sql.psi.core.psi.SqlExpr
 import com.alecstrong.sql.psi.core.psi.SqlNamedElementImpl
 import com.alecstrong.sql.psi.core.psi.SqlTypeName
 import com.intellij.lang.ASTNode
 import com.intellij.lang.PsiBuilder
+import com.intellij.psi.util.PsiTreeUtil
 
 /**
- * Return the columns data types (e.g. TEXT[]) as table row types (e.g. TEXT) by zipping sqldefcolumns and row alias columns together
- * and finding the current node. e.g. zip these nodes - UNNEST(a, b) AS x(y, z).
- * Create a delegate of PostgreSqlTypeName to remove the `[]` from the columnType node so the resolver will create the non-array table row type
+ * Resolves the row type of a single table-function output column alias, e.g. the `y` in
+ * `UNNEST(a, b) AS x(y, z)` or the `a` in `generate_series(0, 14, 7) AS s(a)`.
+ *
+ * The two table functions derive the type differently:
+ *  - `unnest`: zip the source column definitions with the alias columns and unwrap the array (`TEXT[]` -> `TEXT`).
+ *  - `generate_series`: a single column whose type is computed from the argument expressions (same resolution
+ *    as the scalar `generate_series(...)` form).
  */
 internal abstract class TableFunctionColumnAliasMixin(
   node: ASTNode,
 ) : SqlNamedElementImpl(node),
-  TableFunctionRowType {
-  override fun columnType(): SqlTypeName {
-    val column = parent.parent.children.filterIsInstance<SqlColumnExpr>()
-      .map { (it.columnName.reference!!.resolve()!!.parent as SqlColumnDef).columnType.typeName }
-      .zip(
-        parent.parent.children.filterIsInstance<PostgreSqlTableFunctionAliasName>()
-          .flatMap { it.children.filterIsInstance<PostgreSqlTableFunctionColumnAlias>() },
-      )
-      .first { it.second.node == node }
-    return TableRowSqlTypeName(column.first as PostgreSqlTypeName)
+  TableFunctionExprRowType {
+
+  override fun rowType(typeResolver: TypeResolver): IntermediateType {
+    val tableOrSubquery = PsiTreeUtil.getParentOfType(this, PostgreSqlTableOrSubquery::class.java)!!
+    tableOrSubquery.generateSeriesTableFunction?.let {
+      val args = tableOrSubquery.children.filterIsInstance<SqlExpr>()
+      return typeResolver.generateSeriesRowType(args)
+    }
+    tableOrSubquery.jsonTableFunction?.let { jsonFunction ->
+      val columnIndex = parent.children.filterIsInstance<PostgreSqlTableFunctionColumnAlias>().indexOfFirst { it.node == node }
+      return jsonTableFunctionRowType(jsonFunction.name.lowercase(), columnIndex)
+    }
+    return typeResolver.unnestRowType(unnestSourceColumnType())
   }
+
+  /**
+   * Return the `SqlTypeName` of the source array column matching this alias node by zipping the source column
+   * definitions and the row alias columns together, e.g. zip these nodes - `UNNEST(a, b) AS x(y, z)`.
+   */
+  private fun unnestSourceColumnType(): SqlTypeName = parent.parent.children.filterIsInstance<SqlColumnExpr>()
+    .map { (it.columnName.reference!!.resolve()!!.parent as SqlColumnDef).columnType.typeName }
+    .zip(
+      parent.parent.children.filterIsInstance<PostgreSqlTableFunctionAliasName>()
+        .flatMap { it.children.filterIsInstance<PostgreSqlTableFunctionColumnAlias>() },
+    )
+    .first { it.second.node == node }
+    .first
 
   override val parseRule: (PsiBuilder, Int) -> Boolean = PostgreSqlParser::table_function_column_alias_real
-}
-
-/**
- * Delegate that returns single node column type without "[]" for resolving to non-array Intermediate type
- */
-private class TableRowSqlTypeName(private val columnSqlTypeName: PostgreSqlTypeName) : PostgreSqlTypeName by columnSqlTypeName {
-  override fun getNode(): ASTNode {
-    return columnSqlTypeName.node.firstChildNode // take data type and ignore last nodes "[" "]"
-  }
 }

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/TableFunctionNameMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/TableFunctionNameMixin.kt
@@ -1,13 +1,33 @@
 package app.cash.sqldelight.dialects.postgresql.grammar.mixins
 
+import app.cash.sqldelight.dialect.api.IntermediateType
+import app.cash.sqldelight.dialect.api.TableFunctionExprRowType
+import app.cash.sqldelight.dialect.api.TypeResolver
 import app.cash.sqldelight.dialects.postgresql.grammar.PostgreSqlParser
+import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlTableOrSubquery
+import app.cash.sqldelight.dialects.postgresql.unnestRowType
+import com.alecstrong.sql.psi.core.psi.SqlExpr
 import com.alecstrong.sql.psi.core.psi.SqlNamedElementImpl
 import com.intellij.lang.ASTNode
 import com.intellij.lang.PsiBuilder
 
+/**
+ * The `unnest` keyword node when used as a set-returning function in a FROM clause, e.g.
+ * `SELECT u.a FROM UNNEST('{1,2}'::INTEGER[]) AS u(a)`.
+ *
+ * Implements [TableFunctionExprRowType] (like generate_series) so that a standalone UNNEST
+ * observes no underlying table, and so the un-aliased single-column form (`UNNEST(arr) AS r`) can
+ * resolve its element type from the argument.
+ */
 internal abstract class TableFunctionNameMixin(
   node: ASTNode,
-) : SqlNamedElementImpl(node) {
+) : SqlNamedElementImpl(node),
+  TableFunctionExprRowType {
+
+  override fun rowType(typeResolver: TypeResolver): IntermediateType {
+    val arg = (parent as PostgreSqlTableOrSubquery).children.filterIsInstance<SqlExpr>().first()
+    return typeResolver.unnestRowType(arg.unnestArrayTypeName())
+  }
 
   override val parseRule: (builder: PsiBuilder, level: Int) -> Boolean = PostgreSqlParser::unnest_table_function_real
 }

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/TableFunctionTableAliasMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/TableFunctionTableAliasMixin.kt
@@ -13,10 +13,15 @@ internal abstract class TableFunctionTableAliasMixin(
     // `generate_series(...) AS g` / `json_object_keys(...) AS k`: the alias renames the function's
     // single output column, so the alias resolves to the function node whose row type the column
     // type is derived from.
-    PsiTreeUtil.getParentOfType(this, PostgreSqlTableOrSubquery::class.java)?.let { tableOrSubquery ->
-      tableOrSubquery.generateSeriesTableFunction?.let { return it }
-      tableOrSubquery.jsonTableFunction?.let { return it }
+    val tableOrSubquery = PsiTreeUtil.getParentOfType(this, PostgreSqlTableOrSubquery::class.java)
+    tableOrSubquery?.let {
+      it.generateSeriesTableFunction?.let { fn -> return fn }
+      it.jsonTableFunction?.let { fn -> return fn }
     }
-    return (parent.parent.parent as SqlJoinClauseMixin).tablesAvailable(this).map { it.tableName }.first() // TODO fix
+    // `UNNEST(...) AS u(...)`: when the array comes from a sibling table column (e.g. `FROM Business,
+    // UNNEST(zipcodes)`) the alias resolves to that observed table; a standalone `UNNEST('{1,2}'::INT[])`
+    // observes no table, so the alias resolves to the function node like generate_series.
+    return (parent.parent.parent as SqlJoinClauseMixin).tablesAvailable(this).map { it.tableName }.firstOrNull()
+      ?: tableOrSubquery!!.unnestTableFunction!!
   }
 }

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/TableFunctionTableAliasMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/TableFunctionTableAliasMixin.kt
@@ -1,13 +1,22 @@
 package app.cash.sqldelight.dialects.postgresql.grammar.mixins
 
+import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlTableOrSubquery
 import com.alecstrong.sql.psi.core.psi.impl.SqlTableAliasImpl
 import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
 
 internal abstract class TableFunctionTableAliasMixin(
   node: ASTNode,
 ) : SqlTableAliasImpl(node) {
   override fun source(): PsiElement {
+    // `generate_series(...) AS g` / `json_object_keys(...) AS k`: the alias renames the function's
+    // single output column, so the alias resolves to the function node whose row type the column
+    // type is derived from.
+    PsiTreeUtil.getParentOfType(this, PostgreSqlTableOrSubquery::class.java)?.let { tableOrSubquery ->
+      tableOrSubquery.generateSeriesTableFunction?.let { return it }
+      tableOrSubquery.jsonTableFunction?.let { return it }
+    }
     return (parent.parent.parent as SqlJoinClauseMixin).tablesAvailable(this).map { it.tableName }.first() // TODO fix
   }
 }

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/TableOrSubqueryMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/TableOrSubqueryMixin.kt
@@ -45,6 +45,54 @@ internal abstract class TableOrSubqueryMixin(node: ASTNode) :
       }
     }
 
+    if (generateSeriesTableFunction != null) {
+      // generate_series exposes a single output column. Three aliasing forms:
+      //  - `AS s(a)`  : table `s`, column named `a`        e.g. `SELECT s.a FROM generate_series(0, 14, 7) AS s(a)`
+      //  - `AS s`     : the table alias renames the column e.g. `SELECT s FROM generate_series(1, 2, 10) AS s`
+      //  - no alias   : the column is named `generate_series`
+      val tableFunctionAlias = children.filterIsInstance<PostgreSqlTableFunctionAliasName>().firstOrNull()
+
+      if (tableFunctionAlias != null) {
+        val tableName = tableFunctionAlias.children.filterIsInstance<PostgreSqlTableFunctionTableAlias>().single()
+        val aliasColumns = tableFunctionAlias.children.filterIsInstance<PostgreSqlTableFunctionColumnAlias>()
+        val column: PsiElement = aliasColumns.singleOrNull() ?: tableName
+        return@lazy listOf(
+          QueryResult(
+            table = tableName,
+            columns = listOf(QueryElement.QueryColumn(column)),
+          ),
+        )
+      }
+
+      return@lazy listOf(
+        QueryResult(
+          table = generateSeriesTableFunction!!,
+          columns = listOf(QueryElement.QueryColumn(generateSeriesTableFunction!!)),
+        ),
+      )
+    }
+
+    if (jsonTableFunction != null) {
+      // JSON set-returning functions. `*_object_keys` may be un-aliased (column named after the
+      // function); `*_array_elements`/`*_each` require column aliases (enforced in JsonTableFunctionMixin).
+      val tableFunctionAlias = children.filterIsInstance<PostgreSqlTableFunctionAliasName>().firstOrNull()
+
+      if (tableFunctionAlias != null) {
+        val tableName = tableFunctionAlias.children.filterIsInstance<PostgreSqlTableFunctionTableAlias>().single()
+        val aliasColumns = tableFunctionAlias.children.filterIsInstance<PostgreSqlTableFunctionColumnAlias>()
+        val columns =
+          if (aliasColumns.isNotEmpty()) aliasColumns.map { QueryElement.QueryColumn(it) } else listOf(QueryElement.QueryColumn(tableName))
+        return@lazy listOf(QueryResult(table = tableName, columns = columns))
+      }
+
+      return@lazy listOf(
+        QueryResult(
+          table = jsonTableFunction!!,
+          columns = listOf(QueryElement.QueryColumn(jsonTableFunction!!)),
+        ),
+      )
+    }
+
     // Default to parent implementation for non-UNNEST cases
     super.queryExposed()
   }
@@ -74,6 +122,50 @@ internal abstract class TableOrSubqueryMixin(node: ASTNode) :
             columns = listOf(QueryElement.QueryColumn(unnestTableFunction!!)),
           )
         }
+      }
+    }
+
+    if (generateSeriesTableFunction != null) {
+      val tableFunctionAlias = children.filterIsInstance<PostgreSqlTableFunctionAliasName>().firstOrNull()
+
+      if (tableFunctionAlias != null) {
+        val tableName = tableFunctionAlias.children.filterIsInstance<PostgreSqlTableFunctionTableAlias>().single()
+        val aliasColumns = tableFunctionAlias.children.filterIsInstance<PostgreSqlTableFunctionColumnAlias>()
+        val column: PsiElement = aliasColumns.singleOrNull() ?: tableName
+        return super.tablesAvailable(child) + LazyQuery(tableName) {
+          QueryResult(
+            table = tableName,
+            columns = listOf(QueryElement.QueryColumn(column)),
+          )
+        }
+      }
+
+      return super.tablesAvailable(child) + LazyQuery(generateSeriesTableFunction!!) {
+        QueryResult(
+          table = generateSeriesTableFunction!!,
+          columns = listOf(QueryElement.QueryColumn(generateSeriesTableFunction!!)),
+        )
+      }
+    }
+
+    if (jsonTableFunction != null) {
+      val tableFunctionAlias = children.filterIsInstance<PostgreSqlTableFunctionAliasName>().firstOrNull()
+
+      if (tableFunctionAlias != null) {
+        val tableName = tableFunctionAlias.children.filterIsInstance<PostgreSqlTableFunctionTableAlias>().single()
+        val aliasColumns = tableFunctionAlias.children.filterIsInstance<PostgreSqlTableFunctionColumnAlias>()
+        val columns =
+          if (aliasColumns.isNotEmpty()) aliasColumns.map { QueryElement.QueryColumn(it) } else listOf(QueryElement.QueryColumn(tableName))
+        return super.tablesAvailable(child) + LazyQuery(tableName) {
+          QueryResult(table = tableName, columns = columns)
+        }
+      }
+
+      return super.tablesAvailable(child) + LazyQuery(jsonTableFunction!!) {
+        QueryResult(
+          table = jsonTableFunction!!,
+          columns = listOf(QueryElement.QueryColumn(jsonTableFunction!!)),
+        )
       }
     }
 

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/UpdateStmtLimitedMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/UpdateStmtLimitedMixin.kt
@@ -4,6 +4,7 @@ import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlUpdateStmtL
 import com.alecstrong.sql.psi.core.psi.FromQuery
 import com.alecstrong.sql.psi.core.psi.LazyQuery
 import com.alecstrong.sql.psi.core.psi.QueryElement
+import com.alecstrong.sql.psi.core.psi.SqlColumnName
 import com.alecstrong.sql.psi.core.psi.SqlJoinClause
 import com.alecstrong.sql.psi.core.psi.SqlWithClause
 import com.alecstrong.sql.psi.core.psi.SqlWithClauseAuxiliaryStmt
@@ -11,13 +12,18 @@ import com.alecstrong.sql.psi.core.psi.impl.SqlUpdateStmtLimitedImpl
 import com.intellij.lang.ASTNode
 import com.intellij.psi.PsiElement
 
+/**
+ * The left-hand side of a SET assignment targets the table being updated and must only resolve
+ * against it, never against the FROM/join tables. Exposing the FROM columns here lets a `SET col = ...` target
+ * wrongly resolve to a same-named FROM column (e.g. a UNNEST `AS u(a, b)`
+ */
 internal abstract class UpdateStmtLimitedMixin(
   node: ASTNode,
 ) : SqlUpdateStmtLimitedImpl(node),
   PostgreSqlUpdateStmtLimited,
   FromQuery {
   override fun queryAvailable(child: PsiElement): Collection<QueryElement.QueryResult> {
-    if (child != joinClause && joinClause != null) {
+    if (child !is SqlColumnName && child != joinClause && joinClause != null) {
       return super.queryAvailable(child) +
         joinClause!!.queryExposed().map { it.copy(adjacent = true) }
     }

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/generate_series/Test.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/generate_series/Test.s
@@ -1,0 +1,14 @@
+SELECT g
+FROM generate_series(1, 5) AS g;
+
+SELECT g
+FROM generate_series(0, 10, 5) AS g;
+
+SELECT s.a AS dates
+FROM generate_series(0, 14, 7) AS s(a);
+
+SELECT *
+FROM generate_series(?::INTEGER, ?::INTEGER);
+
+SELECT g.t
+FROM generate_series('2024-03-29 00:00:00'::TIMESTAMP, '2024-03-29 03:00:00'::TIMESTAMP, '1 hour'::INTERVAL) AS g(t);

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/json_functions/Test.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/json_functions/Test.s
@@ -89,3 +89,24 @@ SELECT jsonb_agg(t)
 FROM ( SELECT 1 AS id) AS t;
 
 SELECT json_build_object('foo', 1, 2, row(3,'bar'));
+
+SELECT json_object_keys
+FROM json_object_keys('{"a":1,"b":2}');
+
+SELECT json_object_keys
+FROM json_object_keys(?::JSON);
+
+SELECT t
+FROM json_object_keys('{"a":1,"b":2}') AS t;
+
+SELECT t.value
+FROM json_array_elements('[1,2,3]') AS t(value);
+
+SELECT t.value
+FROM json_array_elements_text('["x","y"]') AS t(value);
+
+SELECT t.key, t.value
+FROM json_each('{"a":1,"b":2}') AS t(key, value);
+
+SELECT t.key, t.value
+FROM json_each_text('{"a":1,"b":2}') AS t(key, value);

--- a/sqldelight-compiler/dialect/src/main/kotlin/app/cash/sqldelight/dialect/api/TableFunctionExprRowType.kt
+++ b/sqldelight-compiler/dialect/src/main/kotlin/app/cash/sqldelight/dialect/api/TableFunctionExprRowType.kt
@@ -1,0 +1,12 @@
+package app.cash.sqldelight.dialect.api
+
+import com.alecstrong.sql.psi.core.psi.SqlAnnotatedElement
+/**
+ * A table function (set-returning function) whose output column type is resolved to an
+ * IntermediateType, e.g. PostgreSQL `unnest(...)` (the array element type of  source column) or
+ * `generate_series(...)` . The TypeResolver is supplied by the caller so dialect mixins can resolve types without
+ * needing access into the compiler core api.
+ */
+interface TableFunctionExprRowType : SqlAnnotatedElement {
+  fun rowType(typeResolver: TypeResolver): IntermediateType
+}

--- a/sqldelight-compiler/dialect/src/main/kotlin/app/cash/sqldelight/dialect/api/TableFunctionRowType.kt
+++ b/sqldelight-compiler/dialect/src/main/kotlin/app/cash/sqldelight/dialect/api/TableFunctionRowType.kt
@@ -1,8 +1,0 @@
-package app.cash.sqldelight.dialect.api
-
-import com.alecstrong.sql.psi.core.psi.SqlAnnotatedElement
-import com.alecstrong.sql.psi.core.psi.SqlTypeName
-
-interface TableFunctionRowType : SqlAnnotatedElement {
-  fun columnType(): SqlTypeName
-}

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/model/NamedQuery.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/model/NamedQuery.kt
@@ -40,6 +40,7 @@ import app.cash.sqldelight.dialect.api.PrimitiveType.REAL
 import app.cash.sqldelight.dialect.api.PrimitiveType.TEXT
 import app.cash.sqldelight.dialect.api.QueryWithResults
 import app.cash.sqldelight.dialect.api.SelectQueryable
+import app.cash.sqldelight.dialect.api.TableFunctionExprRowType
 import com.alecstrong.sql.psi.core.psi.NamedElement
 import com.alecstrong.sql.psi.core.psi.QueryElement
 import com.alecstrong.sql.psi.core.psi.SqlCompoundSelectStmt
@@ -227,6 +228,7 @@ data class NamedQuery(
   }
 
   private fun PsiElement.functionName() = when (this) {
+    is TableFunctionExprRowType -> allocateName(this as NamedElement).lowercase()
     is NamedElement -> allocateName(this)
     is SqlExpr -> name
     is SqlPragmaName -> text

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/SelectStmtUtil.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/SelectStmtUtil.kt
@@ -1,6 +1,7 @@
 package app.cash.sqldelight.core.lang.util
 
 import app.cash.sqldelight.core.lang.util.TableNameElement.CreateTableName
+import app.cash.sqldelight.dialect.api.TableFunctionExprRowType
 import com.alecstrong.sql.psi.core.psi.NamedElement
 import com.alecstrong.sql.psi.core.psi.SqlCompoundSelectStmt
 import com.alecstrong.sql.psi.core.psi.SqlCreateTableStmt
@@ -33,6 +34,7 @@ internal fun PsiElement.referencedTables(
   compoundSelectStmt: SqlCompoundSelectStmt? = null,
 ): List<TableNameElement> = when (this) {
   is SqlCompoundSelectStmt -> tablesObserved()
+  is TableFunctionExprRowType -> emptyList() // Set/Table returning functions observe no underlying table
   is SqlTableAlias -> source().referencedTables()
   is SqlNewTableName -> {
     listOf(TableNameElement.NewTableName(this))

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/TreeUtil.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/TreeUtil.kt
@@ -224,7 +224,7 @@ private fun PsiElement.selectStarExpansions(resultColumns: SqlResultColumn): Lis
 
         buildString {
           if (query.table != null) {
-            append("${query.table!!.node.text}.")
+            append("${query.table!!.starExpansionLowerCaseName()}.")
           } else {
             val definition = columnElement.reference?.resolve()
             if (definition?.parent is SqlCreateViewStmt) {
@@ -233,12 +233,14 @@ private fun PsiElement.selectStarExpansions(resultColumns: SqlResultColumn): Lis
               append("${(definition.parent.parent as SqlCreateTableStmt).tableName.node.text}.")
             }
           }
-          append(columnElement.node.text)
+          append(columnElement.starExpansionLowerCaseName())
         }
       }
     }.joinToString(separator = ", "),
   )
 }
+
+private fun PsiElement.starExpansionLowerCaseName(): String = if (this is TableFunctionExprRowType) node.text.lowercase() else node.text
 
 private operator fun IntRange.minus(amount: Int): IntRange {
   return IntRange(start - amount, endInclusive - amount)

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/TreeUtil.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/TreeUtil.kt
@@ -28,7 +28,7 @@ import app.cash.sqldelight.dialect.api.PrimitiveType
 import app.cash.sqldelight.dialect.api.PrimitiveType.INTEGER
 import app.cash.sqldelight.dialect.api.PrimitiveType.REAL
 import app.cash.sqldelight.dialect.api.PrimitiveType.TEXT
-import app.cash.sqldelight.dialect.api.TableFunctionRowType
+import app.cash.sqldelight.dialect.api.TableFunctionExprRowType
 import app.cash.sqldelight.dialect.grammar.mixins.BindParameterMixin
 import com.alecstrong.sql.psi.core.psi.AliasElement
 import com.alecstrong.sql.psi.core.psi.NamedElement
@@ -88,7 +88,7 @@ internal fun PsiElement.type(): IntermediateType = when (this) {
       }
     }
   }
-  is TableFunctionRowType -> (sqFile().typeResolver.definitionType(columnType()).asNullable())
+  is TableFunctionExprRowType -> rowType(sqFile().typeResolver)
   is SqlExpr -> sqFile().typeResolver.resolvedType(this)
   is SqlResultColumn -> sqFile().typeResolver.resolvedType(expr!!)
   else -> throw IllegalStateException("Cannot get function type for psi type ${this.javaClass}")

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/InterfaceGeneration.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/InterfaceGeneration.kt
@@ -1692,6 +1692,205 @@ class InterfaceGeneration {
   }
 
   @Test
+  fun `postgres generate_series as a set returning function in from clause`() {
+    val file = FixtureCompiler.parseSql(
+      """
+        |seriesAliased:
+        |SELECT g
+        |FROM generate_series(1, 2, 10) AS g;
+        |
+        |seriesColumnAliased:
+        |SELECT s.a AS dates
+        |FROM generate_series(0, 14, 7) AS s(a);
+        |
+        |seriesNoAlias:
+        |SELECT *
+        |FROM generate_series(1, 10);
+        |
+        |seriesTimestamp:
+        |SELECT g
+        |FROM generate_series('2024-03-29 00:00:00'::TIMESTAMP, '2024-03-29 23:00:00'::TIMESTAMP, '1 hour'::INTERVAL) AS g;
+      """.trimMargin(),
+      temporaryFolder,
+      fileName = "GenerateSeries.sq",
+      dialect = PostgreSqlDialect(),
+    )
+
+    val (aliased, columnAliased, noAlias, timestamp) = file.namedQueries
+
+    assertThat(QueryInterfaceGenerator(aliased).kotlinImplementationSpec().toString()).isEqualTo(
+      """
+      |public data class SeriesAliased(
+      |  public val g: kotlin.Int,
+      |)
+      |
+      """.trimMargin(),
+    )
+
+    assertThat(QueryInterfaceGenerator(columnAliased).kotlinImplementationSpec().toString()).isEqualTo(
+      """
+      |public data class SeriesColumnAliased(
+      |  public val dates: kotlin.Int,
+      |)
+      |
+      """.trimMargin(),
+    )
+
+    assertThat(QueryInterfaceGenerator(noAlias).kotlinImplementationSpec().toString()).isEqualTo(
+      """
+      |public data class SeriesNoAlias(
+      |  public val generate_series: kotlin.Int,
+      |)
+      |
+      """.trimMargin(),
+    )
+
+    assertThat(QueryInterfaceGenerator(timestamp).kotlinImplementationSpec().toString()).isEqualTo(
+      """
+      |public data class SeriesTimestamp(
+      |  public val g: java.time.LocalDateTime,
+      |)
+      |
+      """.trimMargin(),
+    )
+  }
+
+  @Test
+  fun `postgres unnest set returning function row types resolve from the source array column`() {
+    val file = FixtureCompiler.parseSql(
+      """
+        |CREATE TABLE Business(
+        |  id SERIAL PRIMARY KEY,
+        |  name TEXT NOT NULL,
+        |  zipcodes TEXT[] NOT NULL,
+        |  headcounts INTEGER[] NOT NULL
+        |);
+        |
+        |selectBusinesses:
+        |SELECT name, location.headcount, location.zipcode
+        |FROM Business, UNNEST(zipcodes, headcounts) AS location(zipcode, headcount);
+      """.trimMargin(),
+      temporaryFolder,
+      fileName = "Unnest.sq",
+      dialect = PostgreSqlDialect(),
+    )
+
+    val query = file.namedQueries.single()
+
+    // The unnest columns unwrap the source `TEXT[]` / `INTEGER[]` element types to nullable TEXT / INTEGER.
+    assertThat(QueryInterfaceGenerator(query).kotlinImplementationSpec().toString()).isEqualTo(
+      """
+      |public data class SelectBusinesses(
+      |  public val name: kotlin.String,
+      |  public val headcount: kotlin.Int?,
+      |  public val zipcode: kotlin.String?,
+      |)
+      |
+      """.trimMargin(),
+    )
+  }
+
+  @Test
+  fun `postgres json set returning functions expose fixed String columns`() {
+    val file = FixtureCompiler.parseSql(
+      """
+        |objectKeys:
+        |SELECT json_object_keys
+        |FROM json_object_keys('{"a":1,"b":2}');
+        |
+        |arrayElements:
+        |SELECT t.value
+        |FROM json_array_elements('[1,2,3]') AS t(value);
+        |
+        |arrayElementsText:
+        |SELECT t.value
+        |FROM json_array_elements_text('["x","y"]') AS t(value);
+        |
+        |each:
+        |SELECT t.key, t.value
+        |FROM json_each('{"a":1}') AS t(key, value);
+        |
+        |eachText:
+        |SELECT t.key, t.value
+        |FROM json_each_text('{"a":1}') AS t(key, value);
+      """.trimMargin(),
+      temporaryFolder,
+      fileName = "JsonFunctions.sq",
+      dialect = PostgreSqlDialect(),
+    )
+
+    val (objectKeys, arrayElements, arrayElementsText, each, eachText) = file.namedQueries
+
+    // object_keys: un-aliased; the column is named after the function (no OUT parameter in Postgres).
+    assertThat(QueryInterfaceGenerator(objectKeys).kotlinImplementationSpec().toString()).isEqualTo(
+      """
+      |public data class ObjectKeys(
+      |  public val json_object_keys: kotlin.String,
+      |)
+      |
+      """.trimMargin(),
+    )
+
+    // array_elements: column aliased `value` (json -> String).
+    assertThat(QueryInterfaceGenerator(arrayElements).kotlinImplementationSpec().toString()).isEqualTo(
+      """
+      |public data class ArrayElements(
+      |  public val value_: kotlin.String,
+      |)
+      |
+      """.trimMargin(),
+    )
+
+    // array_elements_text: column aliased `value` (text -> String).
+    assertThat(QueryInterfaceGenerator(arrayElementsText).kotlinImplementationSpec().toString()).isEqualTo(
+      """
+      |public data class ArrayElementsText(
+      |  public val value_: kotlin.String,
+      |)
+      |
+      """.trimMargin(),
+    )
+
+    // json_each: columns aliased `key`, `value` (text, json -> String).
+    assertThat(QueryInterfaceGenerator(each).kotlinImplementationSpec().toString()).isEqualTo(
+      """
+      |public data class Each(
+      |  public val key: kotlin.String,
+      |  public val value_: kotlin.String,
+      |)
+      |
+      """.trimMargin(),
+    )
+
+    // json_each_text: columns aliased `key`, `value` (text, text -> String).
+    assertThat(QueryInterfaceGenerator(eachText).kotlinImplementationSpec().toString()).isEqualTo(
+      """
+      |public data class EachText(
+      |  public val key: kotlin.String,
+      |  public val value_: kotlin.String,
+      |)
+      |
+      """.trimMargin(),
+    )
+  }
+
+  @Test
+  fun `postgres json_each without column aliases is an error`() {
+    val result = FixtureCompiler.compileSql(
+      """
+        |eachNoAlias:
+        |SELECT *
+        |FROM json_each('{"a":1}');
+      """.trimMargin(),
+      temporaryFolder,
+      fileName = "JsonEachError.sq",
+      overrideDialect = PostgreSqlDialect(),
+    )
+
+    assertThat(result.errors.any { "requires 2 column aliases" in it }).isTrue()
+  }
+
+  @Test
   fun `postgres using numeric window function returns BigDecimal`() {
     val file = FixtureCompiler.parseSql(
       """

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/SelectQueryTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/SelectQueryTypeTest.kt
@@ -53,6 +53,59 @@ class SelectQueryTypeTest {
     )
   }
 
+  @Test fun `unnest of an array literal cast resolves the row type from the cast - postgres`() {
+    val file = FixtureCompiler.parseSql(
+      """
+      |selectUnnest:
+      |SELECT u.a
+      |FROM UNNEST('{1,2}'::INTEGER[]) AS u(a);
+      |
+      """.trimMargin(),
+      tempFolder,
+      dialect = PostgreSqlDialect(),
+    )
+
+    val query = file.namedQueries.first()
+    val generator = SelectQueryGenerator(query)
+
+    // The unnest column unwraps the INTEGER[] cast to a nullable INTEGER, and observes no underlying table.
+    assertThat(generator.customResultTypeFunction().toString()).isEqualTo(
+      """
+      |public fun <T : kotlin.Any> selectUnnest(mapper: (a: kotlin.Int?) -> T): app.cash.sqldelight.ExecutableQuery<T> = app.cash.sqldelight.Query(${query.id.withUnderscores}, driver, "Test.sq", "selectUnnest", ""${'"'}
+      ||SELECT u.a
+      ||FROM UNNEST('{1,2}'::INTEGER[]) AS u(a)
+      |""${'"'}.trimMargin()) { cursor ->
+      |  check(cursor is app.cash.sqldelight.driver.jdbc.JdbcCursor)
+      |  mapper(
+      |    cursor.getInt(0)
+      |  )
+      |}
+      |
+      """.trimMargin(),
+    )
+  }
+
+  @Test fun `unnest of multiple array cast bind args resolves the row types from the casts - postgres`() {
+    val file = FixtureCompiler.parseSql(
+      """
+      |selectUnnestPairs:
+      |SELECT u.name, u.age
+      |FROM UNNEST(?::TEXT[], ?::INTEGER[]) AS u(name, age);
+      |
+      """.trimMargin(),
+      tempFolder,
+      dialect = PostgreSqlDialect(),
+    )
+
+    val query = file.namedQueries.first()
+    val generator = SelectQueryGenerator(query)
+
+    // The unnest columns unwrap the TEXT[] / INTEGER[] casts to nullable TEXT / INTEGER.
+    assertThat(generator.customResultTypeFunction().toString()).contains(
+      "mapper: (name: kotlin.String?, age: kotlin.Int?)",
+    )
+  }
+
   @Test fun `json_each set returning function with column aliases generates a query function - postgres`() {
     val file = FixtureCompiler.parseSql(
       """

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/SelectQueryTypeTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/SelectQueryTypeTest.kt
@@ -23,6 +23,69 @@ import org.junit.runner.RunWith
 class SelectQueryTypeTest {
   @get:Rule val tempFolder = TemporaryFolder()
 
+  @Test fun `generate_series set returning function with column alias generates a query function - postgres`() {
+    val file = FixtureCompiler.parseSql(
+      """
+      |selectSeries:
+      |SELECT s.a AS dates
+      |FROM generate_series(0, 14, 7) AS s(a);
+      |
+      """.trimMargin(),
+      tempFolder,
+      dialect = PostgreSqlDialect(),
+    )
+
+    val query = file.namedQueries.first()
+    val generator = SelectQueryGenerator(query)
+
+    // generate_series observes no underlying table, so the query is an ExecutableQuery with no notifyQueries block.
+    assertThat(generator.customResultTypeFunction().toString()).isEqualTo(
+      """
+      |public fun selectSeries(): app.cash.sqldelight.ExecutableQuery<kotlin.Int> = app.cash.sqldelight.Query(${query.id.withUnderscores}, driver, "Test.sq", "selectSeries", ""${'"'}
+      ||SELECT s.a AS dates
+      ||FROM generate_series(0, 14, 7) AS s(a)
+      |""${'"'}.trimMargin()) { cursor ->
+      |  check(cursor is app.cash.sqldelight.driver.jdbc.JdbcCursor)
+      |  cursor.getInt(0)!!
+      |}
+      |
+      """.trimMargin(),
+    )
+  }
+
+  @Test fun `json_each set returning function with column aliases generates a query function - postgres`() {
+    val file = FixtureCompiler.parseSql(
+      """
+      |selectEach:
+      |SELECT t.key, t.value
+      |FROM json_each('{"a":1}') AS t(key, value);
+      |
+      """.trimMargin(),
+      tempFolder,
+      dialect = PostgreSqlDialect(),
+    )
+
+    val query = file.namedQueries.first()
+    val generator = SelectQueryGenerator(query)
+
+    // json_each observes no underlying table, so the query is an ExecutableQuery with no notifyQueries block.
+    assertThat(generator.customResultTypeFunction().toString()).isEqualTo(
+      """
+      |public fun <T : kotlin.Any> selectEach(mapper: (key: kotlin.String, value_: kotlin.String) -> T): app.cash.sqldelight.ExecutableQuery<T> = app.cash.sqldelight.Query(${query.id.withUnderscores}, driver, "Test.sq", "selectEach", ""${'"'}
+      ||SELECT t.key, t.value
+      ||FROM json_each('{"a":1}') AS t(key, value)
+      |""${'"'}.trimMargin()) { cursor ->
+      |  check(cursor is app.cash.sqldelight.driver.jdbc.JdbcCursor)
+      |  mapper(
+      |    cursor.getString(0)!!,
+      |    cursor.getString(1)!!
+      |  )
+      |}
+      |
+      """.trimMargin(),
+    )
+  }
+
   @Test fun `returning clause correctly generates a query function`(dialect: TestDialect) {
     assumeTrue(dialect in listOf(TestDialect.POSTGRESQL, TestDialect.SQLITE_3_35))
     val file = FixtureCompiler.parseSql(

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/GenerateSeries.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/GenerateSeries.sq
@@ -1,0 +1,19 @@
+selectSeriesInt:
+SELECT g
+FROM generate_series(1, 5) AS g;
+
+selectSeriesStep:
+SELECT g
+FROM generate_series(0, 10, 5) AS g;
+
+selectSeriesColumnAlias:
+SELECT s.a AS dates
+FROM generate_series(0, 14, 7) AS s(a);
+
+selectSeriesNoAlias:
+SELECT *
+FROM generate_series(1, 3);
+
+selectSeriesTimestamp:
+SELECT g
+FROM generate_series('2024-03-29 00:00:00'::TIMESTAMP, '2024-03-29 03:00:00'::TIMESTAMP, '1 hour'::INTERVAL) AS g;

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/JsonFunctions.sq
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/main/sqldelight/app/cash/sqldelight/postgresql/integration/JsonFunctions.sq
@@ -1,0 +1,19 @@
+selectObjectKeys:
+SELECT json_object_keys
+FROM json_object_keys('{"a":1,"b":2}');
+
+selectArrayElements:
+SELECT t.value
+FROM json_array_elements('[1,2,3]') AS t(value);
+
+selectArrayElementsText:
+SELECT t.value
+FROM json_array_elements_text('["x","y"]') AS t(value);
+
+selectEach:
+SELECT t.key, t.value
+FROM json_each('{"a":1,"b":2}') AS t(key, value);
+
+selectEachText:
+SELECT t.key, t.value
+FROM json_each_text('{"a":1,"b":2}') AS t(key, value);

--- a/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
+++ b/sqldelight-gradle-plugin/src/test/integration-postgresql/src/test/kotlin/app/cash/sqldelight/postgresql/integration/PostgreSqlTest.kt
@@ -1314,6 +1314,73 @@ class PostgreSqlTest {
   }
 
   @Test
+  fun testGenerateSeriesInt() {
+    assertThat(database.generateSeriesQueries.selectSeriesInt().executeAsList())
+      .containsExactly(1, 2, 3, 4, 5).inOrder()
+  }
+
+  @Test
+  fun testGenerateSeriesStep() {
+    assertThat(database.generateSeriesQueries.selectSeriesStep().executeAsList())
+      .containsExactly(0, 5, 10).inOrder()
+  }
+
+  @Test
+  fun testGenerateSeriesColumnAlias() {
+    assertThat(database.generateSeriesQueries.selectSeriesColumnAlias().executeAsList())
+      .containsExactly(0, 7, 14).inOrder()
+  }
+
+  @Test
+  fun testGenerateSeriesNoAlias() {
+    assertThat(database.generateSeriesQueries.selectSeriesNoAlias().executeAsList())
+      .containsExactly(1, 2, 3).inOrder()
+  }
+
+  @Test
+  fun testJsonObjectKeys() {
+    assertThat(database.jsonFunctionsQueries.selectObjectKeys().executeAsList())
+      .containsExactly("a", "b").inOrder()
+  }
+
+  @Test
+  fun testJsonArrayElements() {
+    assertThat(database.jsonFunctionsQueries.selectArrayElements().executeAsList())
+      .containsExactly("1", "2", "3").inOrder()
+  }
+
+  @Test
+  fun testJsonArrayElementsText() {
+    assertThat(database.jsonFunctionsQueries.selectArrayElementsText().executeAsList())
+      .containsExactly("x", "y").inOrder()
+  }
+
+  @Test
+  fun testJsonEach() {
+    with(database.jsonFunctionsQueries.selectEach().executeAsList()) {
+      assertThat(map { it.key }).containsExactly("a", "b").inOrder()
+      assertThat(map { it.value_ }).containsExactly("1", "2").inOrder()
+    }
+  }
+
+  @Test
+  fun testJsonEachText() {
+    with(database.jsonFunctionsQueries.selectEachText().executeAsList()) {
+      assertThat(map { it.key }).containsExactly("a", "b").inOrder()
+      assertThat(map { it.value_ }).containsExactly("1", "2").inOrder()
+    }
+  }
+
+  @Test
+  fun testGenerateSeriesTimestamp() {
+    with(database.generateSeriesQueries.selectSeriesTimestamp().executeAsList()) {
+      assertThat(this).hasSize(4)
+      assertThat(first()).isEqualTo(LocalDateTime.of(2024, 3, 29, 0, 0))
+      assertThat(last()).isEqualTo(LocalDateTime.of(2024, 3, 29, 3, 0))
+    }
+  }
+
+  @Test
   fun testJsonChecks() {
     database.jsonQueries.insertTestJsonCheck()
     with(database.jsonQueries.selectJsonChecks().executeAsList()) {


### PR DESCRIPTION
🧷 Improve support for set/table returning functions using `FROM ...`
🐘 Most of the changes are in PostgreSql dialect. 

``` sql
SELECT r.a, r.b
FROM UNNEST(?::TEXT[], ?::INTEGER[]) AS r(a, b); -- use explicit column aliases

UPDATE P
SET b = u.b
FROM UNNEST(?::TEXT[], ?::INTEGER[]) AS u(a, b) -- fixes alias name if same as table column name
WHERE P.a = u.a;

SELECT *
FROM GENERATE_SERIES(?::INTEGER, ?::INTEGER); -- could also use BIGINT, NUMERIC or TIMESTAMP/TZ

SELECT g1, g2
FROM GENERATE_SERIES(1, 4) AS g1
CROSS JOIN [LATERAL] GENERATE_SERIES(1, g1) AS g2; -- now supports multiple iterators

INSERT INTO X(timestampz)
SELECT * FROM GENERATE_SERIES(
    '2024-01-01'::TIMESTAMPTZ,
    '2024-12-31'::TIMESTAMPTZ,
    '1 day'::INTERVAL
)
RETURNING *;

SELECT t.key, t.value
FROM JSON_EACH('{"a":1,"b":2}') AS t(key, value); -- use explicit column aliases
```

* Updates `unnest` table returning to use new `TableFunctionExprRowType`
  * So it can use the TypeResolver instead of a column type hack 
  * fixes update statement using unnest alias with same column name 
* Adds `unnest` set/table returning can now be used in `FROM unnest()`
* Adds `generate_series` set returning can now be used in `FROM generate_series()`
* Adds various Json functions both table or set returning
  * function names and return types have to be encoded in the mixin
  * https://www.postgresql.org/docs/current/functions-json.html#FUNCTIONS-JSON-PROCESSING-TABLE 
* Removes `TableFunctionRowType.kt` and replaced with `TableFunctionExprRowType` to allow use with TypeResolver.
  * Ensures table function column names are lowercased
* Adds more tests due to json functions and aliases (Fixture tests, Interface tests, Integration tests)

Note:

The table returning functions must use column aliases as this allows the compiler to infer result columns. Because normal tables have predefined column defs, it's difficult in the compiler to resolve column types unless there are equivalent node elements to parse (Using the existing `synthesizedColumns` types  are not flexible enough)
e.g `SELECT t.key, t.value FROM json_each_text('{"a":1,"b":2}') AS t(key, value)`; 

Using `SELECT json_each(...)` is not supported as it returns a `record`

Bind args must be `::` cast as the compiler cannot infer the input argument.
e.g `generate_series` had overloads for INTEGER, BIGINT, NUMERIC or TIMESTAMP/TZ  calling `generate_series(?, ?, ?)` results in `... argument cannot be inferred, use CAST instead`.

TODO:

More testing to see if extensions modules such as https://github.com/griffio/sqldelight-pghttp-module-app can be supported with this implementation.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
