### PR TITLE
Support uppercase REPLACE function in Postgresql dialect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [PostgreSQL Dialect] Add query support for implicitly defined System Columns (#5834 by @griffio)
 - [PostgreSQL Dialect] Add basic Array literal support (#5997 by @griffio)
 - [PostgreSQL Dialect] Add basic LTREE support (#5880 by @yesitskev @griffio)
+- [PostgreSQL Dialect] Support uppercase REPLACE as a function name (#6301 by @eyupcanakman)
 - [MySQL Dialect] Add support for INET functions (#5072 by @mcxinyu)
 - [PostgreSQL Dialect] Add support for ALTER INDEX (#6224 by @griffio)
 - [SQLite Dialect] Add support for SQLite 3.44 aggregate functions DISTINCT, ORDER BY and FILTER (#6236 by @griffio)

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -146,6 +146,7 @@ overrides ::= type_name
   | binary_like_operator
   | literal_value
   | with_clause
+  | function_name
 
 column_constraint ::= [ CONSTRAINT {identifier} ] (
   PRIMARY KEY [ ASC | DESC ] [ {conflict_clause} ] |
@@ -278,6 +279,12 @@ binary_like_operator ::= ( 'ILIKE' | LIKE | GLOB | REGEXP | MATCH ) {
    extends = "com.alecstrong.sql.psi.core.psi.impl.SqlBinaryLikeOperatorImpl"
    implements = "com.alecstrong.sql.psi.core.psi.SqlBinaryLikeOperator"
    override = true
+}
+
+function_name ::= id | REPLACE {
+  extends = "com.alecstrong.sql.psi.core.psi.impl.SqlFunctionNameImpl"
+  implements = "com.alecstrong.sql.psi.core.psi.SqlFunctionName"
+  override = true
 }
 
 identity_clause ::= 'IDENTITY' [ LP [ 'SEQUENCE' 'NAME' sequence_name ] [ sequence_parameters* ] RP ]

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/update-set-replace/1.s
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/update-set-replace/1.s
@@ -1,0 +1,7 @@
+CREATE TABLE test(
+  id SERIAL PRIMARY KEY,
+  name TEXT NOT NULL
+);
+
+UPDATE test
+SET name = REPLACE(name, 'foo', 'bar');


### PR DESCRIPTION
Fixes #6109

Uppercase `REPLACE(...)` did not parse as a function in the Postgresql dialect. `REPLACE` is a keyword token, so the base `function_name ::= id` rule only matched the lowercase `replace(...)` form.

```
UPDATE test
SET name = REPLACE(name, 'foo', 'bar');
```

Override `function_name` in the Postgresql grammar to also accept the `REPLACE` keyword. This covers every function context, not only the `SET` setter, since uppercase `REPLACE(...)` failed the same way in a `SELECT`.

* Adds fixtures test

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
