### PR TITLE
Fix missing type adapter arguments using bind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - [Gradle Plugin] Fix IDE sync crash when the plugin is applied without configuring any databases (#6088)
 - [PostgreSQL Dialect] Fix json aggregate functions when using nested function call (#6281 by @griffio)
 - [Paging3 Extension] Fix KeyedQueryPagingSource crash on empty database (#6284 by @woods-marshes)
+- [Compiler] Fix java type adapter issue when mutator statements are used with encapsulating functions like COALESCE (#6292 by @griffio)
 
 ## [2.3.2] - 2026-03-16
 [2.3.2]: https://github.com/sqldelight/sqldelight/releases/tag/2.3.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@
 - [Gradle Plugin] Fix IDE sync crash when the plugin is applied without configuring any databases (#6088)
 - [PostgreSQL Dialect] Fix json aggregate functions when using nested function call (#6281 by @griffio)
 - [Paging3 Extension] Fix KeyedQueryPagingSource crash on empty database (#6284 by @woods-marshes)
-- [Compiler] Fix java type adapter issue when mutator statements are used with encapsulating functions like COALESCE (#6292 by @griffio)
+- [Compiler] Fix Java type adapter issue when mutator statements are used with encapsulating functions like `COALESCE` (#6292 by @griffio)
 
 ## [2.3.2] - 2026-03-16
 [2.3.2]: https://github.com/sqldelight/sqldelight/releases/tag/2.3.2

--- a/sqldelight-compiler/dialect/src/main/kotlin/app/cash/sqldelight/dialect/api/TypeResolver.kt
+++ b/sqldelight-compiler/dialect/src/main/kotlin/app/cash/sqldelight/dialect/api/TypeResolver.kt
@@ -74,7 +74,16 @@ fun TypeResolver.encapsulatingType(
     }
     val otherFunctionParameters = sqlTypes.distinct() - PrimitiveType.ARGUMENT
     if (otherFunctionParameters.size == 1) {
-      return IntermediateType(otherFunctionParameters.single())
+      val nonArgumentTypes = types.filter { it.dialectType != PrimitiveType.ARGUMENT }
+      val first = nonArgumentTypes.first()
+      val customType = first.javaType.copy(nullable = false)
+      val hasCustomType = customType != first.dialectType.javaType.copy(nullable = false)
+      val homogeneous = nonArgumentTypes.all { it.javaType.copy(nullable = false) == customType }
+      return if (hasCustomType && homogeneous) {
+        first.asNonNullable()
+      } else {
+        IntermediateType(otherFunctionParameters.single())
+      }
     }
     throw AnnotationException("The Kotlin type of the argument cannot be inferred, use CAST instead.", exprList.first())
   }

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/MutatorQueryFunctionTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/MutatorQueryFunctionTest.kt
@@ -482,6 +482,33 @@ class MutatorQueryFunctionTest {
     )
   }
 
+  @Test fun `coalesce in update uses custom type for bind argument`(dialect: TestDialect) {
+    val file = FixtureCompiler.parseSql(
+      """
+      |CREATE TABLE data (
+      |  id INTEGER PRIMARY KEY,
+      |  value ${dialect.textType} AS kotlin.collections.List
+      |);
+      |
+      |updateData:
+      |UPDATE data
+      |SET value = COALESCE(:newValue, value)
+      |WHERE id = :id;
+      """.trimMargin(),
+      tempFolder,
+      dialect = dialect.dialect,
+    )
+
+    val update = file.namedMutators.first()
+    val generator = MutatorQueryGenerator(update)
+
+    val function = generator.function().toString()
+    assertThat(function).contains("public fun updateData(newValue: kotlin.collections.List?,")
+    assertThat(function).contains(
+      "bindString(parameterIndex++, newValue?.let { data_Adapter.value_Adapter.encode(it) })",
+    )
+  }
+
   @Test fun `bind parameter inside inner select gets proper type`() {
     val file = FixtureCompiler.parseSql(
       """


### PR DESCRIPTION
fixes #5363

Affects all dialects in `TypeResolver.encapsulatingType` the javaType was being discarded.

With the table schema using java types:

```sql
CREATE TABLE nodes(
  node_id TEXT AS NodeId PRIMARY KEY NOT NULL,
  latitude FLOAT AS Latitude NOT NULL,
  longitude FLOAT AS Longitude NOT NULL
);
```

The generated query interface must expose the java types  as bind parameters:

```kotlin
public fun updateNode(
    latitude: Latitude?,
    longitude: Longitude?,
    node_id: NodeId,
  ): QueryResult<Long> {
    val result = driver.execute(-708_918_196, """
        |UPDATE nodes
        |SET
        |    latitude = COALESCE(?, latitude),
        |    longitude = COALESCE(?, longitude)
        |WHERE node_id = ?
        """.trimMargin(), 3) {
          check(this is JdbcPreparedStatement)
          var parameterIndex = 0
          bindDouble(parameterIndex++, latitude?.let { nodesAdapter.latitudeAdapter.encode(it) })
          bindDouble(parameterIndex++, longitude?.let { nodesAdapter.longitudeAdapter.encode(it) })
          bindString(parameterIndex++, nodesAdapter.node_idAdapter.encode(node_id))
        }
    notifyQueries(-708_918_196) { emit ->
      emit("nodes")
    }
    return result
  }
```

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
