### PR TITLE
Support case-insensitive date data type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - [Paging3 Extension] Fix KeyedQueryPagingSource crash on empty database (#6284 by @woods-marshes)
 - [Compiler] Fix Java type adapter issue when mutator statements are used with encapsulating functions like `COALESCE` (#6292 by @griffio)
 - [Compiler] Fix where the module name was capitalized, the generated code's package name also was capitalized (#6316 by @griffio)
+- [PostgreSQL Dialect] Allow date data types to be case-insensitive (#6328 by @griffio)
 
 ## [2.3.2] - 2026-03-16
 [2.3.2]: https://github.com/sqldelight/sqldelight/releases/tag/2.3.2

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
@@ -72,7 +72,7 @@ open class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : Ty
         serialDataType != null -> PostgreSqlType.INTEGER
         bigSerialDataType != null -> PostgreSqlType.BIG_INT
         dateDataType != null -> {
-          when (dateDataType!!.firstChild.text) {
+          when (dateDataType!!.firstChild.text.uppercase()) {
             "DATE" -> PostgreSqlType.DATE
             "TIME" -> PostgreSqlType.TIME
             "TIMESTAMP" -> if (dateDataType!!.node.getChildren(null).any { it.text == "WITH" }) TIMESTAMP_TIMEZONE else TIMESTAMP


### PR DESCRIPTION
fixes #6107

The convention in SqlDelight is for uppercased types and keywords  https://github.com/sqldelight/sqldelight/issues/3345

In this case, Date types are literals matched in the type resolver and can be supported as case-insensitive and atleast avoids the cryptic error.  

* Adds uppercase as this is now the same as MySql.
   * https://github.com/sqldelight/sqldelight/blob/45c9012d209f15cdefb9438d64e3512aecb5cc0b/dialects/mysql/src/main/kotlin/app/cash/sqldelight/dialects/mysql/MySqlTypeResolver.kt#L213
* Upper case to match on literal `DATE`, `TIME`, `TIMESTAMP`

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
