### PR TITLE
Set buildLogic jvm target to 17

### DIFF
--- a/buildLogic/build.gradle
+++ b/buildLogic/build.gradle
@@ -7,13 +7,13 @@ plugins {
 
 allprojects {
   tasks.withType(JavaCompile).configureEach {
-    sourceCompatibility = '11'
-    targetCompatibility = '11'
+    sourceCompatibility = '17'
+    targetCompatibility = '17'
   }
 
   tasks.withType(KotlinJvmCompile).configureEach {
     compilerOptions {
-      jvmTarget = JvmTarget.JVM_11
+      jvmTarget = JvmTarget.JVM_17
     }
   }
 }


### PR DESCRIPTION
This is required to update AGP to 9.3.1, which is now java 17 bytecode.

Unblocks #6308
