### PR TITLE
Support PostgreSql dialect trigger RAISE statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [Compiler] Add `allTableNames` function to schema (#6245 by @edenman)
 - [PostgreSQL Dialect] Add support for ANY operator (#6253 by @griffio)
 - [SQLite Dialect] Add SQLite 3.39 support RIGHT JOIN and FULL JOIN (#6273 by @griffio)
+- [PostgreSQL Dialect] Add support for `RAISE` statement in trigger functions (#6297 by @griffio)
 
 ### Changed
 - [PostgreSQL Dialect] Change arrayIntermediateType visibility to public (#5835 by @griffio)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - [Compiler] Add `allTableNames` function to schema (#6245 by @edenman)
 - [PostgreSQL Dialect] Add support for ANY operator (#6253 by @griffio)
 - [SQLite Dialect] Add SQLite 3.39 support RIGHT JOIN and FULL JOIN (#6273 by @griffio)
-- [PostgreSQL Dialect] Add support for `RAISE` statement in trigger functions (#6297 by @griffio)
+- [PostgreSQL Dialect] Add support for `RAISE` statement and `FOUND` variable in trigger functions (#6297 by @griffio)
 
 ### Changed
 - [PostgreSQL Dialect] Change arrayIntermediateType visibility to public (#5835 by @griffio)

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -591,7 +591,7 @@ compound_select_stmt ::= [ {with_clause} ] {select_stmt}  ( {compound_operator} 
   override = true
 }
 
-extension_expr ::= any_operator_expr | geometry_setsrid_function_stmt | geometry_point_function_stmt | json_object_agg_stmt | json_agg_stmt | plsql_trigger_var_expression | is_json_expression | overlaps_operator_expression | range_operator_expression | extract_temporal_expression | double_colon_cast_operator_expression | array_value_expression | contains_operator_expression | at_time_zone_operator_expression | regex_match_operator_expression | match_operator_expression | json_function_stmt | array_agg_stmt| string_agg_stmt | json_expression | exists_operator_expression | boolean_not_expression | window_function_expr {
+extension_expr ::= any_operator_expr | geometry_setsrid_function_stmt | geometry_point_function_stmt | json_object_agg_stmt | json_agg_stmt | plsql_trigger_var_expression | plsql_found_expression | is_json_expression | overlaps_operator_expression | range_operator_expression | extract_temporal_expression | double_colon_cast_operator_expression | array_value_expression | contains_operator_expression | at_time_zone_operator_expression | regex_match_operator_expression | match_operator_expression | json_function_stmt | array_agg_stmt| string_agg_stmt | json_expression | exists_operator_expression | boolean_not_expression | window_function_expr {
   extends = "com.alecstrong.sql.psi.core.psi.impl.SqlExtensionExprImpl"
   implements = "com.alecstrong.sql.psi.core.psi.SqlExtensionExpr"
   override = true
@@ -634,7 +634,7 @@ frame_spec ::= ( 'RANGE' | 'ROWS' | 'GROUPS' )
   pin = 1
 }
 
-boolean_not_expression ::= NOT ( {function_expr} | boolean_literal | {column_name} )
+boolean_not_expression ::= NOT ( {function_expr} | boolean_literal | plsql_found_expression | {column_name} )
 
 boolean_literal ::= TRUE | FALSE
 
@@ -915,7 +915,8 @@ drop_trigger_stmt ::= DROP TRIGGER [ IF EXISTS ] [ database_name DOT ] {trigger_
  override = true
 }
 
-plsql_trigger_var_expression ::= 'TG_OP' | 'TG_WHEN' | 'TG_LEVEL' | 'TG_OP' | 'TG_RELID' | 'TG_TABLE_NAME' | 'TG_TABLE_SCHEMA' |
+plsql_trigger_var_expression ::= 'TG_OP' | 'TG_WHEN' | 'TG_LEVEL' | 'TG_RELID' | 'TG_TABLE_NAME' | 'TG_TABLE_SCHEMA'
+plsql_found_expression ::= 'FOUND'
 
 plsql_assignment ::= {column_expr} ':=' <<expr '-1'>>
 plsql_conditional ::= IF <<expr '-1'>> 'THEN' plsql_statement [ ( 'ELSIF' <<expr '-1'>> 'THEN' plsql_statement ) * ] [ 'ELSE' plsql_statement ] END IF

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -920,7 +920,9 @@ plsql_trigger_var_expression ::= 'TG_OP' | 'TG_WHEN' | 'TG_LEVEL' | 'TG_OP' | 'T
 plsql_assignment ::= {column_expr} ':=' <<expr '-1'>>
 plsql_conditional ::= IF <<expr '-1'>> 'THEN' plsql_statement [ ( 'ELSIF' <<expr '-1'>> 'THEN' plsql_statement ) * ] [ 'ELSE' plsql_statement ] END IF
 plsql_return ::= 'RETURN' ( 'NEW' | 'OLD' | NULL )
-plsql_statement ::= ( plsql_return SEMI | plsql_conditional SEMI | plsql_assignment SEMI | delete_stmt_limited SEMI | insert_stmt SEMI | update_stmt_limited SEMI ) *
+plsql_raise_level ::= 'EXCEPTION' | 'WARNING' | 'NOTICE'
+plsql_raise ::= 'RAISE' plsql_raise_level string_literal ( COMMA <<expr '-1'>> ) * [ USING 'ERRCODE' EQ string_literal ]
+plsql_statement ::= ( plsql_return SEMI | plsql_conditional SEMI | plsql_assignment SEMI | plsql_raise SEMI | delete_stmt_limited SEMI | insert_stmt SEMI | update_stmt_limited SEMI ) *
 
 create_function_stmt ::= CREATE [ OR REPLACE ] 'FUNCTION' {function_expr} 'RETURNS' TRIGGER [ 'LANGUAGE' 'PLPGSQL' ] AS
 '$$'

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/create-or-replace-trigger/Test.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/create-or-replace-trigger/Test.s
@@ -137,3 +137,27 @@ CREATE OR REPLACE TRIGGER accounts_check_balance
     BEFORE UPDATE OF balance ON accounts
     FOR EACH ROW
     EXECUTE FUNCTION accounts_check_balance();
+
+CREATE OR REPLACE FUNCTION accounts_sync_audit()
+RETURNS TRIGGER LANGUAGE PLPGSQL AS $$
+BEGIN
+    UPDATE accounts_audit SET balance = new.balance, changed_on = NOW() WHERE account_id = new.id;
+
+    IF FOUND THEN
+        RETURN new;
+    END IF;
+
+    INSERT INTO accounts_audit(account_id, balance, changed_on) VALUES (new.id, new.balance, NOW());
+
+    IF NOT FOUND THEN
+        RETURN NULL;
+    END IF;
+
+    RETURN new;
+END;
+$$;
+
+CREATE OR REPLACE TRIGGER accounts_sync_audit
+    AFTER INSERT OR UPDATE OF balance ON accounts
+    FOR EACH ROW
+    EXECUTE FUNCTION accounts_sync_audit();

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/create-or-replace-trigger/Test.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/create-or-replace-trigger/Test.s
@@ -111,3 +111,29 @@ $$;
 CREATE TRIGGER emp_audit
 AFTER INSERT OR UPDATE OR DELETE ON emp
   FOR EACH ROW EXECUTE FUNCTION process_emp_audit();
+
+CREATE OR REPLACE FUNCTION accounts_check_balance()
+RETURNS TRIGGER LANGUAGE PLPGSQL AS $$
+BEGIN
+    RAISE NOTICE 'checking balance for account %', new.id;
+
+    IF new.balance IS NULL THEN
+        RAISE WARNING 'balance is null for account %', new.id;
+    END IF;
+
+    IF new.balance < old.balance THEN
+        RAISE EXCEPTION 'balance decreased for account %', new.id USING ERRCODE = 'check_violation';
+    END IF;
+
+    IF new.balance < 0 THEN
+        RAISE EXCEPTION 'negative balance not allowed' USING ERRCODE = '23514';
+    END IF;
+
+    RETURN new;
+END;
+$$;
+
+CREATE OR REPLACE TRIGGER accounts_check_balance
+    BEFORE UPDATE OF balance ON accounts
+    FOR EACH ROW
+    EXECUTE FUNCTION accounts_check_balance();


### PR DESCRIPTION
fixes #6296 

* Add grammar support for `RAISE EXCEPTION | WARNING | NOTICE` `USING ERRCODE`
* Add grammar support for `FOUND` special variable
* Add fixture test
   * Grammar fix only there is no other implementation required
   
```sql
CREATE OR REPLACE FUNCTION accounts_check_balance()
RETURNS TRIGGER LANGUAGE PLPGSQL AS $$
BEGIN
    RAISE NOTICE 'checking balance for account %', new.id;

    IF new.balance IS NULL THEN
        RAISE WARNING 'balance is null for account %', new.id;
    END IF;

    IF new.balance < old.balance THEN
        RAISE EXCEPTION 'balance decreased for account %', new.id USING ERRCODE = 'check_violation';
    END IF;

    IF new.balance < 0 THEN
        RAISE EXCEPTION 'negative balance not allowed' USING ERRCODE = '23514';
    END IF;

    RETURN new;
END;
$$;

CREATE OR REPLACE TRIGGER accounts_check_balance
    BEFORE UPDATE OF balance ON accounts
    FOR EACH ROW
    EXECUTE FUNCTION accounts_check_balance();
```

Produces:

```
org.postgresql.util.PSQLException: ERROR: balance decreased for account 1
  Where: PL/pgSQL function accounts_check_balance() line 10 at RAISE
```

`FOUND` is a local boolean variable within each PL/pgSQL function.

```sql
CREATE OR REPLACE FUNCTION accounts_check_balance()
RETURNS TRIGGER LANGUAGE PLPGSQL AS $$
BEGIN

    DELETE FROM accounts WHERE id = new.id;

    IF NOT FOUND THEN
      RAISE EXCEPTION 'account id not found %', new.id;
    END IF;

    RETURN new;
END;
$$;
```

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
