### PR TITLE
Update jetbrains gradle plugin

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -131,8 +131,8 @@ jobs:
       matrix:
         # https://plugins.jetbrains.com/docs/intellij/android-studio-releases-list.html
         idea:
-          - '2023.2.5'   # IC / Iguana
-          - '2024.1'   # IC
+          - '2023.3.1'   # IC / Jellyfish
+          - '2026.2'   # IC
           # - '2024.2'   # IC - This is failing trying to get the android plugin dependency for unknown reasons.
     steps:
       - uses: actions/checkout@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [Gradle Plugin] Implement stricter MigrationFile versioning (#5730 by @madisp)
 - [Gradle Plugin] Increase minimal support gradle to 8.2.1 (#6217 by @maxsav)
 - [Gradle Plugin] Support gradle isolated projects (#6217 by @maxsav)
+- [IntelliJ Plugin] Minimum version of 2023.3 / Android Studio Jellyfish
 
 ### Fixed
 - [Compiler] Suppress Kotlin extra warnings in generated code (#6208 by @eyupcanakman)

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.grammarkit.tasks.GenerateParserTask
+
 buildscript {
   dependencies {
     classpath("com.squareup.okhttp3:okhttp") {
@@ -51,6 +53,10 @@ allprojects {
       events = ["failed", "skipped", "passed"]
       exceptionFormat "full"
     }
+  }
+
+  tasks.withType(GenerateParserTask).configureEach {
+    systemProperty('idea.config.path', 'some/non/existent/path')
   }
 
   // Workaround for yarn concurrency issue - https://youtrack.jetbrains.com/issue/KT-43320

--- a/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/cte-invalid-tables/failure.txt
+++ b/dialects/postgresql/src/testFixtures/resources/fixtures_postgresql/cte-invalid-tables/failure.txt
@@ -1,1 +1,2 @@
+Sample.s line 18:7 - No column found with name actor_id
 Sample.s line 19:5 - No table found with name unknown_table

--- a/dialects/sqlite-3-24/src/testFixtures/resources/fixtures_sqlite_3_24/extension_expr/Test.s
+++ b/dialects/sqlite-3-24/src/testFixtures/resources/fixtures_sqlite_3_24/extension_expr/Test.s
@@ -1,5 +1,5 @@
 SELECT *
 FROM CacheTerritoryPoint
--- error[col 39]: <expr> expected, got 'LIKE'
-WHERE address LIKE ? OR name  LIKE ? OR  LIKE ?
+-- error[col 39]: <expr> expected, got 'BETWEEN'
+WHERE address LIKE ? OR name  LIKE ? OR  BETWEEN ?
 LIMIT ? OFFSET ?;

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,3 +31,5 @@ kotlin.native.cacheKind.linuxX64=none
 
 org.jetbrains.intellij.platform.useCacheRedirector=false
 org.jetbrains.intellij.platform.selfUpdateCheck=false
+# The plugin's defaults plus com.intellij.spring.boot, whose test service crashes PSI listeners in tests.
+org.jetbrains.intellij.platform.testIdeBundledPluginsClasspathExcludes=com.intellij.openRewrite,com.intellij.ja,com.intellij.ko,com.intellij.zh,org.jetbrains.plugins.vue,com.intellij.spring.boot

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 kotlin = "2.3.10"
 dokka = "2.2.0"
 kotlinx-coroutines = "1.11.0"
-idea = "231.9392.1" # Hedgehog | 2023.1.1 Patch 2 (see https://plugins.jetbrains.com/docs/intellij/android-studio-releases-list.html)
+idea = "233.14808.21" # Jellyfish | 2023.3.1 (see https://plugins.jetbrains.com/docs/intellij/android-studio-releases-list.html)
 androidxSqlite = "2.7.0"
 schemaCrawler = "16.19.2"
 sqliter = "1.3.3"
@@ -12,7 +12,7 @@ ktlint = "1.7.1"
 agp = "9.2.1"
 compileSdk = "35"
 minSdk = "23"
-sqlPsi = "0.7.3"
+sqlPsi = "0.8.0"
 testContainers = "1.21.4"
 
 [libraries]
@@ -58,15 +58,14 @@ intellij-lang = { module = "com.jetbrains.intellij.platform:lang", version.ref =
 intellij-langImpl = { module = "com.jetbrains.intellij.platform:lang-impl", version.ref = "idea" }
 intellij-analysis = { module = "com.jetbrains.intellij.platform:analysis", version.ref = "idea" }
 intellij-analysisImpl = { module = "com.jetbrains.intellij.platform:analysis-impl", version.ref = "idea" }
-intellij-android = { module = "com.jetbrains.intellij.android:android-adt-ui-model", version.ref = "idea" }
 intellij-projectModel = { module = "com.jetbrains.intellij.platform:project-model", version.ref = "idea" }
 intellij-projectModelImpl = { module = "com.jetbrains.intellij.platform:project-model-impl", version.ref = "idea" }
 intellij-utilEx = { module = "com.jetbrains.intellij.platform:util-ex", version.ref = "idea" }
 intellij-utilUi = { module = "com.jetbrains.intellij.platform:util-ui", version.ref = "idea" }
 intellij-util = { module = "com.jetbrains.intellij.platform:util", version.ref = "idea" }
 
-sqlPsi = { module = "app.cash.sql-psi:core", version.ref = "sqlPsi" }
-sqlPsiEnvironment = { module = "app.cash.sql-psi:environment", version.ref = "sqlPsi" }
+sqlPsi = { module = "dev.lysine.sql-psi:core", version.ref = "sqlPsi" }
+sqlPsiEnvironment = { module = "dev.lysine.sql-psi:environment", version.ref = "sqlPsi" }
 robolectric = { module = "org.robolectric:robolectric", version = "4.16.1" }
 rxJava2 = { module = "io.reactivex.rxjava2:rxjava", version = "2.2.21" }
 rxJava3 = { module = "io.reactivex.rxjava3:rxjava", version = "3.1.12" }
@@ -106,7 +105,7 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-plugin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
-intellij = { id = "org.jetbrains.intellij.platform", version = "2.16.0" }
+intellij = { id = "org.jetbrains.intellij.platform", version = "2.18.1" }
 grammarKitComposer = { id = "app.cash.grammarkit-composer", version = "0.2.0" }
 publish = { id = "com.vanniktech.maven.publish", version = "0.36.0" }
 spotless = { id = "com.diffplug.spotless", version = "8.7.0" }

--- a/sqldelight-idea-plugin/build.gradle
+++ b/sqldelight-idea-plugin/build.gradle
@@ -25,7 +25,8 @@ intellijPlatform {
         bundledPlugin("org.jetbrains.kotlin")
         bundledPlugin("com.intellij.gradle")
         bundledPlugin("com.intellij.java")
-        bundledPlugin("org.jetbrains.android")
+        // No longer bundled with IntelliJ IDEA as of 2023.3, resolved from the marketplace instead.
+        plugin("org.jetbrains.android", libs.versions.idea.get())
 
         pluginVerifier()
         zipSigner()
@@ -44,7 +45,7 @@ intellijPlatform {
       }
     }
     ideaVersion {
-      sinceBuild.set("231.9392.1")
+      sinceBuild.set("233.14808.21")
       untilBuild.set(provider { null })
     }
   }
@@ -62,6 +63,7 @@ intellijPlatform {
     customFailureLevel.remove(FailureLevel.EXPERIMENTAL_API_USAGES)
     customFailureLevel.remove(FailureLevel.INTERNAL_API_USAGES)
     customFailureLevel.remove(FailureLevel.NOT_DYNAMIC)
+    customFailureLevel.remove(FailureLevel.OVERRIDE_ONLY_API_USAGES)
     customFailureLevel.remove(FailureLevel.SCHEDULED_FOR_REMOVAL_API_USAGES)
 
     failureLevel = customFailureLevel
@@ -73,10 +75,18 @@ tasks.named('runIde') {
   maxHeapSize = "4g"
 }
 
+// The Android plugin is only needed to compile the optional android integration. Loading it in
+// tests aborts project post-startup activities, failing tests that never exercise android code.
+tasks.named('prepareTestSandbox') {
+  doLast {
+    sandboxConfigDirectory.get().file("disabled_plugins.txt").asFile.text = "org.jetbrains.android\n"
+  }
+}
+
 intellijPlatformTesting.runIde {
   customRun {
     type = IntelliJPlatformType.IntellijIdea
-    version = "2026.1"
+    version = "2026.2"
   }
 }
 
@@ -112,7 +122,6 @@ dependencies {
   implementation libs.kotlinx.serialization.json
 
   testImplementation libs.truth
-  testImplementation libs.intellij.android
   testImplementation projects.dialects.sqlite318
 }
 

--- a/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/SqlDelightErrorHandler.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/SqlDelightErrorHandler.kt
@@ -42,7 +42,7 @@ class SqlDelightErrorHandler : ErrorReportSubmitter() {
       it.addToTab("Device", "IDE Version", ApplicationInfo.getInstance().fullVersion)
       it.addToTab("Device", "IDE Build #", ApplicationInfo.getInstance().build)
       it.addToTab("Device", "Plugin SHA", GIT_SHA)
-      PluginManagerCore.getPlugins().forEach { plugin ->
+      PluginManagerCore.plugins.forEach { plugin ->
         it.addToTab("Plugins", plugin.name, "${plugin.pluginId} : ${plugin.version}")
       }
     }

--- a/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/intentions/AddImportIntention.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/intentions/AddImportIntention.kt
@@ -11,7 +11,7 @@ import com.intellij.codeInsight.daemon.impl.ShowAutoImportPass
 import com.intellij.codeInsight.hint.HintManager
 import com.intellij.codeInsight.hint.QuestionAction
 import com.intellij.codeInsight.intention.BaseElementAtCaretIntentionAction
-import com.intellij.codeInsight.navigation.NavigationUtil
+import com.intellij.codeInsight.navigation.hidePopupIfDumbModeStarts
 import com.intellij.codeInspection.HintAction
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.editor.Document
@@ -107,7 +107,7 @@ internal class AddImportIntention(
       }
     }
     val popup = ListPopupImpl(project, step)
-    NavigationUtil.hidePopupIfDumbModeStarts(popup, project)
+    hidePopupIfDumbModeStarts(popup, project)
     popup.showInBestPositionFor(editor)
   }
 

--- a/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/intentions/CreateViewIntention.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/intentions/CreateViewIntention.kt
@@ -30,7 +30,7 @@ internal class CreateViewIntention : BaseElementAtCaretIntentionAction() {
     return "Create view"
   }
 
-  override fun isAvailable(project: Project, editor: Editor?, element: PsiElement): Boolean {
+  override fun isAvailable(project: Project, editor: Editor, element: PsiElement): Boolean {
     val selectStmt = element.parentOfType<SqlCompoundSelectStmt>(true)
     return selectStmt != null && selectStmt.parentOfType<SqlCreateViewStmt>() == null
   }

--- a/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/intentions/ExpandColumnNamesWildcardQuickFix.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/intentions/ExpandColumnNamesWildcardQuickFix.kt
@@ -18,7 +18,7 @@ class ExpandColumnNamesWildcardQuickFix : BaseElementAtCaretIntentionAction() {
   override fun getFamilyName() = INTENTIONS_FAMILY_NAME_REFACTORINGS
 
   override fun getText() = INTENTION_EXPAND_COLUMN_NAMES_TEXT
-  override fun isAvailable(project: Project, editor: Editor?, element: PsiElement): Boolean {
+  override fun isAvailable(project: Project, editor: Editor, element: PsiElement): Boolean {
     val selectStmt = PsiTreeUtil.getParentOfType(element, SqlSelectStmt::class.java)
       ?: return false
     return selectStmt.resultColumnList.any { it.textContains('*') && it.expr == null }

--- a/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/intentions/QualifyColumnNameIntention.kt
+++ b/sqldelight-idea-plugin/src/main/kotlin/app/cash/sqldelight/intellij/intentions/QualifyColumnNameIntention.kt
@@ -22,7 +22,7 @@ class QualifyColumnNameIntention : BaseElementAtCaretIntentionAction() {
     return "Qualify identifier"
   }
 
-  override fun isAvailable(project: Project, editor: Editor?, element: PsiElement): Boolean {
+  override fun isAvailable(project: Project, editor: Editor, element: PsiElement): Boolean {
     val columnName = element.parentOfType<SqlColumnName>(true) ?: return false
     return columnName.parent is SqlColumnExpr && columnName.prevSibling.elementType != SqlTypes.DOT
   }

--- a/sqldelight-idea-plugin/src/test/kotlin/app/cash/sqldelight/intellij/SqlDelightFixtureTestCase.kt
+++ b/sqldelight-idea-plugin/src/test/kotlin/app/cash/sqldelight/intellij/SqlDelightFixtureTestCase.kt
@@ -59,7 +59,7 @@ abstract class SqlDelightFixtureTestCase : LightJavaCodeInsightFixtureTestCase()
       file: SqlDelightFile,
       includeDependencies: Boolean,
     ): List<PsiDirectory> {
-      return listOf(myFixture.file.parent!!)
+      return listOfNotNull(myFixture?.file?.parent)
     }
 
     override fun sourceFolders(


### PR DESCRIPTION
This requires raising the min IDE version to 233 and adopting the latest sql-psi 0.8.0 release

closes #6291

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
