### PR TITLE
Suppress warning for sun.misc.Unsafe in SqlDelightWorkerTask.kt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [IntelliJ Plugin] Minimum version of 2023.3 / Android Studio Jellyfish
 
 ### Fixed
+- [Gradle Plugin] Suppress `sun.misc.Unsafe` deprecation warnings from the compiler worker on JDK 24+ (#6321)
 - [Compiler] Suppress Kotlin extra warnings in generated code (#6208 by @eyupcanakman)
 - [Compiler] Other columns in a non-grouped aggregate result set are always nullable
 - [PostgreSQL Dialect] Resolve nullability correctly for coalesce and ifnull

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightWorkerTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightWorkerTask.kt
@@ -55,19 +55,11 @@ abstract class SqlDelightWorkerTask : SourceTask() {
  * Suppress "WARNING: A terminally deprecated method in sun.misc.Unsafe has been called".
  * The IntelliJ platform runs on calls to terminally deprecated `sun.misc.Unsafe` memory access methods,
  * which JEP 498 warns about and eventually denies, in phases.
- *
- * Pick the most permissive value the JVM accepts. Values it does not accept prevent it from starting,
- * so JVMs newer than the phases below fall back to the value documented to survive them.
  */
 internal fun unsafeMemoryAccessJvmArgs(javaFeatureVersion: Int): List<String> {
   return when {
-    // The option was only added in JDK 23, and memory access is allowed anyway.
     javaFeatureVersion < 23 -> emptyList()
-    // Phase 1 and 2 warn about memory access, but still accept `allow` to silence it.
     javaFeatureVersion < 26 -> listOf("--sun-misc-unsafe-memory-access=allow")
-    // Phase 3 (JDK 26 at the earliest) denies memory access by default, which fails the compiler with
-    // an UnsupportedOperationException, and no longer accepts `allow`. Reverting to `warn` keeps the
-    // compiler working, at the cost of one warning per worker.
     else -> listOf("--sun-misc-unsafe-memory-access=warn")
   }
 }

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightWorkerTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightWorkerTask.kt
@@ -46,6 +46,21 @@ abstract class SqlDelightWorkerTask : SourceTask() {
       forkOptions.environment("TMPDIR", tmpdir)
       forkOptions.minHeapSize = minHeapSize.orNull
       forkOptions.maxHeapSize = maxHeapSize.get()
+      forkOptions.jvmArgs(unsafeMemoryAccessJvmArgs(Runtime.version().feature()))
     }
+  }
+}
+
+/**
+ * Suppress "WARNING: A terminally deprecated method in sun.misc.Unsafe has been called".
+ * The IntelliJ platform runs on calls to terminally deprecated `sun.misc.Unsafe` memory access methods,
+ * which the JVM warns about since JDK 24 (JEP 498).
+ * The option was only added in JDK 23, and passing it to older JVMs prevents them from starting.
+ */
+private fun unsafeMemoryAccessJvmArgs(javaFeatureVersion: Int): List<String> {
+  return if (javaFeatureVersion >= 23) {
+    listOf("--sun-misc-unsafe-memory-access=allow")
+  } else {
+    emptyList()
   }
 }

--- a/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightWorkerTask.kt
+++ b/sqldelight-gradle-plugin/src/main/kotlin/app/cash/sqldelight/gradle/SqlDelightWorkerTask.kt
@@ -54,13 +54,20 @@ abstract class SqlDelightWorkerTask : SourceTask() {
 /**
  * Suppress "WARNING: A terminally deprecated method in sun.misc.Unsafe has been called".
  * The IntelliJ platform runs on calls to terminally deprecated `sun.misc.Unsafe` memory access methods,
- * which the JVM warns about since JDK 24 (JEP 498).
- * The option was only added in JDK 23, and passing it to older JVMs prevents them from starting.
+ * which JEP 498 warns about and eventually denies, in phases.
+ *
+ * Pick the most permissive value the JVM accepts. Values it does not accept prevent it from starting,
+ * so JVMs newer than the phases below fall back to the value documented to survive them.
  */
-private fun unsafeMemoryAccessJvmArgs(javaFeatureVersion: Int): List<String> {
-  return if (javaFeatureVersion >= 23) {
-    listOf("--sun-misc-unsafe-memory-access=allow")
-  } else {
-    emptyList()
+internal fun unsafeMemoryAccessJvmArgs(javaFeatureVersion: Int): List<String> {
+  return when {
+    // The option was only added in JDK 23, and memory access is allowed anyway.
+    javaFeatureVersion < 23 -> emptyList()
+    // Phase 1 and 2 warn about memory access, but still accept `allow` to silence it.
+    javaFeatureVersion < 26 -> listOf("--sun-misc-unsafe-memory-access=allow")
+    // Phase 3 (JDK 26 at the earliest) denies memory access by default, which fails the compiler with
+    // an UnsupportedOperationException, and no longer accepts `allow`. Reverting to `warn` keeps the
+    // compiler working, at the cost of one warning per worker.
+    else -> listOf("--sun-misc-unsafe-memory-access=warn")
   }
 }


### PR DESCRIPTION
fixes #6076

Currently SqlDelight is on IntelliJ Platform 2023.3.1 (build  233) to support Android Jellyfish.
The official fix that doesn't use Unsafe is first available in IntelliJ Platform 2025.3 (build 253) Android 🐼.

```
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::objectFieldOffset has been called by com.intellij.util.containers.Unsafe 
WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
```

The older IntelliJ platform uses calls to terminally deprecated `sun.misc.Unsafe` memory access methods, using JDKs containing `JEP 498` warns about and eventually denies in phases.

* We need to modify `SqlDelightWorkerTask` `forkOptions.jvmArgs` as this is not exposed due to gradle process isolation
* Sets the `jvmArgs` to `--sun-misc-unsafe-memory-access=allow` up to `JDK 26`, then use `--sun-misc-unsafe-memory-access=warn` to allow worker to run without exception but we end up back to showing warnings.
* Tested with local snapshot build

Note: It will not be possible to use `allow` to avoid the warning in `JDK 26` ...

```
deny will be the default value in phase 3 (JDK 26 or later). 
It will be possible in phase 3 to revert the value from deny to warn in order to 
receive a single warning rather than exceptions. 
It will not be possible to use allow to avoid the warning.
```

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
