### PR TITLE
Update SqlDelightCompiler where package module name segment to be lower cased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - [PostgreSQL Dialect] Fix json aggregate functions when using nested function call (#6281 by @griffio)
 - [Paging3 Extension] Fix KeyedQueryPagingSource crash on empty database (#6284 by @woods-marshes)
 - [Compiler] Fix Java type adapter issue when mutator statements are used with encapsulating functions like `COALESCE` (#6292 by @griffio)
+- [Compiler] Fix where the module name was capitalized, the generated code's package name also was capitalized (#6316 by @griffio)
 
 ## [2.3.2] - 2026-03-16
 [2.3.2]: https://github.com/sqldelight/sqldelight/releases/tag/2.3.2

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/SqlDelightCompiler.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/SqlDelightCompiler.kt
@@ -79,7 +79,7 @@ object SqlDelightCompiler {
     output: FileAppender,
   ) {
     val fileIndex = SqlDelightFileIndex.getInstance(module)
-    val packageName = "${fileIndex.packageName}.$implementationFolder"
+    val packageName = "${fileIndex.packageName}.${implementationFolder.lowercase()}"
     val databaseImplementationType = DatabaseGenerator(module, sourceFile).type()
     val exposer = DatabaseExposerGenerator(databaseImplementationType, fileIndex, sourceFile.generateAsync)
 
@@ -106,7 +106,7 @@ object SqlDelightCompiler {
     val queryWrapperType = DatabaseGenerator(module, sourceFile).interfaceType()
     val fileSpec = FileSpec.builder(packageName, queryWrapperType.name!!)
       // TODO: Remove these when kotlinpoet supports top level types.
-      .addImport("$packageName.$implementationFolder", "newInstance", "schema")
+      .addImport("$packageName.${implementationFolder.lowercase()}", "newInstance", "schema")
       .apply {
         var index = 0
         fileIndex.dependencies.forEach {

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/QueryWrapperTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/QueryWrapperTest.kt
@@ -1034,4 +1034,28 @@ class QueryWrapperTest {
       )
     }
   }
+
+  @Test fun `capitalized module name generates a lowercase implementation package`() {
+    val result = FixtureCompiler.compileSql(
+      """
+      |CREATE TABLE test_table(
+      |  _id INTEGER NOT NULL PRIMARY KEY,
+      |  value TEXT
+      |);
+      """.trimMargin(),
+      tempFolder,
+      moduleName = "TestModule",
+    )
+
+    assertThat(result.errors).isEmpty()
+
+    val queryWrapperFile = result.compilerOutput[File(result.outputDirectory, "com/example/testmodule/TestDatabaseImpl.kt")]
+    assertThat(queryWrapperFile).isNotNull()
+    assertThat(queryWrapperFile.toString()).contains("package com.example.testmodule")
+
+    val databaseInterfaceFile = result.compilerOutput[File(result.outputDirectory, "com/example/TestDatabase.kt")]
+    assertThat(databaseInterfaceFile).isNotNull()
+    assertThat(databaseInterfaceFile.toString()).contains("import com.example.testmodule.newInstance")
+    assertThat(databaseInterfaceFile.toString()).contains("import com.example.testmodule.schema")
+  }
 }

--- a/test-util/src/main/kotlin/app/cash/sqldelight/test/util/FixtureCompiler.kt
+++ b/test-util/src/main/kotlin/app/cash/sqldelight/test/util/FixtureCompiler.kt
@@ -42,6 +42,7 @@ object FixtureCompiler {
     treatNullAsUnknownForEquality: Boolean = false,
     generateAsync: Boolean = false,
     codegenExcludedColumns: Set<String> = emptySet(),
+    moduleName: String = "testmodule",
   ): CompilationResult {
     writeSql(sql, temporaryFolder, fileName)
     return compileFixture(
@@ -51,6 +52,7 @@ object FixtureCompiler {
       treatNullAsUnknownForEquality = treatNullAsUnknownForEquality,
       generateAsync = generateAsync,
       codegenExcludedColumns = codegenExcludedColumns,
+      moduleName = moduleName,
     )
   }
 
@@ -113,6 +115,7 @@ object FixtureCompiler {
     treatNullAsUnknownForEquality: Boolean = false,
     generateAsync: Boolean = false,
     codegenExcludedColumns: Set<String> = emptySet(),
+    moduleName: String = "testmodule",
   ): CompilationResult {
     val compilerOutput = mutableMapOf<File, StringBuilder>()
     val errors = mutableListOf<String>()
@@ -164,11 +167,11 @@ object FixtureCompiler {
 
     if (generateDb && errors.isEmpty()) {
       val compiledFile = checkNotNull(file)
-      SqlDelightCompiler.writeDatabaseInterface(environment.module, compiledFile, "testmodule", fileWriter)
+      SqlDelightCompiler.writeDatabaseInterface(environment.module, compiledFile, moduleName, fileWriter)
       SqlDelightCompiler.writeImplementations(
         environment.module,
         compiledFile,
-        "testmodule",
+        moduleName,
         fileWriter,
       )
     }


### PR DESCRIPTION
fixes #6235

Only lowercase the `implementationFolder` that contains the module name.

* The module derived package segment is now lower cased in both places where it's used. The user's configured `packageName` is left untouched as it may have intentional capitalized package name in existing codebases.

* Add test and allow `moduleName` to be configured in fixture test instead of hardcoded.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
