### PR TITLE
Fix Postgres string_agg to be nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Fixed
 
-- Nothing yet!
+- [PostgreSQL Dialect] Fix `string_agg` function to be nullable (#6340 by @griffio)
 
 
 ## [2.4.0-rc1] - 2026-09-01
@@ -63,7 +63,6 @@
 - [Compiler] Fix Java type adapter issue when mutator statements are used with encapsulating functions like `COALESCE` (#6292 by @griffio)
 - [Compiler] Fix where the module name was capitalized, the generated code's package name also was capitalized (#6316 by @griffio)
 - [PostgreSQL Dialect] Allow date data types to be case-insensitive (#6328 by @griffio)
-- [PostgreSQL Dialect] Fix `string_agg` function to be nullable (#6340 by @griffio)
 
 ## [2.3.2] - 2026-03-16
 [2.3.2]: https://github.com/sqldelight/sqldelight/releases/tag/2.3.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 - [Compiler] Fix Java type adapter issue when mutator statements are used with encapsulating functions like `COALESCE` (#6292 by @griffio)
 - [Compiler] Fix where the module name was capitalized, the generated code's package name also was capitalized (#6316 by @griffio)
 - [PostgreSQL Dialect] Allow date data types to be case-insensitive (#6328 by @griffio)
+- [PostgreSQL Dialect] Fix `string_agg` function to be nullable (#6340 by @griffio)
 
 ## [2.3.2] - 2026-03-16
 [2.3.2]: https://github.com/sqldelight/sqldelight/releases/tag/2.3.2

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/PostgreSqlTypeResolver.kt
@@ -220,7 +220,7 @@ open class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : Ty
       val typeForAgg = encapsulatingTypePreferringKotlin(exprList, SMALL_INT, PostgreSqlType.INTEGER, BIG_INT, REAL, PostgreSqlType.NUMERIC, TEXT, TIMESTAMP_TIMEZONE, TIMESTAMP, DATE).asNullable()
       arrayIntermediateType(typeForAgg)
     }
-    "string_agg" -> IntermediateType(TEXT)
+    "string_agg" -> IntermediateType(TEXT).asNullable()
     "json_array_length", "jsonb_array_length" -> IntermediateType(PostgreSqlType.INTEGER)
     "jsonb_path_exists", "jsonb_path_match", "jsonb_path_exists_tz", "jsonb_path_match_tz" -> IntermediateType(BOOLEAN)
     "currval", "lastval", "nextval", "setval" -> IntermediateType(BIG_INT)
@@ -378,7 +378,7 @@ open class PostgreSqlTypeResolver(private val parentResolver: TypeResolver) : Ty
         arrayIntermediateType(typeForArray)
       }
       stringAggStmt != null -> {
-        IntermediateType(TEXT)
+        IntermediateType(TEXT).asNullable()
       }
       windowFunctionExpr != null -> {
         val windowFunctionExpr = windowFunctionExpr as WindowFunctionMixin

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -828,13 +828,17 @@ json_function_stmt ::= ( 'row_to_json' | 'to_json' | 'to_jsonb' ) LP ( {table_al
 
 json_agg_stmt ::= ( 'json_agg' | 'jsonb_agg' | 'json_agg_strict' | 'jsonb_agg_strict')
 LP [ ALL | DISTINCT ] ( json_expression | {table_alias} | {table_name} | <<expr '-1'>> ) [ ORDER BY {ordering_term} ( COMMA {ordering_term} ) * ] RP
-[ 'FILTER' LP WHERE <<expr '-1'>> [ double_colon_cast_operator ] RP ]
+[ 'FILTER' LP WHERE <<expr '-1'>> [ double_colon_cast_operator ] RP ] {
+ mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.AggregateExpressionMixin"
+}
 
 json_object_agg_stmt ::= ('json_object_agg' | 'jsonb_object_agg' | 'json_object_agg_strict' | 'jsonb_object_agg_strict'
-| 'json_object_agg_unique' | 'jsonb_object_agg_unique' | 'json_object_agg_unique_strict' | 'jsonb_object_agg_unique_strict' ) {
+| 'json_object_agg_unique' | 'jsonb_object_agg_unique' | 'json_object_agg_unique_strict' | 'jsonb_object_agg_unique_strict' )
 LP [ ALL | DISTINCT ] ( json_expression | {column_expr} | <<expr '-1'>> ) COMMA ( json_expression | {column_expr} | <<expr '-1'>> )
 [ ORDER BY {ordering_term} ( COMMA {ordering_term} ) * ] RP
-[ 'FILTER' LP WHERE <<expr '-1'>> [ double_colon_cast_operator ] RP ]
+[ 'FILTER' LP WHERE <<expr '-1'>> [ double_colon_cast_operator ] RP ] {
+ mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.AggregateExpressionMixin"
+}
 
 geometry_point_function_stmt ::= ( ( 'ST_POINTZM' | 'ST_POINTZ' | 'ST_POINTM' | 'ST_POINT' ) LP ( {bind_expr} | {signed_number} ) ( COMMA ( {bind_expr} | {signed_number} ) ) * [ COMMA {signed_number} ] RP ) |
 ( ( 'ST_MAKEPOINTM' | 'ST_MAKEPOINT' ) LP ( {bind_expr} | {signed_number} ) ( COMMA ( {bind_expr} | {signed_number} ) ) * RP ) {
@@ -847,6 +851,7 @@ geometry_setsrid_function_stmt ::= 'ST_SetSRID' LP geometry_point_function_stmt 
 
 string_agg_stmt ::= 'string_agg' LP [ ALL | DISTINCT ] <<expr '-1'>> COMMA string_literal [ ORDER BY {ordering_term} ( COMMA {ordering_term} ) * ] RP
 [ 'FILTER' LP WHERE <<expr '-1'>> RP ] {
+ mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.AggregateExpressionMixin"
 }
 
 array_agg_stmt ::= 'array_agg' LP [ ALL | DISTINCT ] <<expr '-1'>> [ ORDER BY {ordering_term} ( COMMA {ordering_term} ) * ] RP

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/AggregateExpressionMixin.kt
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/mixins/AggregateExpressionMixin.kt
@@ -1,13 +1,18 @@
 package app.cash.sqldelight.dialects.postgresql.grammar.mixins
 
-import app.cash.sqldelight.dialects.postgresql.grammar.psi.PostgreSqlArrayAggStmt
+import app.cash.sqldelight.dialect.api.AggregateFunctionExpression
 import com.alecstrong.sql.psi.core.psi.SqlCompositeElementImpl
 import com.alecstrong.sql.psi.core.psi.SqlExpr
 import com.intellij.lang.ASTNode
 
+/**
+ * The aggregates `array_agg`, `string_agg`, `json_agg` and `json_object_agg` are parsed as their own
+ * expressions instead of a SqlFunctionExpr, this exposes them as an AggregateFunctionExpression for
+ * the compiler.
+ */
 internal abstract class AggregateExpressionMixin(
   node: ASTNode,
 ) : SqlCompositeElementImpl(node),
-  PostgreSqlArrayAggStmt {
-  val expr get() = children.filterIsInstance<SqlExpr>().first()
+  AggregateFunctionExpression {
+  val expr: SqlExpr get() = functionArguments.first()
 }

--- a/sqldelight-compiler/dialect/src/main/kotlin/app/cash/sqldelight/dialect/api/AggregateFunctionExpression.kt
+++ b/sqldelight-compiler/dialect/src/main/kotlin/app/cash/sqldelight/dialect/api/AggregateFunctionExpression.kt
@@ -1,0 +1,34 @@
+package app.cash.sqldelight.dialect.api
+
+import com.alecstrong.sql.psi.core.psi.SqlAnnotatedElement
+import com.alecstrong.sql.psi.core.psi.SqlExpr
+
+/**
+ * An aggregate function which a dialect parses as its own expression rather than as a SqlFunctionExpr,
+ * for example Sqlite 3.44 `group_concat(name, ',' ORDER BY name)` or PostgreSql `string_agg(name, ',') ORDER BY name`.
+ *
+ * Implementing AggregateFunctionExpression treats the expression as an aggregate when working out the
+ * nullability of a query's columns.
+ *
+ * The defaults assume the grammar of `name ( arguments ) [ FILTER ( WHERE condition ) ]`.
+ */
+interface AggregateFunctionExpression : SqlAnnotatedElement {
+  val functionName: String get() = node.firstChildNode.text
+
+  /** The expressions being aggregated, whose nullability the result of the aggregate follows. */
+  val functionArguments: List<SqlExpr>
+    get() {
+      val filterClause = filterClauseOffset() ?: Int.MAX_VALUE
+      return children.filterIsInstance<SqlExpr>().filter { it.node.startOffset < filterClause }
+    }
+
+  /**
+   * True if the aggregate can return NULL for a group of non null functionArguments, for example
+   * because a FILTER clause can exclude every row of a group.
+   */
+  val canReturnNullForNonNullArguments: Boolean get() = filterClauseOffset() != null
+}
+
+private fun AggregateFunctionExpression.filterClauseOffset(): Int? = node.getChildren(null)
+  .firstOrNull { it.text.equals("FILTER", ignoreCase = true) }
+  ?.startOffset

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/ExpressionTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/ExpressionTest.kt
@@ -427,6 +427,76 @@ class ExpressionTest {
     ).inOrder()
   }
 
+  @Test fun `string_agg over a non null column is nullable without a group`() {
+    val file = FixtureCompiler.parseSql(
+      """
+      |CREATE TABLE test (
+      |  name TEXT NOT NULL
+      |);
+      |
+      |someSelect:
+      |SELECT string_agg(name, ','), string_agg(DISTINCT name, ',' ORDER BY name)
+      |FROM test;
+      """.trimMargin(),
+      tempFolder,
+      dialect = POSTGRESQL.dialect,
+    )
+
+    val query = file.namedQueries.first()
+    assertThat(query.resultColumns.map { it.javaType }).containsExactly(
+      String::class.asClassName().copy(nullable = true),
+      String::class.asClassName().copy(nullable = true),
+    ).inOrder()
+  }
+
+  @Test fun `string_agg over a non null column stays nullable with a group`() {
+    val file = FixtureCompiler.parseSql(
+      """
+      |CREATE TABLE test (
+      |  id INTEGER NOT NULL,
+      |  name TEXT NOT NULL
+      |);
+      |
+      |someSelect:
+      |SELECT id, string_agg(name, ',')
+      |FROM test
+      |GROUP BY id;
+      """.trimMargin(),
+      tempFolder,
+      dialect = POSTGRESQL.dialect,
+    )
+
+    val query = file.namedQueries.first()
+    assertThat(query.resultColumns.map { it.javaType }).containsExactly(
+      INT,
+      String::class.asClassName().copy(nullable = true),
+    ).inOrder()
+  }
+
+  @Test fun `string_agg over a nullable column stays nullable with a group`() {
+    val file = FixtureCompiler.parseSql(
+      """
+      |CREATE TABLE test (
+      |  id INTEGER,
+      |  name TEXT
+      |);
+      |
+      |someSelect:
+      |SELECT id, string_agg(name, ',')
+      |FROM test
+      |GROUP BY id;
+      """.trimMargin(),
+      tempFolder,
+      dialect = POSTGRESQL.dialect,
+    )
+
+    val query = file.namedQueries.first()
+    assertThat(query.resultColumns.map { it.javaType }).containsExactly(
+      INT.copy(nullable = true),
+      String::class.asClassName().copy(nullable = true),
+    ).inOrder()
+  }
+
   @Test fun `instr function returns nullable int if any of the args are null`() {
     val file = FixtureCompiler.parseSql(
       """


### PR DESCRIPTION
First problem: Using Postgres dialect, it had a null pointer exception in the case of an empty table, because currently "string_agg" is always resolved to non-nullable `String`.

All aggregates functions in Postgres return a single row : `sum, max, array_agg, string_agg` return `NULL` when there's nothing to aggregate. Except `count`, it returns 0.

```sql
SELECT string_agg(name, ','), string_agg(DISTINCT name, ',' ORDER BY name)
FROM test; -- null, null
```
Current work arounds with empty table:
`SELECT COALESCE(STRING_AGG(name, ', '), '') FROM test` for `String` result  
`SELECT COALESCE(STRING_AGG(name, ', '), NULL) FROM test` for `String?` result

Second problem: Used with `GROUP BY`

This PR is only part 1 and is completed in part 2

Group By rules:

1. `string_agg` with `GROUP BY` without `FILTER` uses column nullability for result 
2. `string_agg` with `GROUP BY` and `FILTER` uses nullable for result since potentially can return empty

Using a not null `name` and `string_agg` with `GROUP BY` produces a non-null result column for
```sql
SELECT id, string_agg(name, ',') FROM test GROUP BY id
```

Using a not null `name` and `string_agg` with `FILTER` and `GROUP BY` produces a nullable result column for 
```sql
SELECT id,  string_agg(distinct name, 'a' ORDER BY name) FILTER (WHERE id > 1)
FROM test
GROUP BY id;
```

Adds new `app.cash.sqldelight.dialect.api.AggregateFunctionExpression` initially implemented by Postgresql
Adds tests to check that using `string_agg` with `GROUP BY` doesn't change the column type nullability. 

Part 2 - for Sqlite 3.44
https://github.com/sqldelight/sqldelight/pull/6343

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
