### PR TITLE
Fix Sqlite 3.44 aggregates using GROUP BY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 - [Compiler] Fix Java type adapter issue when mutator statements are used with encapsulating functions like `COALESCE` (#6292 by @griffio)
 - [Compiler] Fix where the module name was capitalized, the generated code's package name also was capitalized (#6316 by @griffio)
 - [PostgreSQL Dialect] Allow date data types to be case-insensitive (#6328 by @griffio)
+- [PostgreSQL Dialect] Fix `string_agg` function to be nullable (#6340 by @griffio)
 
 ## [2.3.2] - 2026-03-16
 [2.3.2]: https://github.com/sqldelight/sqldelight/releases/tag/2.3.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### Fixed
 
 - [PostgreSQL Dialect] Fix `string_agg` function to be nullable (#6340 by @griffio)
-
+- [SQLite Dialect] Fix SQLite 3.44 aggregate functions using `GROUP BY` (#6343 by @griffio)
 
 ## [2.4.0-rc1] - 2026-09-01
 [2.4.0-rc1]: https://github.com/sqldelight/sqldelight/releases/tag/2.4.0-rc1
@@ -63,7 +63,6 @@
 - [Compiler] Fix Java type adapter issue when mutator statements are used with encapsulating functions like `COALESCE` (#6292 by @griffio)
 - [Compiler] Fix where the module name was capitalized, the generated code's package name also was capitalized (#6316 by @griffio)
 - [PostgreSQL Dialect] Allow date data types to be case-insensitive (#6328 by @griffio)
-- [PostgreSQL Dialect] Fix `string_agg` function to be nullable (#6340 by @griffio)
 
 ## [2.3.2] - 2026-03-16
 [2.3.2]: https://github.com/sqldelight/sqldelight/releases/tag/2.3.2

--- a/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
+++ b/dialects/postgresql/src/main/kotlin/app/cash/sqldelight/dialects/postgresql/grammar/PostgreSql.bnf
@@ -849,7 +849,7 @@ geometry_setsrid_function_stmt ::= 'ST_SetSRID' LP geometry_point_function_stmt 
  mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.GeometryStmtExpressionMixin"
 }
 
-string_agg_stmt ::= 'string_agg' LP [ ALL | DISTINCT ] <<expr '-1'>> COMMA string_literal [ ORDER BY {ordering_term} ( COMMA {ordering_term} ) * ] RP
+string_agg_stmt ::= 'string_agg' LP [ ALL | DISTINCT ] <<expr '-1'>> COMMA <<expr '-1'>> [ ORDER BY {ordering_term} ( COMMA {ordering_term} ) * ] RP
 [ 'FILTER' LP WHERE <<expr '-1'>> RP ] {
  mixin = "app.cash.sqldelight.dialects.postgresql.grammar.mixins.AggregateExpressionMixin"
 }

--- a/dialects/sqlite-3-44/src/main/kotlin/app/cash/sqldelight/dialects/sqlite_3_44/grammar/mixins/AggregateFunctionExprMixin.kt
+++ b/dialects/sqlite-3-44/src/main/kotlin/app/cash/sqldelight/dialects/sqlite_3_44/grammar/mixins/AggregateFunctionExprMixin.kt
@@ -1,0 +1,32 @@
+package app.cash.sqldelight.dialects.sqlite_3_44.grammar.mixins
+
+import app.cash.sqldelight.dialect.api.AggregateFunctionExpression
+import com.alecstrong.sql.psi.core.SqlAnnotationHolder
+import com.alecstrong.sql.psi.core.psi.SqlCompositeElementImpl
+import com.alecstrong.sql.psi.core.psi.SqlTypes
+import com.intellij.lang.ASTNode
+
+/**
+ * `group_concat` and `string_agg` are parsed as an aggregate function expression instead of a
+ * SqlFunctionExpr, so expose them as an AggregateFunctionExpression for the compiler.
+ *
+ * Sqlite only allows `DISTINCT` on an aggregate with a single argument and always requires the
+ * separator argument of `string_agg`, use error annotation.
+ */
+internal abstract class AggregateFunctionExprMixin(
+  node: ASTNode,
+) : SqlCompositeElementImpl(node),
+  AggregateFunctionExpression {
+  private val distinct get() = node.findChildByType(SqlTypes.DISTINCT)
+
+  private val separator get() = functionArguments.getOrNull(1)
+
+  override fun annotate(annotationHolder: SqlAnnotationHolder) {
+    super.annotate(annotationHolder)
+    if (functionName.lowercase() == "string_agg" && separator == null) {
+      annotationHolder.createErrorAnnotation(this, "Wrong number of arguments to function string_agg()")
+    } else if (distinct != null && separator != null) {
+      annotationHolder.createErrorAnnotation(this, "DISTINCT aggregates must have exactly one argument")
+    }
+  }
+}

--- a/dialects/sqlite-3-44/src/main/kotlin/app/cash/sqldelight/dialects/sqlite_3_44/grammar/sqlite.bnf
+++ b/dialects/sqlite-3-44/src/main/kotlin/app/cash/sqldelight/dialects/sqlite_3_44/grammar/sqlite.bnf
@@ -41,8 +41,9 @@ ordering_term ::= <<expr '-1'>> [ COLLATE {collation_name} ] [ ASC | DESC ] [ 'N
   override = true
 }
 
-aggregate_function_expr ::= ('string_agg' | 'group_concat') LP [ DISTINCT ] <<expr '-1'>> [ COMMA {string_literal} ] [ ORDER BY {ordering_term} ( COMMA {ordering_term} ) * ] RP
+aggregate_function_expr ::= ('string_agg' | 'group_concat') LP [ DISTINCT ] <<expr '-1'>> [ COMMA <<expr '-1'>> ] [ ORDER BY {ordering_term} ( COMMA {ordering_term} ) * ] RP
 [ 'FILTER' LP WHERE <<expr '-1'>> RP ] {
+  mixin = "app.cash.sqldelight.dialects.sqlite_3_44.grammar.mixins.AggregateFunctionExprMixin"
 }
 
 private sqlite_3_25_window_function_expr ::= <<windowFunctionExprExt <<window_function_expr_real>>>>

--- a/dialects/sqlite-3-44/src/testFixtures/resources/fixtures_sqlite_3_44/aggregate_functions/Test.s
+++ b/dialects/sqlite-3-44/src/testFixtures/resources/fixtures_sqlite_3_44/aggregate_functions/Test.s
@@ -30,3 +30,20 @@ FROM users;
 SELECT STRING_AGG(name, ', ' ORDER BY created_at DESC)
 FROM users;
 
+
+-- The separator is any expression, not only a string literal
+SELECT GROUP_CONCAT(name, created_at)
+FROM users;
+
+SELECT STRING_AGG(name, created_at)
+FROM users;
+
+SELECT STRING_AGG(name, created_at ORDER BY name)
+FROM users;
+
+SELECT STRING_AGG(name, ', ' || ' ' ORDER BY name)
+FROM users;
+
+SELECT STRING_AGG(name, created_at ORDER BY name)
+   FILTER (WHERE active = 1)
+FROM users;

--- a/dialects/sqlite-3-44/src/testFixtures/resources/fixtures_sqlite_3_44/aggregate_functions_distinct/Test.s
+++ b/dialects/sqlite-3-44/src/testFixtures/resources/fixtures_sqlite_3_44/aggregate_functions_distinct/Test.s
@@ -1,0 +1,32 @@
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY,
+  name TEXT
+);
+
+-- Sqlite allows DISTINCT only on an aggregate with a single argument
+SELECT GROUP_CONCAT(DISTINCT name)
+FROM users;
+
+SELECT GROUP_CONCAT(DISTINCT name ORDER BY name)
+FROM users;
+
+-- error[col 7]: DISTINCT aggregates must have exactly one argument
+SELECT GROUP_CONCAT(DISTINCT name, ', ')
+FROM users;
+
+-- error[col 7]: DISTINCT aggregates must have exactly one argument
+SELECT GROUP_CONCAT(DISTINCT name, ', ' ORDER BY name)
+FROM users;
+
+-- error[col 7]: DISTINCT aggregates must have exactly one argument
+SELECT STRING_AGG(DISTINCT name, ', ')
+FROM users;
+
+-- string_agg always requires the separator argument
+-- error[col 7]: Wrong number of arguments to function string_agg()
+SELECT STRING_AGG(name)
+FROM users;
+
+-- error[col 7]: Wrong number of arguments to function string_agg()
+SELECT STRING_AGG(DISTINCT name)
+FROM users;

--- a/dialects/sqlite-3-44/src/testFixtures/resources/fixtures_sqlite_3_44/aggregate_functions_distinct/Test.s
+++ b/dialects/sqlite-3-44/src/testFixtures/resources/fixtures_sqlite_3_44/aggregate_functions_distinct/Test.s
@@ -30,3 +30,7 @@ FROM users;
 -- error[col 7]: Wrong number of arguments to function string_agg()
 SELECT STRING_AGG(DISTINCT name)
 FROM users;
+
+-- error[col 7]: DISTINCT aggregates must have exactly one argument
+SELECT STRING_AGG(DISTINCT name, name)
+FROM users;

--- a/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/model/NamedQuery.kt
+++ b/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/model/NamedQuery.kt
@@ -30,6 +30,7 @@ import app.cash.sqldelight.core.lang.util.table
 import app.cash.sqldelight.core.lang.util.tablesObserved
 import app.cash.sqldelight.core.lang.util.type
 import app.cash.sqldelight.core.psi.SqlDelightStmtClojureStmtList
+import app.cash.sqldelight.dialect.api.AggregateFunctionExpression
 import app.cash.sqldelight.dialect.api.IntermediateType
 import app.cash.sqldelight.dialect.api.PrimitiveType.ARGUMENT
 import app.cash.sqldelight.dialect.api.PrimitiveType.BLOB
@@ -42,12 +43,14 @@ import app.cash.sqldelight.dialect.api.QueryWithResults
 import app.cash.sqldelight.dialect.api.SelectQueryable
 import com.alecstrong.sql.psi.core.psi.NamedElement
 import com.alecstrong.sql.psi.core.psi.QueryElement
+import com.alecstrong.sql.psi.core.psi.SqlColumnAlias
 import com.alecstrong.sql.psi.core.psi.SqlCompoundSelectStmt
 import com.alecstrong.sql.psi.core.psi.SqlCreateVirtualTableStmt
 import com.alecstrong.sql.psi.core.psi.SqlExpr
 import com.alecstrong.sql.psi.core.psi.SqlFunctionExpr
 import com.alecstrong.sql.psi.core.psi.SqlInsertStmt
 import com.alecstrong.sql.psi.core.psi.SqlPragmaName
+import com.alecstrong.sql.psi.core.psi.SqlResultColumn
 import com.alecstrong.sql.psi.core.psi.SqlSelectStmt
 import com.alecstrong.sql.psi.core.psi.SqlValuesExpression
 import com.intellij.psi.PsiElement
@@ -269,13 +272,45 @@ data class NamedQuery(
     }
   }
 
-  private fun PsiElement.asAggregateFunction(): SqlFunctionExpr? = (this as? SqlFunctionExpr)?.takeIf { it.functionName.text.lowercase() in AGGREGATE_FUNCTIONS }
+  private fun PsiElement.asAggregateFunction(): AggregateFunction? = when (val expr = resolveAliasedExpression().unwrapAggregateExpression()) {
+    is SqlFunctionExpr -> expr.functionName.text.lowercase()
+      .takeIf { it in AGGREGATE_FUNCTIONS }
+      ?.let { AggregateFunction(it, expr.exprList, canReturnNullForNonNullArguments = false) }
+    is AggregateFunctionExpression -> AggregateFunction(
+      name = expr.functionName.lowercase(),
+      arguments = expr.functionArguments,
+      canReturnNullForNonNullArguments = expr.canReturnNullForNonNullArguments,
+    )
+    else -> null
+  }
+
+  // An aliased result column exposes the alias rather than the expression it names, so look the
+  // expression back up to keep the nullability of an aliased aggregate.
+  private fun PsiElement.resolveAliasedExpression(): PsiElement = if (this is SqlColumnAlias) (parent as? SqlResultColumn)?.expr ?: this else this
+
+  // A dialect can parse an aggregate as its own expression wrapped in other expressions, e.g. Sqlite
+  // 3.44 parses group_concat as SqlOtherExpr(SqliteExtensionExpr(SqliteAggregateFunctionExpr)), so
+  // descend through single child wrappers to find it.
+  private fun PsiElement.unwrapAggregateExpression(): PsiElement {
+    var current = this
+    while (current !is SqlFunctionExpr && current !is AggregateFunctionExpression) {
+      current = current.children.singleOrNull() ?: return this
+    }
+    return current
+  }
+
+  private class AggregateFunction(
+    val name: String,
+    val arguments: List<SqlExpr>,
+    val canReturnNullForNonNullArguments: Boolean,
+  )
 
   // count/total always return a value; max/min/sum/avg/group_concat return NULL when their
   // argument is NULL (e.g. group_concat over a nullable LEFT JOIN column).
-  private fun SqlFunctionExpr.alwaysReturnsNonNull(): Boolean {
-    if (functionName.text.lowercase() in NON_NULLABLE_AGGREGATE_FUNCTIONS) return true
-    return exprList.isNotEmpty() && exprList.none { it.type().javaType.isNullable }
+  private fun AggregateFunction.alwaysReturnsNonNull(): Boolean {
+    if (canReturnNullForNonNullArguments) return false
+    if (name in NON_NULLABLE_AGGREGATE_FUNCTIONS) return true
+    return arguments.isNotEmpty() && arguments.none { it.type().javaType.isNullable }
   }
 
   private fun QueryElement.QueryColumn.type(): IntermediateType {

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/ExpressionTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/ExpressionTest.kt
@@ -473,6 +473,31 @@ class ExpressionTest {
     ).inOrder()
   }
 
+  @Test fun `string_agg with a column separator is non null with a group`() {
+    val file = FixtureCompiler.parseSql(
+      """
+      |CREATE TABLE test (
+      |  id INTEGER NOT NULL,
+      |  name TEXT NOT NULL,
+      |  separator TEXT NOT NULL
+      |);
+      |
+      |someSelect:
+      |SELECT id, string_agg(name, separator)
+      |FROM test
+      |GROUP BY id;
+      """.trimMargin(),
+      tempFolder,
+      dialect = POSTGRESQL.dialect,
+    )
+
+    val query = file.namedQueries.first()
+    assertThat(query.resultColumns.map { it.javaType }).containsExactly(
+      INT,
+      String::class.asClassName(),
+    ).inOrder()
+  }
+
   @Test fun `string_agg with a filter stays nullable with a group`() {
     val file = FixtureCompiler.parseSql(
       """
@@ -595,6 +620,32 @@ class ExpressionTest {
     ).inOrder()
   }
 
+  @Test fun `string_agg with a column separator and an order by is non null with a group`() {
+    val file = FixtureCompiler.parseSql(
+      """
+      |CREATE TABLE test (
+      |  id INTEGER NOT NULL,
+      |  name TEXT NOT NULL,
+      |  separator TEXT NOT NULL
+      |);
+      |
+      |someSelect:
+      |SELECT id,
+      |       string_agg(name, separator ORDER BY name)
+      |FROM test
+      |GROUP BY id;
+      """.trimMargin(),
+      tempFolder,
+      dialect = TestDialect.SQLITE_3_44.dialect,
+    )
+
+    val query = file.namedQueries.first()
+    assertThat(query.resultColumns.map { it.javaType }).containsExactly(
+      LONG,
+      String::class.asClassName(),
+    ).inOrder()
+  }
+
   @Test fun `group_concat with an order by over a nullable column stays nullable with a group`() {
     val file = FixtureCompiler.parseSql(
       """
@@ -667,6 +718,45 @@ class ExpressionTest {
       LONG.copy(nullable = true),
       String::class.asClassName().copy(nullable = true),
     ).inOrder()
+  }
+
+  @Test fun `aliased aggregate keeps the aggregate nullability`() {
+    val file = FixtureCompiler.parseSql(
+      """
+      |CREATE TABLE test (
+      |  id INTEGER NOT NULL,
+      |  name TEXT NOT NULL
+      |);
+      |
+      |someSelect:
+      |SELECT count(*) AS total
+      |FROM test;
+      """.trimMargin(),
+      tempFolder,
+      dialect = TestDialect.SQLITE_3_44.dialect,
+    )
+
+    val query = file.namedQueries.first()
+    assertThat(query.resultColumns.map { it.javaType }).containsExactly(LONG).inOrder()
+  }
+
+  @Test fun `aliased json_agg is non null`() {
+    val file = FixtureCompiler.parseSql(
+      """
+      |CREATE TABLE test (
+      |  data JSON NOT NULL
+      |);
+      |
+      |someSelect:
+      |SELECT json_agg(data) FILTER (WHERE data IS NOT NULL) AS rows
+      |FROM test;
+      """.trimMargin(),
+      tempFolder,
+      dialect = POSTGRESQL.dialect,
+    )
+
+    val query = file.namedQueries.first()
+    assertThat(query.resultColumns.map { it.javaType.isNullable }).containsExactly(false).inOrder()
   }
 
   @Test fun `instr function returns nullable int if any of the args are null`() {

--- a/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/ExpressionTest.kt
+++ b/sqldelight-compiler/src/test/kotlin/app/cash/sqldelight/core/queries/ExpressionTest.kt
@@ -449,7 +449,7 @@ class ExpressionTest {
     ).inOrder()
   }
 
-  @Test fun `string_agg over a non null column stays nullable with a group`() {
+  @Test fun `string_agg over a non null column is non null with a group`() {
     val file = FixtureCompiler.parseSql(
       """
       |CREATE TABLE test (
@@ -469,7 +469,55 @@ class ExpressionTest {
     val query = file.namedQueries.first()
     assertThat(query.resultColumns.map { it.javaType }).containsExactly(
       INT,
+      String::class.asClassName(),
+    ).inOrder()
+  }
+
+  @Test fun `string_agg with a filter stays nullable with a group`() {
+    val file = FixtureCompiler.parseSql(
+      """
+      |CREATE TABLE test (
+      |  id INTEGER NOT NULL,
+      |  name TEXT NOT NULL
+      |);
+      |
+      |someSelect:
+      |SELECT id, string_agg(name, ',') FILTER (WHERE id > 1)
+      |FROM test
+      |GROUP BY id;
+      """.trimMargin(),
+      tempFolder,
+      dialect = POSTGRESQL.dialect,
+    )
+
+    val query = file.namedQueries.first()
+    assertThat(query.resultColumns.map { it.javaType }).containsExactly(
+      INT,
       String::class.asClassName().copy(nullable = true),
+    ).inOrder()
+  }
+
+  @Test fun `array_agg over a non null column is non null with a group`() {
+    val file = FixtureCompiler.parseSql(
+      """
+      |CREATE TABLE test (
+      |  id INTEGER NOT NULL,
+      |  name TEXT NOT NULL
+      |);
+      |
+      |someSelect:
+      |SELECT id, array_agg(name)
+      |FROM test
+      |GROUP BY id;
+      """.trimMargin(),
+      tempFolder,
+      dialect = POSTGRESQL.dialect,
+    )
+
+    val query = file.namedQueries.first()
+    assertThat(query.resultColumns.map { it.javaType.isNullable }).containsExactly(
+      false,
+      false,
     ).inOrder()
   }
 
@@ -493,6 +541,130 @@ class ExpressionTest {
     val query = file.namedQueries.first()
     assertThat(query.resultColumns.map { it.javaType }).containsExactly(
       INT.copy(nullable = true),
+      String::class.asClassName().copy(nullable = true),
+    ).inOrder()
+  }
+
+  @Test fun `group_concat with an order by is non null with a group`() {
+    val file = FixtureCompiler.parseSql(
+      """
+      |CREATE TABLE test (
+      |  id INTEGER NOT NULL,
+      |  name TEXT NOT NULL
+      |);
+      |
+      |someSelect:
+      |SELECT id,
+      |       group_concat(name, ',' ORDER BY name)
+      |FROM test
+      |GROUP BY id;
+      """.trimMargin(),
+      tempFolder,
+      dialect = TestDialect.SQLITE_3_44.dialect,
+    )
+
+    val query = file.namedQueries.first()
+    assertThat(query.resultColumns.map { it.javaType }).containsExactly(
+      LONG,
+      String::class.asClassName(),
+    ).inOrder()
+  }
+
+  @Test fun `string_agg with an order by is non null with a group`() {
+    val file = FixtureCompiler.parseSql(
+      """
+      |CREATE TABLE test (
+      |  id INTEGER NOT NULL,
+      |  name TEXT NOT NULL
+      |);
+      |
+      |someSelect:
+      |SELECT id,
+      |       string_agg(name, ',' ORDER BY name)
+      |FROM test
+      |GROUP BY id;
+      """.trimMargin(),
+      tempFolder,
+      dialect = TestDialect.SQLITE_3_44.dialect,
+    )
+
+    val query = file.namedQueries.first()
+    assertThat(query.resultColumns.map { it.javaType }).containsExactly(
+      LONG,
+      String::class.asClassName(),
+    ).inOrder()
+  }
+
+  @Test fun `group_concat with an order by over a nullable column stays nullable with a group`() {
+    val file = FixtureCompiler.parseSql(
+      """
+      |CREATE TABLE test (
+      |  id INTEGER NOT NULL,
+      |  name TEXT
+      |);
+      |
+      |someSelect:
+      |SELECT id,
+      |       group_concat(name, ',' ORDER BY name)
+      |FROM test
+      |GROUP BY id;
+      """.trimMargin(),
+      tempFolder,
+      dialect = TestDialect.SQLITE_3_44.dialect,
+    )
+
+    val query = file.namedQueries.first()
+    assertThat(query.resultColumns.map { it.javaType }).containsExactly(
+      LONG,
+      String::class.asClassName().copy(nullable = true),
+    ).inOrder()
+  }
+
+  @Test fun `group_concat with a filter stays nullable with a group`() {
+    val file = FixtureCompiler.parseSql(
+      """
+      |CREATE TABLE test (
+      |  id INTEGER NOT NULL,
+      |  name TEXT NOT NULL
+      |);
+      |
+      |someSelect:
+      |SELECT id,
+      |       group_concat(name, ',' ORDER BY name) FILTER (WHERE id > 1)
+      |FROM test
+      |GROUP BY id;
+      """.trimMargin(),
+      tempFolder,
+      dialect = TestDialect.SQLITE_3_44.dialect,
+    )
+
+    val query = file.namedQueries.first()
+    assertThat(query.resultColumns.map { it.javaType }).containsExactly(
+      LONG,
+      String::class.asClassName().copy(nullable = true),
+    ).inOrder()
+  }
+
+  @Test fun `columns are nullable when a group_concat has no group`() {
+    val file = FixtureCompiler.parseSql(
+      """
+      |CREATE TABLE test (
+      |  id INTEGER NOT NULL,
+      |  name TEXT NOT NULL
+      |);
+      |
+      |someSelect:
+      |SELECT id,
+      |       group_concat(name, ',' ORDER BY name)
+      |FROM test;
+      """.trimMargin(),
+      tempFolder,
+      dialect = TestDialect.SQLITE_3_44.dialect,
+    )
+
+    val query = file.namedQueries.first()
+    assertThat(query.resultColumns.map { it.javaType }).containsExactly(
+      LONG.copy(nullable = true),
       String::class.asClassName().copy(nullable = true),
     ).inOrder()
   }


### PR DESCRIPTION
Fix Sqlite 3.44 Aggregates using `GROUP BY`

Problem:
Current code https://github.com/sqldelight/sqldelight/pull/6271 doesn't work for Sqlite 3.44 `group_concat` https://github.com/sqldelight/sqldelight/pull/6236 because it assumes the expression is a `SqlFunctionExpression`.

For this to work with both Postgres dialect and Sqlite 3.44 a new interface is needed in dialect api `AggregateFunctionExpression`.

Changes NamedQuery.kt to check for new`AggregateFunctionExpression`
https://github.com/sqldelight/sqldelight/blob/4580923af3c0a335e79890e2d107d2a00d1cc249/sqldelight-compiler/src/main/kotlin/app/cash/sqldelight/core/compiler/model/NamedQuery.kt#L272 

The grammar is changed slightly for  Sqlite 3.44 so that:
`aggregate_function_expr ::= ('string_agg' | 'group_concat')`
as they are alias functions in Sqlite e.g `string_agg(x, y)` is same as `group_concat(x, y)`

* Adds Fixture Tests
  * For annotation errors
* Adds Compiler Tests
  * Existing Expression tests for nullability of `group by with group_concat` remain unchanged 
  * New Expression tests added for Sqlite 3.44 and Postgresql as these take into account `FILTER`

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
