### PR TITLE
Fix StackOverflow when FK column is self-referential

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - [PostgreSQL Dialect] Fix json aggregate functions when using nested function call (#6281 by @griffio)
 - [Paging3 Extension] Fix KeyedQueryPagingSource crash on empty database (#6284 by @woods-marshes)
 - [Compiler] Fix Java type adapter issue when mutator statements are used with encapsulating functions like `COALESCE` (#6292 by @griffio)
+- [Compiler] Fix StackOverflow when an FK column is self-referential (#6318 by @eygraber)
 
 ## [2.3.2] - 2026-03-16
 [2.3.2]: https://github.com/sqldelight/sqldelight/releases/tag/2.3.2

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/psi/ColumnTypeMixin.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/lang/psi/ColumnTypeMixin.kt
@@ -84,6 +84,9 @@ internal abstract class ColumnTypeMixin(
       ?.columnNameList?.singleOrNull() // Foreign Column
 
     (tableForeignKeyClause ?: columnConstraint)?.reference?.resolve()?.let { resolvedKey ->
+      // A foreign key can reference the column it constrains. The type is already known, and
+      // recursing into it would never terminate.
+      if (resolvedKey == columnName) return@let
       // Resolved Column
       val dialectType = resolvedKey.asSafely<SqlColumnName>() // Column Name
         ?.parent?.asSafely<SqlColumnDef>() // Column Definition

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/InterfaceGeneration.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/InterfaceGeneration.kt
@@ -758,6 +758,82 @@ class InterfaceGeneration {
     )
   }
 
+  @Test fun `foreign key with column referencing itself does not stack overflow`() {
+    val result = FixtureCompiler.compileSql(
+      """
+      |CREATE TABLE Node (
+      |  a INTEGER NOT NULL UNIQUE,
+      |  FOREIGN KEY (a) REFERENCES Node(a)
+      |);
+      |
+      |selectAll:
+      |SELECT * FROM Node;
+      """.trimMargin(),
+      temporaryFolder,
+    )
+
+    assertThat(result.errors).isEmpty()
+    val generatedInterface = result.compilerOutput.get(
+      File(result.outputDirectory, "com/example/Node.kt"),
+    )
+    assertThat(generatedInterface).isNotNull()
+    assertThat(generatedInterface.toString()).isEqualTo(
+      """
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
+      |package com.example
+      |
+      |import kotlin.Long
+      |
+      |public data class Node(
+      |  public val a: Long,
+      |)
+      |
+      """.trimMargin(),
+    )
+  }
+
+  @Test fun `composite foreign key sharing a column with the referenced key does not stack overflow`() {
+    val result = FixtureCompiler.compileSql(
+      """
+      |CREATE TABLE Item (
+      |  id INTEGER PRIMARY KEY AUTOINCREMENT,
+      |  itemId INTEGER NOT NULL,
+      |  parentId INTEGER,
+      |  UNIQUE (itemId, id),
+      |  FOREIGN KEY (itemId, parentId)
+      |    REFERENCES Item(itemId, id) ON DELETE CASCADE
+      |);
+      |
+      |selectAll:
+      |SELECT * FROM Item;
+      """.trimMargin(),
+      temporaryFolder,
+    )
+
+    assertThat(result.errors).isEmpty()
+    val generatedInterface = result.compilerOutput.get(
+      File(result.outputDirectory, "com/example/Item.kt"),
+    )
+    assertThat(generatedInterface).isNotNull()
+    assertThat(generatedInterface.toString()).isEqualTo(
+      """
+      |@file:Suppress("REDUNDANT_VISIBILITY_MODIFIER", "ASSIGNED_VALUE_IS_NEVER_READ")
+      |
+      |package com.example
+      |
+      |import kotlin.Long
+      |
+      |public data class Item(
+      |  public val id: Long,
+      |  public val itemId: Long,
+      |  public val parentId: Long?,
+      |)
+      |
+      """.trimMargin(),
+    )
+  }
+
   @Test fun `avg aggregate has proper nullable type`() {
     val result = FixtureCompiler.compileSql(
       """


### PR DESCRIPTION
---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
