### PR TITLE
Support multi-column collection binds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Added
+- [Compiler] Add collection binds for multi-column `IN` expressions
 - [Native Driver] Add `extendedConfig` parameter to `inMemoryDriver` (#5539 by @GuilhE)
 - [PostgreSQL Dialect] Add query support for implicitly defined System Columns (#5834 by @griffio)
 - [PostgreSQL Dialect] Add basic Array literal support (#5997 by @griffio)
@@ -24,6 +25,7 @@
 - [Gradle Plugin] Support gradle isolated projects (#6217 by @maxsav)
 
 ### Fixed
+- [Compiler] Resolve observed tables inside dialect-defined table expressions
 - [Compiler] Suppress Kotlin extra warnings in generated code (#6208 by @eyupcanakman)
 - [Compiler] Other columns in a non-grouped aggregate result set are always nullable
 - [PostgreSQL Dialect] Resolve nullability correctly for coalesce and ifnull

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/CollectionArgumentInterfaceGenerator.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/CollectionArgumentInterfaceGenerator.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2026 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.sqldelight.core.compiler
+
+import app.cash.sqldelight.core.compiler.model.BindableQuery
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier.DATA
+import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.TypeSpec
+
+internal class CollectionArgumentInterfaceGenerator(
+  private val argument: BindableQuery.Argument,
+) {
+  fun kotlinImplementationSpec(): TypeSpec {
+    val className = checkNotNull(argument.collectionTypeName)
+    val typeSpec = TypeSpec.classBuilder(className.simpleName)
+      .addModifiers(DATA)
+    val constructor = FunSpec.constructorBuilder()
+
+    argument.collectionElementTypes.orEmpty().forEach { field ->
+      val javaType = field.javaType
+      val typeWithoutAnnotations = javaType.copy(annotations = emptyList())
+      typeSpec.addProperty(
+        PropertySpec.builder(field.name, typeWithoutAnnotations)
+          .initializer(field.name)
+          .addAnnotations(javaType.annotations)
+          .build(),
+      )
+      constructor.addParameter(field.name, typeWithoutAnnotations)
+    }
+
+    return typeSpec
+      .primaryConstructor(constructor.build())
+      .build()
+  }
+}

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/QueryGenerator.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/QueryGenerator.kt
@@ -144,13 +144,28 @@ abstract class QueryGenerator(
       val type = argument.type
       if (bindArg?.isSqlInExprArrayParameter() == true) {
         needsFreshStatement = true
+        val collectionElementTypes = argument.collectionElementTypes
 
         if (!handledArrayArgs.contains(argument) && seenArrayArguments.add(argument)) {
-          result.addStatement(
-            """
-            |val ${type.name}Indexes = createArguments(count = ${type.name}.size)
-            """.trimMargin(),
-          )
+          if (collectionElementTypes == null) {
+            result.addStatement(
+              """
+              |val ${type.name}Indexes = createArguments(count = ${type.name}.size)
+              """.trimMargin(),
+            )
+          } else {
+            result.add(
+              "val %NIndexes = %N.joinToString(prefix = %S, postfix = %S) {\n",
+              type.name,
+              type.name,
+              "(",
+              ")",
+            )
+            result.indent()
+            result.addStatement("createArguments(count = %L)", collectionElementTypes.size)
+            result.unindent()
+            result.add("}\n")
+          }
         }
 
         // Replace the single bind argument with the array of bind arguments:
@@ -159,16 +174,35 @@ abstract class QueryGenerator(
 
         // Perform the necessary binds using the appropriate indexing strategy
         val elementName = argumentNameAllocator.newName(type.name)
-        bindStatements.add(
-          """
-          |${type.name}.forEach { $elementName ->
-          |  %L}
-          |
-          """.trimMargin(),
-          type.copy(name = elementName).preparedStatementBinder(CodeBlock.of("parameterIndex++")),
-        )
+        if (collectionElementTypes == null) {
+          bindStatements.add(
+            """
+            |${type.name}.forEach { $elementName ->
+            |  %L}
+            |
+            """.trimMargin(),
+            type.copy(name = elementName).preparedStatementBinder(CodeBlock.of("parameterIndex++")),
+          )
+        } else {
+          bindStatements.add("${type.name}.forEach { $elementName ->\n")
+          collectionElementTypes.forEach { field ->
+            val fieldExpression = CodeBlock.of("%N.%N", elementName, field.name).toString()
+            bindStatements.add(
+              "  %L",
+              field.copy(name = fieldExpression)
+                .preparedStatementBinder(CodeBlock.of("parameterIndex++")),
+            )
+          }
+          bindStatements.add("}\n")
+        }
 
-        arrayParameterSizes.add("${type.name}.size")
+        arrayParameterSizes.add(
+          if (collectionElementTypes == null) {
+            "${type.name}.size"
+          } else {
+            "${type.name}.size * ${collectionElementTypes.size}"
+          },
+        )
       } else {
         val bindParameter = bindArg?.bindParameter as? BindParameterMixin
         if (bindParameter == null || bindParameter.text != "DEFAULT") {

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/SqlDelightCompiler.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/SqlDelightCompiler.kt
@@ -168,10 +168,16 @@ object SqlDelightCompiler {
     output: FileAppender,
   ) {
     val packageName = file.packageName ?: return
+    val compositeCollectionArguments = file.compositeCollectionArguments
     val queriesType = QueriesTypeGenerator(module, file, dialect)
       .generateType(packageName) ?: return
 
     val fileSpec = FileSpec.builder(packageName, file.queriesName.capitalize())
+      .apply {
+        compositeCollectionArguments.forEach { argument ->
+          addType(CollectionArgumentInterfaceGenerator(argument).kotlinImplementationSpec())
+        }
+      }
       .addType(queriesType)
       .build()
 

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/model/BindableQuery.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/model/BindableQuery.kt
@@ -24,6 +24,7 @@ import app.cash.sqldelight.core.lang.types.typeResolver
 import app.cash.sqldelight.core.lang.util.argumentType
 import app.cash.sqldelight.core.lang.util.childOfType
 import app.cash.sqldelight.core.lang.util.findChildrenOfType
+import app.cash.sqldelight.core.lang.util.name
 import app.cash.sqldelight.core.lang.util.queryColumns
 import app.cash.sqldelight.core.lang.util.sqFile
 import app.cash.sqldelight.core.lang.util.type
@@ -36,11 +37,15 @@ import app.cash.sqldelight.dialect.grammar.mixins.BindParameterMixin
 import com.alecstrong.sql.psi.core.psi.SqlAnnotatedElement
 import com.alecstrong.sql.psi.core.psi.SqlBindExpr
 import com.alecstrong.sql.psi.core.psi.SqlBindParameter
+import com.alecstrong.sql.psi.core.psi.SqlColumnName
 import com.alecstrong.sql.psi.core.psi.SqlIdentifier
 import com.alecstrong.sql.psi.core.psi.SqlInsertStmt
+import com.alecstrong.sql.psi.core.psi.SqlMultiColumnInExpr
 import com.alecstrong.sql.psi.core.psi.SqlTypes
 import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
 import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.NameAllocator
 import java.util.concurrent.ConcurrentHashMap
 
 abstract class BindableQuery(
@@ -67,7 +72,9 @@ abstract class BindableQuery(
         ),
       )
     }
-    return@lazy arguments.sortedBy { it.index }.map { it.type }
+    return@lazy arguments.sortedBy { it.index }.map { argument ->
+      argument.collectionTypeName?.let { argument.type.copy(javaType = it) } ?: argument.type
+    }
   }
 
   /**
@@ -103,7 +110,7 @@ abstract class BindableQuery(
             return@forEach
           }
           maxIndexSeen = maxOf(maxIndexSeen, index)
-          result.add(Argument(index, typeResolver.argumentType(bindArg), mutableListOf(bindArg)))
+          result.add(argument(index, bindArg))
           return@forEach
         }
         bindParameter.identifier?.let {
@@ -114,12 +121,12 @@ abstract class BindableQuery(
           val index = ++maxIndexSeen
           indexesSeen.add(index)
           manuallyNamedIndexes.add(index)
-          result.add(Argument(index, typeResolver.argumentType(bindArg).copy(name = it.text), mutableListOf(bindArg)))
+          result.add(argument(index, bindArg, it.text))
           return@forEach
         }
         val index = ++maxIndexSeen
         indexesSeen.add(index)
-        result.add(Argument(index, typeResolver.argumentType(bindArg), mutableListOf(bindArg)))
+        result.add(argument(index, bindArg))
       }
     }
 
@@ -131,6 +138,15 @@ abstract class BindableQuery(
         name += "_"
       }
       it.copy(type = it.type.copy(name = name))
+    }
+
+    result.forEach { argument ->
+      if (argument.collectionElementTypes == null) return@forEach
+      val queryName = NameAllocator().newName(identifier?.name ?: "Query")
+      argument.collectionTypeName = ClassName(
+        statement.sqFile().packageName!!,
+        "${queryName.capitalize()}${argument.type.name.capitalize()}",
+      )
     }
 
     if (statement is SqlInsertStmt) {
@@ -146,6 +162,37 @@ abstract class BindableQuery(
     }
 
     return@lazy result
+  }
+
+  private fun argument(
+    index: Int,
+    bindArg: SqlBindExpr,
+    name: String? = null,
+  ): Argument {
+    val type = typeResolver.argumentType(bindArg).let {
+      if (name == null) it else it.copy(name = name)
+    }
+    val multiColumnInExpr = bindArg.parent as? SqlMultiColumnInExpr
+    val collectionElementTypes = multiColumnInExpr?.multiColumnExpression?.exprList?.let { expressions ->
+      val names = NameAllocator()
+      expressions.map { expression ->
+        expression.type().let { fieldType ->
+          val columnName = PsiTreeUtil.findChildOfType(expression, SqlColumnName::class.java)
+          val quotedName = expression.text
+            .takeIf { it.length >= 2 && it.first() == '"' && it.last() == '"' }
+            ?.substring(1, expression.text.length - 1)
+            ?.replace("\"\"", "\"")
+          val fieldName = columnName?.let(::allocateName) ?: quotedName ?: expression.name
+          fieldType.copy(name = names.newName(fieldName))
+        }
+      }
+    }
+    return Argument(
+      index = index,
+      type = type,
+      bindArgs = mutableListOf(bindArg),
+      collectionElementTypes = collectionElementTypes,
+    )
   }
 
   private fun MutableList<Argument>.findAndReplace(
@@ -205,7 +252,10 @@ abstract class BindableQuery(
     val index: Int,
     val type: IntermediateType,
     val bindArgs: MutableList<SqlBindExpr> = mutableListOf(),
-  )
+    val collectionElementTypes: List<IntermediateType>? = null,
+  ) {
+    var collectionTypeName: ClassName? = null
+  }
 
   companion object {
     /**

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/SqlDelightQueriesFile.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/SqlDelightQueriesFile.kt
@@ -16,6 +16,7 @@
 package app.cash.sqldelight.core.lang
 
 import app.cash.sqldelight.core.SqlDelightFileIndex
+import app.cash.sqldelight.core.capitalize
 import app.cash.sqldelight.core.compiler.integration.adapterProperty
 import app.cash.sqldelight.core.compiler.integration.needsAdapters
 import app.cash.sqldelight.core.compiler.model.BindableQuery
@@ -27,17 +28,21 @@ import app.cash.sqldelight.core.compiler.model.NamedQuery
 import app.cash.sqldelight.core.lang.psi.StmtIdentifierMixin
 import app.cash.sqldelight.core.lang.util.argumentType
 import app.cash.sqldelight.core.lang.util.table
+import app.cash.sqldelight.core.lang.util.type
 import app.cash.sqldelight.core.psi.SqlDelightStmtList
 import com.alecstrong.sql.psi.core.SqlAnnotationHolder
 import com.alecstrong.sql.psi.core.psi.SqlAnnotatedElement
 import com.alecstrong.sql.psi.core.psi.SqlBindExpr
 import com.alecstrong.sql.psi.core.psi.SqlInsertStmt
+import com.alecstrong.sql.psi.core.psi.SqlMultiColumnInExpr
 import com.alecstrong.sql.psi.core.psi.SqlStmt
 import com.intellij.psi.FileViewProvider
 import com.intellij.psi.PsiDirectory
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.util.parentOfType
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.NameAllocator
 
 class SqlDelightQueriesFile(
   viewProvider: FileViewProvider,
@@ -102,16 +107,44 @@ class SqlDelightQueriesFile(
     return@lazy transactions().filterIsInstance<NamedExecute>() + statements
   }
 
+  internal val compositeCollectionArguments by lazy {
+    val arguments = (namedQueries + namedMutators + namedExecutes)
+      .flatMap { it.arguments }
+      .filter { it.collectionElementTypes != null }
+
+    val names = NameAllocator()
+    names.newName(queriesName.capitalize(), this)
+    namedQueries.forEach { query ->
+      names.newName(query.name.capitalize(), query)
+    }
+    arguments.forEach { argument ->
+      val typeName = checkNotNull(argument.collectionTypeName)
+      argument.collectionTypeName = ClassName(
+        typeName.packageName,
+        names.newName(typeName.simpleName, argument),
+      )
+    }
+    arguments
+  }
+
   /**
    * A collection of all the adapters needed for arguments or result columns in this query.
    */
   internal val requiredAdapters by lazy {
     val binders = PsiTreeUtil.findChildrenOfType(this, SqlBindExpr::class.java)
-    val argumentAdapters = binders.mapNotNull {
+    val argumentAdapters = binders.flatMap {
       it.parentOfType<SqlInsertStmt>()?.let {
-        if (it.acceptsTableInterface() && it.table.needsAdapters()) return@mapNotNull it.table.adapterProperty()
+        if (it.acceptsTableInterface() && it.table.needsAdapters()) {
+          return@flatMap listOfNotNull(it.table.adapterProperty())
+        }
       }
-      typeResolver.argumentType(it).parentAdapter()
+      val multiColumnInExpr = it.parent as? SqlMultiColumnInExpr
+      if (multiColumnInExpr != null) {
+        return@flatMap multiColumnInExpr.multiColumnExpression.exprList.mapNotNull { expression ->
+          expression.type().parentAdapter()
+        }
+      }
+      listOfNotNull(typeResolver.argumentType(it).parentAdapter())
     }
 
     val resultColumnAdapters = namedQueries.flatMap {

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/Arguments.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/Arguments.kt
@@ -47,6 +47,7 @@ import com.alecstrong.sql.psi.core.psi.SqlLikeEscapeCharacterExpr
 import com.alecstrong.sql.psi.core.psi.SqlLimitingTerm
 import com.alecstrong.sql.psi.core.psi.SqlMultiColumnExpr
 import com.alecstrong.sql.psi.core.psi.SqlMultiColumnExpression
+import com.alecstrong.sql.psi.core.psi.SqlMultiColumnInExpr
 import com.alecstrong.sql.psi.core.psi.SqlNullExpr
 import com.alecstrong.sql.psi.core.psi.SqlParenExpr
 import com.alecstrong.sql.psi.core.psi.SqlResultColumn
@@ -62,7 +63,9 @@ import com.intellij.psi.util.PsiTreeUtil
 import com.squareup.kotlinpoet.asClassName
 
 internal fun SqlBindExpr.isSqlInExprArrayParameter(): Boolean {
-  return (parent is SqlInExpr && this == parent.lastChild)
+  val multiColumnInExpr = parent as? SqlMultiColumnInExpr
+  return (parent is SqlInExpr && this == parent.lastChild) ||
+    this == multiColumnInExpr?.bindExpr
 }
 
 internal fun SqlBindExpr.isAnyExprArrayParameter(): Boolean {
@@ -109,6 +112,10 @@ internal fun SqlExpr.argumentType(argument: SqlExpr): IntermediateType {
       if (argument === firstChild) return IntermediateType(ARGUMENT)
 
       return exprList.first().type()
+    }
+
+    is SqlMultiColumnInExpr -> {
+      return multiColumnExpression.exprList.first().type()
     }
 
     is SqlCaseExpr -> {

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/SelectStmtUtil.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/util/SelectStmtUtil.kt
@@ -10,6 +10,7 @@ import com.alecstrong.sql.psi.core.psi.SqlCteTableName
 import com.alecstrong.sql.psi.core.psi.SqlNewTableName
 import com.alecstrong.sql.psi.core.psi.SqlTableAlias
 import com.alecstrong.sql.psi.core.psi.SqlTableName
+import com.alecstrong.sql.psi.core.psi.SqlTableOrSubquery
 import com.alecstrong.sql.psi.core.psi.SqlViewName
 import com.alecstrong.sql.psi.core.psi.SqlWithClause
 import com.intellij.psi.PsiElement
@@ -36,6 +37,11 @@ internal fun PsiElement.referencedTables(
   is SqlTableAlias -> source().referencedTables()
   is SqlNewTableName -> {
     listOf(TableNameElement.NewTableName(this))
+  }
+  is SqlTableOrSubquery -> {
+    findChildrenOfType<SqlTableName>()
+      .flatMap { it.referencedTables(compoundSelectStmt) }
+      .distinctBy { it.name }
   }
   is SqlTableName, is SqlViewName -> {
     when (val parentRule = parent!!) {

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/CompositeCollectionBindTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/CompositeCollectionBindTest.kt
@@ -1,0 +1,524 @@
+package app.cash.sqldelight.core
+
+import app.cash.sqldelight.test.util.FixtureCompiler
+import com.google.common.truth.Truth.assertThat
+import java.io.File
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class CompositeCollectionBindTest {
+  @get:Rule val temporaryFolder = TemporaryFolder()
+
+  @Test fun `multi column IN bind generates a typed collection and expands every field`() {
+    val result = FixtureCompiler.compileSql(
+      """
+      |CREATE TABLE data (
+      |  department_id INTEGER NOT NULL,
+      |  status TEXT,
+      |  priority INTEGER NOT NULL
+      |);
+      |
+      |selectByPairs:
+      |SELECT *
+      |FROM data
+      |WHERE (department_id, status) IN :pairs
+      |  AND (department_id, status, priority) IN ?;
+      """.trimMargin(),
+      temporaryFolder,
+      fileName = "Data.sq",
+    )
+
+    assertThat(result.errors).isEmpty()
+    val queries = File(result.outputDirectory, "com/example/DataQueries.kt")
+    assertThat(result.compilerOutput).containsKey(queries)
+    val generated = result.compilerOutput.getValue(queries).toString()
+
+    assertThat(generated).isEqualTo(
+      """
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
+      |package com.example
+      |
+      |import app.cash.sqldelight.Query
+      |import app.cash.sqldelight.TransacterImpl
+      |import app.cash.sqldelight.db.QueryResult
+      |import app.cash.sqldelight.db.SqlCursor
+      |import app.cash.sqldelight.db.SqlDriver
+      |import kotlin.Any
+      |import kotlin.Long
+      |import kotlin.String
+      |import kotlin.collections.Collection
+      |
+      |public data class SelectByPairsPairs(
+      |  public val department_id: Long,
+      |  public val status: String?,
+      |)
+      |
+      |public data class SelectByPairsDepartment_id(
+      |  public val department_id: Long,
+      |  public val status: String?,
+      |  public val priority: Long,
+      |)
+      |
+      |public class DataQueries(
+      |  driver: SqlDriver,
+      |) : TransacterImpl(driver) {
+      |  public fun <T : Any> selectByPairs(
+      |    pairs: Collection<SelectByPairsPairs>,
+      |    department_id: Collection<SelectByPairsDepartment_id>,
+      |    mapper: (
+      |      department_id: Long,
+      |      status: String?,
+      |      priority: Long,
+      |    ) -> T,
+      |  ): Query<T> = SelectByPairsQuery(pairs, department_id) { cursor ->
+      |    mapper(
+      |      cursor.getLong(0)!!,
+      |      cursor.getString(1),
+      |      cursor.getLong(2)!!
+      |    )
+      |  }
+      |
+      |  public fun selectByPairs(pairs: Collection<SelectByPairsPairs>, department_id: Collection<SelectByPairsDepartment_id>): Query<Data_> = selectByPairs(pairs, department_id, ::Data_)
+      |
+      |  private inner class SelectByPairsQuery<out T : Any>(
+      |    public val pairs: Collection<SelectByPairsPairs>,
+      |    public val department_id: Collection<SelectByPairsDepartment_id>,
+      |    mapper: (SqlCursor) -> T,
+      |  ) : Query<T>(mapper) {
+      |    override fun addListener(listener: Query.Listener) {
+      |      driver.addListener("data", listener = listener)
+      |    }
+      |
+      |    override fun removeListener(listener: Query.Listener) {
+      |      driver.removeListener("data", listener = listener)
+      |    }
+      |
+      |    override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>): QueryResult<R> {
+      |      val pairsIndexes = pairs.joinToString(prefix = "(", postfix = ")") {
+      |        createArguments(count = 2)
+      |      }
+      |      val department_idIndexes = department_id.joinToString(prefix = "(", postfix = ")") {
+      |        createArguments(count = 3)
+      |      }
+      |      return driver.executeQuery(null, ""${'"'}
+      |          |SELECT data.department_id, data.status, data.priority
+      |          |FROM data
+      |          |WHERE (department_id, status) IN ${"$"}pairsIndexes
+      |          |  AND (department_id, status, priority) IN ${"$"}department_idIndexes
+      |          ""${'"'}.trimMargin(), mapper, pairs.size * 2 + department_id.size * 3) {
+      |            var parameterIndex = 0
+      |            pairs.forEach { pairs_ ->
+      |              bindLong(parameterIndex++, pairs_.department_id)
+      |              bindString(parameterIndex++, pairs_.status)
+      |            }
+      |            department_id.forEach { department_id_ ->
+      |              bindLong(parameterIndex++, department_id_.department_id)
+      |              bindString(parameterIndex++, department_id_.status)
+      |              bindLong(parameterIndex++, department_id_.priority)
+      |            }
+      |          }
+      |    }
+      |
+      |    override fun toString(): String = "Data.sq:selectByPairs"
+      |  }
+      |}
+      |
+      """.trimMargin(),
+    )
+  }
+
+  @Test fun `multi column IN bind preserves value types adapters and mixed bind order`() {
+    val result = FixtureCompiler.compileSql(
+      """
+      |import com.example.Status;
+      |
+      |CREATE TABLE data (
+      |  id INTEGER AS VALUE NOT NULL,
+      |  status TEXT AS Status NOT NULL,
+      |  note TEXT
+      |);
+      |
+      |selectByPairs:
+      |SELECT *
+      |FROM data
+      |WHERE note = :note
+      |  AND id IN :ids
+      |  AND (id, status) IN :pairs;
+      """.trimMargin(),
+      temporaryFolder,
+      fileName = "Data.sq",
+    )
+
+    assertThat(result.errors).isEmpty()
+    val queries = File(result.outputDirectory, "com/example/DataQueries.kt")
+    val generated = result.compilerOutput.getValue(queries).toString()
+
+    assertThat(generated).isEqualTo(
+      """
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
+      |package com.example
+      |
+      |import app.cash.sqldelight.Query
+      |import app.cash.sqldelight.TransacterImpl
+      |import app.cash.sqldelight.db.QueryResult
+      |import app.cash.sqldelight.db.SqlCursor
+      |import app.cash.sqldelight.db.SqlDriver
+      |import kotlin.Any
+      |import kotlin.String
+      |import kotlin.collections.Collection
+      |
+      |public data class SelectByPairsPairs(
+      |  public val id: Data_.Id,
+      |  public val status: Status,
+      |)
+      |
+      |public class DataQueries(
+      |  driver: SqlDriver,
+      |  private val data_Adapter: Data_.Adapter,
+      |) : TransacterImpl(driver) {
+      |  public fun <T : Any> selectByPairs(
+      |    note: String?,
+      |    ids: Collection<Data_.Id>,
+      |    pairs: Collection<SelectByPairsPairs>,
+      |    mapper: (
+      |      id: Data_.Id,
+      |      status: Status,
+      |      note: String?,
+      |    ) -> T,
+      |  ): Query<T> = SelectByPairsQuery(note, ids, pairs) { cursor ->
+      |    mapper(
+      |      Data_.Id(cursor.getLong(0)!!),
+      |      data_Adapter.statusAdapter.decode(cursor.getString(1)!!),
+      |      cursor.getString(2)
+      |    )
+      |  }
+      |
+      |  public fun selectByPairs(
+      |    note: String?,
+      |    ids: Collection<Data_.Id>,
+      |    pairs: Collection<SelectByPairsPairs>,
+      |  ): Query<Data_> = selectByPairs(note, ids, pairs, ::Data_)
+      |
+      |  private inner class SelectByPairsQuery<out T : Any>(
+      |    public val note: String?,
+      |    public val ids: Collection<Data_.Id>,
+      |    public val pairs: Collection<SelectByPairsPairs>,
+      |    mapper: (SqlCursor) -> T,
+      |  ) : Query<T>(mapper) {
+      |    override fun addListener(listener: Query.Listener) {
+      |      driver.addListener("data", listener = listener)
+      |    }
+      |
+      |    override fun removeListener(listener: Query.Listener) {
+      |      driver.removeListener("data", listener = listener)
+      |    }
+      |
+      |    override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>): QueryResult<R> {
+      |      val idsIndexes = createArguments(count = ids.size)
+      |      val pairsIndexes = pairs.joinToString(prefix = "(", postfix = ")") {
+      |        createArguments(count = 2)
+      |      }
+      |      return driver.executeQuery(null, ""${'"'}
+      |          |SELECT data.id, data.status, data.note
+      |          |FROM data
+      |          |WHERE note ${"$"}{ if (note == null) "IS" else "=" } ?
+      |          |  AND id IN ${"$"}idsIndexes
+      |          |  AND (id, status) IN ${"$"}pairsIndexes
+      |          ""${'"'}.trimMargin(), mapper, 1 + ids.size + pairs.size * 2) {
+      |            var parameterIndex = 0
+      |            bindString(parameterIndex++, note)
+      |            ids.forEach { ids_ ->
+      |              bindLong(parameterIndex++, ids_.id)
+      |            }
+      |            pairs.forEach { pairs_ ->
+      |              bindLong(parameterIndex++, pairs_.id.id)
+      |              bindString(parameterIndex++, data_Adapter.statusAdapter.encode(pairs_.status))
+      |            }
+      |          }
+      |    }
+      |
+      |    override fun toString(): String = "Data.sq:selectByPairs"
+      |  }
+      |}
+      |
+      """.trimMargin(),
+    )
+  }
+
+  @Test fun `multi column IN bind allocates duplicate and keyword field names`() {
+    val result = FixtureCompiler.compileSql(
+      """
+      |CREATE TABLE data (
+      |  "when" TEXT NOT NULL,
+      |  status TEXT NOT NULL
+      |);
+      |
+      |selectReserved:
+      |SELECT *
+      |FROM data
+      |WHERE ("when", status, status) IN :values;
+      """.trimMargin(),
+      temporaryFolder,
+      fileName = "Data.sq",
+    )
+
+    assertThat(result.errors).isEmpty()
+    val queries = File(result.outputDirectory, "com/example/DataQueries.kt")
+    val generated = result.compilerOutput.getValue(queries).toString()
+
+    assertThat(generated).isEqualTo(
+      """
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
+      |package com.example
+      |
+      |import app.cash.sqldelight.Query
+      |import app.cash.sqldelight.TransacterImpl
+      |import app.cash.sqldelight.db.QueryResult
+      |import app.cash.sqldelight.db.SqlCursor
+      |import app.cash.sqldelight.db.SqlDriver
+      |import kotlin.Any
+      |import kotlin.String
+      |import kotlin.collections.Collection
+      |
+      |public data class SelectReservedValues(
+      |  public val when_: String,
+      |  public val status: String,
+      |  public val status_: String,
+      |)
+      |
+      |public class DataQueries(
+      |  driver: SqlDriver,
+      |) : TransacterImpl(driver) {
+      |  public fun <T : Any> selectReserved(values: Collection<SelectReservedValues>, mapper: (when_: String, status: String) -> T): Query<T> = SelectReservedQuery(values) { cursor ->
+      |    mapper(
+      |      cursor.getString(0)!!,
+      |      cursor.getString(1)!!
+      |    )
+      |  }
+      |
+      |  public fun selectReserved(values: Collection<SelectReservedValues>): Query<Data_> = selectReserved(values, ::Data_)
+      |
+      |  private inner class SelectReservedQuery<out T : Any>(
+      |    public val values: Collection<SelectReservedValues>,
+      |    mapper: (SqlCursor) -> T,
+      |  ) : Query<T>(mapper) {
+      |    override fun addListener(listener: Query.Listener) {
+      |      driver.addListener("data", listener = listener)
+      |    }
+      |
+      |    override fun removeListener(listener: Query.Listener) {
+      |      driver.removeListener("data", listener = listener)
+      |    }
+      |
+      |    override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>): QueryResult<R> {
+      |      val valuesIndexes = values.joinToString(prefix = "(", postfix = ")") {
+      |        createArguments(count = 3)
+      |      }
+      |      return driver.executeQuery(null, ""${'"'}
+      |          |SELECT data."when", data.status
+      |          |FROM data
+      |          |WHERE ("when", status, status) IN ${"$"}valuesIndexes
+      |          ""${'"'}.trimMargin(), mapper, values.size * 3) {
+      |            var parameterIndex = 0
+      |            values.forEach { values_ ->
+      |              bindString(parameterIndex++, values_.when_)
+      |              bindString(parameterIndex++, values_.status)
+      |              bindString(parameterIndex++, values_.status_)
+      |            }
+      |          }
+      |    }
+      |
+      |    override fun toString(): String = "Data.sq:selectReserved"
+      |  }
+      |}
+      |
+      """.trimMargin(),
+    )
+  }
+
+  @Test fun `multi column IN bind allocates colliding generated type names`() {
+    val result = FixtureCompiler.compileSql(
+      """
+      |CREATE TABLE data (
+      |  id INTEGER NOT NULL,
+      |  status TEXT NOT NULL
+      |);
+      |
+      |selectA:
+      |SELECT * FROM data WHERE (id, status) IN :bC;
+      |
+      |selectAB:
+      |SELECT * FROM data WHERE (id, status) IN :c;
+      |
+      |selectABC:
+      |SELECT id + 1 AS next_id FROM data;
+      |
+      |Data:
+      |SELECT * FROM data WHERE (id, status) IN :queries;
+      """.trimMargin(),
+      temporaryFolder,
+      fileName = "Data.sq",
+    )
+
+    assertThat(result.errors).isEmpty()
+    val queries = File(result.outputDirectory, "com/example/DataQueries.kt")
+    val generated = result.compilerOutput.getValue(queries).toString()
+
+    assertThat(generated).isEqualTo(
+      """
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
+      |package com.example
+      |
+      |import app.cash.sqldelight.Query
+      |import app.cash.sqldelight.TransacterImpl
+      |import app.cash.sqldelight.db.QueryResult
+      |import app.cash.sqldelight.db.SqlCursor
+      |import app.cash.sqldelight.db.SqlDriver
+      |import kotlin.Any
+      |import kotlin.Long
+      |import kotlin.String
+      |import kotlin.collections.Collection
+      |
+      |public data class SelectABC_(
+      |  public val id: Long,
+      |  public val status: String,
+      |)
+      |
+      |public data class SelectABC__(
+      |  public val id: Long,
+      |  public val status: String,
+      |)
+      |
+      |public data class DataQueries_(
+      |  public val id: Long,
+      |  public val status: String,
+      |)
+      |
+      |public class DataQueries(
+      |  driver: SqlDriver,
+      |) : TransacterImpl(driver) {
+      |  public fun <T : Any> selectA(bC: Collection<SelectABC_>, mapper: (id: Long, status: String) -> T): Query<T> = SelectAQuery(bC) { cursor ->
+      |    mapper(
+      |      cursor.getLong(0)!!,
+      |      cursor.getString(1)!!
+      |    )
+      |  }
+      |
+      |  public fun selectA(bC: Collection<SelectABC_>): Query<Data_> = selectA(bC, ::Data_)
+      |
+      |  public fun <T : Any> selectAB(c: Collection<SelectABC__>, mapper: (id: Long, status: String) -> T): Query<T> = SelectABQuery(c) { cursor ->
+      |    mapper(
+      |      cursor.getLong(0)!!,
+      |      cursor.getString(1)!!
+      |    )
+      |  }
+      |
+      |  public fun selectAB(c: Collection<SelectABC__>): Query<Data_> = selectAB(c, ::Data_)
+      |
+      |  public fun selectABC(): Query<Long> = Query(-493_514_991, arrayOf("data"), driver, "Data.sq", "selectABC", "SELECT id + 1 AS next_id FROM data") { cursor ->
+      |    cursor.getLong(0)!!
+      |  }
+      |
+      |  public fun <T : Any> Data(queries: Collection<DataQueries_>, mapper: (id: Long, status: String) -> T): Query<T> = DataQuery(queries) { cursor ->
+      |    mapper(
+      |      cursor.getLong(0)!!,
+      |      cursor.getString(1)!!
+      |    )
+      |  }
+      |
+      |  public fun Data(queries: Collection<DataQueries_>): Query<Data_> = Data(queries, ::Data_)
+      |
+      |  private inner class SelectAQuery<out T : Any>(
+      |    public val bC: Collection<SelectABC_>,
+      |    mapper: (SqlCursor) -> T,
+      |  ) : Query<T>(mapper) {
+      |    override fun addListener(listener: Query.Listener) {
+      |      driver.addListener("data", listener = listener)
+      |    }
+      |
+      |    override fun removeListener(listener: Query.Listener) {
+      |      driver.removeListener("data", listener = listener)
+      |    }
+      |
+      |    override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>): QueryResult<R> {
+      |      val bCIndexes = bC.joinToString(prefix = "(", postfix = ")") {
+      |        createArguments(count = 2)
+      |      }
+      |      return driver.executeQuery(null, ""${'"'}SELECT data.id, data.status FROM data WHERE (id, status) IN ${"$"}bCIndexes""${'"'}, mapper, bC.size * 2) {
+      |            var parameterIndex = 0
+      |            bC.forEach { bC_ ->
+      |              bindLong(parameterIndex++, bC_.id)
+      |              bindString(parameterIndex++, bC_.status)
+      |            }
+      |          }
+      |    }
+      |
+      |    override fun toString(): String = "Data.sq:selectA"
+      |  }
+      |
+      |  private inner class SelectABQuery<out T : Any>(
+      |    public val c: Collection<SelectABC__>,
+      |    mapper: (SqlCursor) -> T,
+      |  ) : Query<T>(mapper) {
+      |    override fun addListener(listener: Query.Listener) {
+      |      driver.addListener("data", listener = listener)
+      |    }
+      |
+      |    override fun removeListener(listener: Query.Listener) {
+      |      driver.removeListener("data", listener = listener)
+      |    }
+      |
+      |    override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>): QueryResult<R> {
+      |      val cIndexes = c.joinToString(prefix = "(", postfix = ")") {
+      |        createArguments(count = 2)
+      |      }
+      |      return driver.executeQuery(null, ""${'"'}SELECT data.id, data.status FROM data WHERE (id, status) IN ${"$"}cIndexes""${'"'}, mapper, c.size * 2) {
+      |            var parameterIndex = 0
+      |            c.forEach { c_ ->
+      |              bindLong(parameterIndex++, c_.id)
+      |              bindString(parameterIndex++, c_.status)
+      |            }
+      |          }
+      |    }
+      |
+      |    override fun toString(): String = "Data.sq:selectAB"
+      |  }
+      |
+      |  private inner class DataQuery<out T : Any>(
+      |    public val queries: Collection<DataQueries_>,
+      |    mapper: (SqlCursor) -> T,
+      |  ) : Query<T>(mapper) {
+      |    override fun addListener(listener: Query.Listener) {
+      |      driver.addListener("data", listener = listener)
+      |    }
+      |
+      |    override fun removeListener(listener: Query.Listener) {
+      |      driver.removeListener("data", listener = listener)
+      |    }
+      |
+      |    override fun <R> execute(mapper: (SqlCursor) -> QueryResult<R>): QueryResult<R> {
+      |      val queriesIndexes = queries.joinToString(prefix = "(", postfix = ")") {
+      |        createArguments(count = 2)
+      |      }
+      |      return driver.executeQuery(null, ""${'"'}SELECT data.id, data.status FROM data WHERE (id, status) IN ${"$"}queriesIndexes""${'"'}, mapper, queries.size * 2) {
+      |            var parameterIndex = 0
+      |            queries.forEach { queries_ ->
+      |              bindLong(parameterIndex++, queries_.id)
+      |              bindString(parameterIndex++, queries_.status)
+      |            }
+      |          }
+      |    }
+      |
+      |    override fun toString(): String = "Data.sq:Data"
+      |  }
+      |}
+      |
+      """.trimMargin(),
+    )
+  }
+}


### PR DESCRIPTION
## Summary
- expose row-value `IN` binds as `Collection` parameters with generated top-level data classes
- expand each collection element into one parenthesized SQL tuple and bind fields left-to-right
- preserve nullable, value-class, and adapter-backed column types
- allocate generated field and tuple type names safely
- resolve observed tables inside dialect-defined derived-table expressions

## Why
SQLDelight already expands collection binds for scalar `IN` expressions, but a `SqlMultiColumnInExpr` bind was treated as one scalar parameter. This prevented typed row-value collection filters in dialects that support the syntax. The derived-table fallback is needed for dialect integrations such as Oracle `JSON_TABLE`.

## Validation
- `./gradlew :sqldelight-compiler:test`
- `./gradlew spotlessCheck`
- Oracle dialect composite build: multi-column `IN` / `NOT IN` and `JSON_TABLE` codegen regressions pass

## Dependency
- Depends on lysine-dev/sql-psi#776 for base `NOT IN` parsing. The compiler path is symmetric because both forms produce `SqlMultiColumnInExpr`; an explicit base-dialect `NOT IN` regression will be added once that parser change is available.

## Coverage
- named and positional 2/3-column binds
- nullable, custom adapter, and value-class fields
- mixed scalar and collection bind ordering/counts
- reserved, duplicate, and colliding generated names
- exact generated-file golden assertions covering tuple SQL, arity, parameter counts, and binder order