### PR TITLE
Add isThreadConfined to Transacter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [Gradle Plugin] Increase minimal support gradle to 8.2.1 (#6217 by @maxsav)
 - [Gradle Plugin] Support gradle isolated projects (#6217 by @maxsav)
 - [IntelliJ Plugin] Minimum version of 2023.3 / Android Studio Jellyfish
+- [Runtime] Allow transactions to be scoped in a coroutine context and not confined to a thread (#6317 by @griffio)
 
 ### Fixed
 - [Gradle Plugin] Suppress `sun.misc.Unsafe` deprecation warnings from the compiler worker on JDK 24+ (#6321)

--- a/runtime/api/runtime.api
+++ b/runtime/api/runtime.api
@@ -91,6 +91,7 @@ public abstract class app/cash/sqldelight/Transacter$Transaction : app/cash/sqld
 	public fun afterRollback (Lkotlin/jvm/functions/Function0;)V
 	protected abstract fun endTransaction (Z)Lapp/cash/sqldelight/db/QueryResult;
 	protected abstract fun getEnclosingTransaction ()Lapp/cash/sqldelight/Transacter$Transaction;
+	protected fun isThreadConfined ()Z
 }
 
 public abstract interface class app/cash/sqldelight/TransacterBase {

--- a/runtime/src/commonMain/kotlin/app/cash/sqldelight/Transacter.kt
+++ b/runtime/src/commonMain/kotlin/app/cash/sqldelight/Transacter.kt
@@ -100,8 +100,9 @@ interface Transacter : TransacterBase {
    * A SQL transaction. Can be created through the driver via [SqlDriver.newTransaction] or
    * through an implementation of [Transacter] by calling [Transacter.transaction].
    *
-   * A transaction is expected never to escape the thread it is created on, or more specifically,
-   * never to escape the lambda scope of [Transacter.transaction] and [Transacter.transactionWithResult].
+   * A transaction is expected never to escape the lambda scope of [Transacter.transaction] and
+   * [Transacter.transactionWithResult]. By default, it is also expected never to escape the thread
+   * it is created on, unless the driver's transaction opts out via [isThreadConfined].
    */
   abstract class Transaction : TransactionCallbacks {
     private val ownerThreadId = currentThreadId()
@@ -120,6 +121,19 @@ interface Transacter : TransacterBase {
      * The parent transaction, if there is any.
      */
     protected abstract val enclosingTransaction: Transaction?
+
+    /**
+     * Whether this transaction may only be used on the thread it was created on.
+     *
+     * When true (the default), using this transaction from another thread is treated as the
+     * transaction object escaping the lambda scope of [Transacter.transaction] and
+     * [Transacter.transactionWithResult], and throws an [IllegalStateException].
+     *
+     * Drivers whose transaction bookkeeping is not bound to a thread, for example an
+     * asynchronous driver whose suspending transaction body may resume on a different thread,
+     * should override this to return false to disable the thread-identity check.
+     */
+    protected open val isThreadConfined: Boolean get() = true
 
     internal fun enclosingTransaction() = enclosingTransaction
 
@@ -151,7 +165,7 @@ interface Transacter : TransacterBase {
       postRollbackHooks.add(function)
     }
 
-    internal fun checkThreadConfinement() = check(ownerThreadId == currentThreadId()) {
+    internal fun checkThreadConfinement() = check(!isThreadConfined || ownerThreadId == currentThreadId()) {
       """
         Transaction objects (`TransactionWithReturn` and `TransactionWithoutReturn`) must be used
         only within the transaction lambda scope.


### PR DESCRIPTION
Add property `isThreadConfined` as a minimal change in the Api.
Determines if this transaction may only be used on the thread it was created on.
If overridden, this property allows an Async Driver to opt-out of the `checkThreadConfinement`.

Currently, the R2dbcDriver is limited to a single connection by the internal `checkThreadConfinement`.

Therefore,  a new `R2dbcPooledDriver` https://github.com/sqldelight/sqldelight/commit/163bd636e580f00b7344b4374a37115601a26eda can be created that supports `ConnectionFactory` and  `SuspendingTransacter` where connections/transactions are scoped to a coroutine context rather than to a thread.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
